### PR TITLE
BCSC Authentication

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/appsettings.Development.json
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/appsettings.Development.json
@@ -6,6 +6,6 @@
     }
   },
   "cors": {
-    "allowedOrigins": "https://dev.loginproxy.gov.bc.ca/"
+    "allowedOrigins": "https://dev.loginproxy.gov.bc.ca/;https://idtest.gov.bc.ca/"
   }
 }

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/App.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/App.vue
@@ -17,19 +17,48 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, watch } from "vue";
+import { useRouter } from "vue-router";
 
 import { useUserStore } from "@/store/user";
+
+import { useOidcStore } from "./store/oidc";
 
 export default defineComponent({
   name: "App",
   setup() {
     const userStore = useUserStore();
-    return { userStore };
+    const oidcStore = useOidcStore();
+    const router = useRouter();
+
+    // Watch for changes to isAuthenticated flag
+    watch(
+      () => userStore.isAuthenticated,
+      (newValue: boolean) => {
+        if (!newValue) {
+          // If not authenticated, navigate to the login page
+          router.push("/login");
+        } else {
+          // If authenticated, navigate to the home page
+          router.push("/"); // Adjust the route name based on your routes
+        }
+      },
+    );
+
+    return { userStore, oidcStore };
   },
   methods: {
-    logout: async function () {
-      await this.userStore.logout();
+    logout() {
+      if (this.userStore.isAuthenticated && this.userStore.authority) {
+        if (this.userStore.authority == "bceid") {
+          this.oidcStore.logout(this.userStore.authority);
+        }
+        if (this.userStore.authority == "bcsc") {
+          // BCSC does not support a session logout callback endpoint so just remove session data from client
+          this.oidcStore.removeUser(this.userStore.authority);
+          this.userStore.$reset();
+        }
+      }
     },
   },
 });

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/api/client.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/api/client.ts
@@ -12,15 +12,12 @@ export const getClient = async (appendToken: boolean = true) => {
 
   if (appendToken) {
     const userStore = useUserStore();
-    const access_token = await userStore.getAccessToken();
+    const access_token = userStore.getAccessToken;
 
     // Add a request interceptor to append the access token to the request
     axiosClient.interceptors.request.use((config) => {
       if (access_token) {
         config.headers.Authorization = `Bearer ${access_token}`;
-      } else {
-        // If we've failed to get an access token from oidc-client-ts sessionStorage, clear the profile and logout
-        userStore.clearProfile();
       }
       return config;
     });

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Login.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Login.vue
@@ -3,7 +3,10 @@
     <h1>Login</h1>
 
     <div>
-      <button type="button" @click="userStore.login()">Login with BCeID</button>
+      <button type="button" @click="handleLogin('bceid')">Login with BCeID</button>
+    </div>
+    <div>
+      <button type="button" @click="handleLogin('bcsc')">Login with BCSC</button>
     </div>
   </div>
 </template>
@@ -11,13 +14,22 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 
+import { useOidcStore } from "@/store/oidc";
 import { useUserStore } from "@/store/user";
+import type { Authority } from "@/types/authority";
 
 export default defineComponent({
   name: "Login",
   setup() {
     const userStore = useUserStore();
-    return { userStore };
+    const oidcStore = useOidcStore();
+    return { userStore, oidcStore };
+  },
+  methods: {
+    async handleLogin(authority: Authority) {
+      this.userStore.setAuthority(authority);
+      this.oidcStore.login(authority);
+    },
   },
 });
 </script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/LogoutCallback.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/LogoutCallback.vue
@@ -1,22 +1,25 @@
 <template><div></div></template>
 
 <script lang="ts">
+import { useOidcStore } from "@/store/oidc";
 import { useUserStore } from "@/store/user";
 
 export default {
   setup() {
     const userStore = useUserStore();
+    const oidcStore = useOidcStore();
 
-    return { userStore };
+    return { userStore, oidcStore };
   },
   mounted() {
     this.handleCallback();
   },
   methods: {
     handleCallback() {
-      this.userStore.completeLogout();
-      this.userStore.clearProfile();
-      this.$router.push("/");
+      if (this.userStore.isAuthenticated && this.userStore.authority) {
+        this.oidcStore.completeLogout(this.userStore.authority);
+        this.userStore.$reset();
+      }
     },
   },
 };

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/SigninCallback.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/SigninCallback.vue
@@ -1,22 +1,25 @@
 <template><div></div></template>
 
 <script lang="ts">
+import { useOidcStore } from "@/store/oidc";
 import { useUserStore } from "@/store/user";
 
 export default {
   setup() {
     const userStore = useUserStore();
+    const oidcStore = useOidcStore();
 
-    return { userStore };
+    return { userStore, oidcStore };
   },
   mounted() {
     this.handleCallback();
   },
   methods: {
     async handleCallback(): Promise<void> {
-      const user = await this.userStore.signinCallback();
-      this.userStore.setProfile(user.profile);
-      this.$router.push("/");
+      if (this.userStore.authority) {
+        const user = await this.oidcStore.signinCallback(this.userStore.authority);
+        this.userStore.setUser(user);
+      }
     },
   },
 };

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/SilentCallback.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/SilentCallback.vue
@@ -1,20 +1,24 @@
 <template><div></div></template>
 
 <script lang="ts">
+import { useOidcStore } from "@/store/oidc";
 import { useUserStore } from "@/store/user";
 
 export default {
   setup() {
     const userStore = useUserStore();
+    const oidcStore = useOidcStore();
 
-    return { userStore };
+    return { userStore, oidcStore };
   },
   mounted() {
     this.handleCallback();
   },
   methods: {
     handleCallback() {
-      this.userStore.silentCallback();
+      if (this.userStore.isAuthenticated && this.userStore.authority) {
+        this.oidcStore.silentCallback(this.userStore.authority);
+      }
     },
   },
 };

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/main.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/main.ts
@@ -16,6 +16,7 @@ app.use(router);
 
 const configStore = useConfigStore();
 
+// Fetch OIDC configuration from the API and initialize the store before mounting the app
 configStore.initialize().then(() => {
   app.mount("#app");
 });

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/oidc-config.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/oidc-config.ts
@@ -7,7 +7,7 @@ type BaseUserManagerSettings = Pick<UserManagerSettings, "redirect_uri" | "post_
 const oidcConfig: BaseUserManagerSettings = {
   redirect_uri: `${window.location.origin}/signin-callback`,
   post_logout_redirect_uri: `${window.location.origin}/logout-callback`,
-  silent_redirect_uri: `${window.location.origin}/silent-renew`,
+  silent_redirect_uri: `${window.location.origin}/silent-callback`,
   response_type: "code",
 };
 

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/config.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/config.ts
@@ -27,8 +27,6 @@ export const useConfigStore = defineStore("config", {
         scope: oidc?.scope ?? "",
       };
 
-      console.log(combinedConfig);
-
       return combinedConfig;
     },
     bcscOidcConfiguration: (state): UserManagerSettings => {
@@ -40,8 +38,6 @@ export const useConfigStore = defineStore("config", {
         authority: oidc?.authority ?? "",
         scope: oidc?.scope ?? "",
       };
-
-      console.log(combinedConfig);
 
       return combinedConfig;
     },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/config.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/config.ts
@@ -17,7 +17,7 @@ export const useConfigStore = defineStore("config", {
     applicationConfiguration: {} as Components.Schemas.ApplicationConfiguration,
   }),
   getters: {
-    oidcConfiguration: (state): UserManagerSettings => {
+    bceidOidcConfiguration: (state): UserManagerSettings => {
       const oidc = state.applicationConfiguration?.authenticationMethods ? state.applicationConfiguration?.authenticationMethods["bceid"] : null;
 
       const combinedConfig: UserManagerSettings = {
@@ -26,6 +26,22 @@ export const useConfigStore = defineStore("config", {
         authority: oidc?.authority ?? "",
         scope: oidc?.scope ?? "",
       };
+
+      console.log(combinedConfig);
+
+      return combinedConfig;
+    },
+    bcscOidcConfiguration: (state): UserManagerSettings => {
+      const oidc = state.applicationConfiguration?.authenticationMethods ? state.applicationConfiguration?.authenticationMethods["bcsc"] : null;
+
+      const combinedConfig: UserManagerSettings = {
+        ...oidcConfig,
+        client_id: oidc?.clientId ?? "",
+        authority: oidc?.authority ?? "",
+        scope: oidc?.scope ?? "",
+      };
+
+      console.log(combinedConfig);
 
       return combinedConfig;
     },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/oidc.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/oidc.ts
@@ -1,0 +1,49 @@
+import type { SignoutResponse, User } from "oidc-client-ts";
+import { UserManager } from "oidc-client-ts";
+import { defineStore } from "pinia";
+
+import type { Authority } from "@/types/authority";
+
+import { useConfigStore } from "./config";
+
+export interface UserState {
+  bceidUserManager: UserManager;
+  bcscUserManager: UserManager;
+}
+
+export const useOidcStore = defineStore("oidc", {
+  state: (): UserState => ({
+    bceidUserManager: new UserManager(useConfigStore().bceidOidcConfiguration),
+    bcscUserManager: new UserManager(useConfigStore().bcscOidcConfiguration),
+  }),
+
+  actions: {
+    async login(authority: Authority): Promise<void> {
+      return authority === "bceid" ? await this.bceidUserManager.signinRedirect() : await this.bcscUserManager.signinRedirect();
+    },
+
+    async removeUser(authority: Authority): Promise<void> {
+      return authority === "bceid" ? await this.bceidUserManager.removeUser() : await this.bcscUserManager.removeUser();
+    },
+
+    async signinCallback(authority: Authority): Promise<User> {
+      return authority === "bceid" ? await this.bceidUserManager.signinRedirectCallback() : await this.bcscUserManager.signinRedirectCallback();
+    },
+
+    async silentCallback(authority: Authority): Promise<void> {
+      return authority === "bceid" ? await this.bceidUserManager.signinSilentCallback() : await this.bcscUserManager.signinSilentCallback();
+    },
+
+    async signinSilent(authority: Authority): Promise<User | null> {
+      return authority === "bceid" ? await this.bceidUserManager.signinSilent() : await this.bcscUserManager.signinSilent();
+    },
+
+    async logout(authority: Authority): Promise<void> {
+      return authority === "bceid" ? await this.bceidUserManager.signoutRedirect() : await this.bcscUserManager.signoutRedirect();
+    },
+
+    async completeLogout(authority: Authority): Promise<SignoutResponse> {
+      return authority === "bceid" ? await this.bceidUserManager.signoutRedirectCallback() : await this.bcscUserManager.signoutRedirectCallback();
+    },
+  },
+});

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/user.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/user.ts
@@ -1,66 +1,36 @@
-import type { SignoutResponse, User, UserProfile } from "oidc-client-ts";
-import { UserManager } from "oidc-client-ts";
+import type { User, UserProfile } from "oidc-client-ts";
 import { defineStore } from "pinia";
 
-import { useConfigStore } from "./config";
+import type { Authority } from "@/types/authority";
 
 export interface UserState {
   profile: UserProfile | null;
-  userManager: UserManager;
+  accessToken: string;
+  authority: Authority | null;
 }
 
 export const useUserStore = defineStore("user", {
   persist: {
-    paths: ["profile"],
+    paths: ["profile", "accessToken", "authority"],
   },
   state: (): UserState => ({
     profile: null,
-    userManager: new UserManager(useConfigStore().bcscOidcConfiguration),
+    accessToken: "",
+    authority: null,
   }),
   getters: {
-    isAuthenticated: (state) => state.profile !== null,
+    isAuthenticated: (state) => state.accessToken !== "",
+    getAccessToken: (state) => state.accessToken,
+    getAuthority: (state) => state.authority,
+    getProfile: (state) => state.profile,
   },
   actions: {
-    clearProfile(): void {
-      this.profile = null;
+    setUser(user: User): void {
+      this.accessToken = user.access_token;
+      this.profile = user.profile;
     },
-
-    setProfile(user: UserProfile | null): void {
-      this.profile = user;
-    },
-
-    async getAccessToken(): Promise<string | null> {
-      const user = await this.userManager.getUser();
-      return user?.access_token ?? null;
-    },
-
-    async getRefreshToken(): Promise<string | null> {
-      const user = await this.userManager.getUser();
-      return user?.access_token ?? null;
-    },
-
-    async login(): Promise<void> {
-      return await this.userManager.signinRedirect();
-    },
-
-    async signinCallback(): Promise<User> {
-      return await this.userManager.signinRedirectCallback();
-    },
-
-    async silentCallback(): Promise<void> {
-      return this.userManager.signinSilentCallback();
-    },
-
-    async signinSilent(): Promise<User | null> {
-      return await this.userManager.signinSilent();
-    },
-
-    async logout(): Promise<void> {
-      return this.userManager.signoutRedirect();
-    },
-
-    async completeLogout(): Promise<SignoutResponse> {
-      return this.userManager.signoutRedirectCallback();
+    setAuthority(authority: Authority | null): void {
+      this.authority = authority;
     },
   },
 });

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/user.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/user.ts
@@ -15,7 +15,7 @@ export const useUserStore = defineStore("user", {
   },
   state: (): UserState => ({
     profile: null,
-    userManager: new UserManager(useConfigStore().oidcConfiguration),
+    userManager: new UserManager(useConfigStore().bcscOidcConfiguration),
   }),
   getters: {
     isAuthenticated: (state) => state.profile !== null,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/authority.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/authority.d.ts
@@ -1,0 +1,2 @@
+export type Authority = "bceid" | "bcsc";
+


### PR DESCRIPTION
- Reworked pinia stores to include: oidc, config and user store
- Initialize config store with API call to server to retrieve configuration before app mount
- Initialize oidc-client-ts UserManagers for **both** BCSC and BCeID with configuration from config store
- Switched to using user store as source of truth for authentication status and access token **not** the oidc-client-ts UserManager