### PR TITLE
ECER-712: Show ITE and SNE options under ECE Five Year panel

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEFiveYearContent.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEFiveYearContent.vue
@@ -21,7 +21,7 @@
         </div>
       </v-col>
       <v-col cols="11" offset="1">
-        <v-checkbox v-model="selection" color="primary" label="Infant and Toddler Educator (ITE)" value="Ite">
+        <v-checkbox v-model="certificationTypeStore.subSelection" color="primary" label="Infant and Toddler Educator (ITE)" value="Ite">
           <template #details>
             <div class="ml-10">
               An Infant and Toddler specialization requires successful completion of an infant and toddler educator training program recognized by the ECE
@@ -30,7 +30,7 @@
           </template>
         </v-checkbox>
 
-        <v-checkbox v-model="selection" color="primary" label="Special Needs Educator (SNE)" value="Sne">
+        <v-checkbox v-model="certificationTypeStore.subSelection" color="primary" label="Special Needs Educator (SNE)" value="Sne">
           <template #details>
             <div class="ml-10">
               A Special Needs specialization requires successful completion of a special needs early childhood educator training program recognized by the ECE
@@ -46,22 +46,14 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 
-import type { Components } from "@/types/openapi";
+import { useCertificationTypeStore } from "@/store/certificationType";
 
 export default defineComponent({
   name: "ECEFiveYearContent",
-  emits: {
-    selection: (_selected: Array<Components.Schemas.CertificationType>) => true,
-  },
-  data() {
-    return {
-      selection: [] as Array<Components.Schemas.CertificationType>,
-    };
-  },
-  watch: {
-    selection(selected: Array<Components.Schemas.CertificationType>) {
-      this.$emit("selection", selected);
-    },
+  setup: () => {
+    const certificationTypeStore = useCertificationTypeStore();
+
+    return { certificationTypeStore };
   },
 });
 </script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/CertificationType.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/CertificationType.vue
@@ -11,15 +11,10 @@
         <h2 class="text-center">What certificate type(s) are you applying for?</h2>
       </v-col>
       <v-col cols="12" md="8" lg="8" xl="8" class="mx-auto">
-        <ExpandSelect
-          :options="certificationTypes"
-          :selected="selectedCertificationType?.toString()"
-          @selection="handleExpandSelectSelection"
-          @sub-selection="handleExpandSelectSubSelection"
-        ></ExpandSelect>
+        <ExpandSelect :options="certificationTypes"></ExpandSelect>
         <v-row justify="end" class="mt-12">
           <v-btn rounded="lg" variant="outlined" class="mr-2" @click="$router.back()">Cancel</v-btn>
-          <v-btn rounded="lg" color="primary" :disabled="selectedCertificationType === null" @click="submit">Start Application</v-btn>
+          <v-btn rounded="lg" color="primary" :disabled="certificationTypeStore.certificationTypes.length === 0" @click="submit">Start Application</v-btn>
         </v-row>
       </v-col>
     </v-row>
@@ -34,7 +29,7 @@ import PageContainer from "@/components/PageContainer.vue";
 import certificationTypes from "@/config/certification-types";
 import { useAlertStore } from "@/store/alert";
 import { useApplicationStore } from "@/store/application";
-import type { Components } from "@/types/openapi";
+import { useCertificationTypeStore } from "@/store/certificationType";
 
 export default defineComponent({
   name: "CertificationType",
@@ -42,34 +37,21 @@ export default defineComponent({
   setup() {
     const applicationStore = useApplicationStore();
     const alertStore = useAlertStore();
+    const certificationTypeStore = useCertificationTypeStore();
 
-    return { certificationTypes, applicationStore, alertStore };
+    return { certificationTypes, applicationStore, alertStore, certificationTypeStore };
   },
-  data() {
-    return {
-      subSelection: [] as Array<Components.Schemas.CertificationType>,
-      selectedCertificationType: null as Components.Schemas.CertificationType | null,
-    };
-  },
+
   methods: {
     submit() {
-      if (this.selectedCertificationType === null) {
-        this.alertStore.setFailureAlert("Select a certification type to continue");
-      } else {
-        const certificationTypes: Array<Components.Schemas.CertificationType> = [this.selectedCertificationType, ...this.subSelection];
-
-        this.applicationStore.setCertificationTypes(certificationTypes);
-        this.applicationStore.newDraftApplication(certificationTypes);
+      if (this.certificationTypeStore.certificationTypes.length > 0) {
+        this.applicationStore.setCertificationTypes(this.certificationTypeStore.certificationTypes);
+        this.applicationStore.newDraftApplication(this.certificationTypeStore.certificationTypes);
 
         this.$router.push("/requirements");
+      } else {
+        this.alertStore.setFailureAlert("Select a certification type to continue");
       }
-    },
-
-    handleExpandSelectSelection(selected: string | null) {
-      this.selectedCertificationType = selected as Components.Schemas.CertificationType;
-    },
-    handleExpandSelectSubSelection(selected: Array<string>) {
-      this.subSelection = selected as Components.Schemas.CertificationType[];
     },
   },
 });

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/certificationType.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/certificationType.ts
@@ -1,0 +1,20 @@
+import { defineStore } from "pinia";
+
+import type { Components } from "@/types/openapi";
+
+export interface CertificationTypeState {
+  selection: Components.Schemas.CertificationType | null;
+  subSelection: Components.Schemas.CertificationType[];
+}
+
+export const useCertificationTypeStore = defineStore("certificationType", {
+  state: (): CertificationTypeState => ({
+    selection: null,
+    subSelection: [],
+  }),
+  getters: {
+    certificationTypes(state): Components.Schemas.CertificationType[] {
+      return state.selection === null ? [] : [state.selection, ...state.subSelection];
+    },
+  },
+});

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/certificationType.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/certificationType.ts
@@ -14,7 +14,7 @@ export const useCertificationTypeStore = defineStore("certificationType", {
   }),
   getters: {
     certificationTypes(state): Components.Schemas.CertificationType[] {
-      return state.selection === null ? [] : [state.selection, ...state.subSelection];
+      return state.selection === null || typeof state.selection === "undefined" ? [] : [state.selection, ...state.subSelection];
     },
   },
 });


### PR DESCRIPTION
## Description

- Addressed QA issue to show ITE and SNE options before Five Year certification type selection
- Pinia store for the state certification type selection

## Related Jira Issue(s)

- [ECER-712]()

## Checklist
- [X] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
<img width="834" alt="Screenshot 2024-02-03 at 3 57 20 PM" src="https://github.com/bcgov/ECC-ECER/assets/10508230/e93bb088-523f-4965-a28e-ec992c695267">
