### PR TITLE
ECER-712: certification selection feedback

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEAssistantRequirements.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEAssistantRequirements.vue
@@ -1,6 +1,6 @@
 <template>
   <v-col cols="12">
-    <h1>Requirements for ECE Assistant Certification</h1>
+    <h1 :class="$vuetify.display.mobile ? 'mobile-header' : ''">Requirements for ECE Assistant Certification</h1>
   </v-col>
   <v-col cols="12">
     <p>Before you proceed, please make sure that you meet the following requirements:</p>
@@ -42,3 +42,9 @@ export default defineComponent({
   name: "ECEAssistantRequirements",
 });
 </script>
+
+<style>
+.mobile-header {
+  line-height: 1;
+}
+</style>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEFiveYearContent.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEFiveYearContent.vue
@@ -12,23 +12,29 @@
         </p>
       </v-col>
       <v-col cols="11" offset="1">
-        <v-checkbox v-model="certificationTypeStore.subSelection" color="primary" label="Infant and Toddler Educator (ITE)" value="Ite">
-          <template #details>
-            <div class="ml-10">
-              An Infant and Toddler specialization requires successful completion of an infant and toddler educator training program recognized by the ECE
-              Registry.
-            </div>
-          </template>
-        </v-checkbox>
-
-        <v-checkbox v-model="certificationTypeStore.subSelection" color="primary" label="Special Needs Educator (SNE)" value="Sne">
-          <template #details>
-            <div class="ml-10">
-              A Special Needs specialization requires successful completion of a special needs early childhood educator training program recognized by the ECE
-              Registry.
-            </div>
-          </template>
-        </v-checkbox>
+        <v-checkbox
+          v-model="certificationTypeStore.subSelection"
+          color="primary"
+          label="Infant and Toddler Educator (ITE)"
+          value="Ite"
+          hide-details="auto"
+          aria-describedby="ITEDescription"
+        ></v-checkbox>
+        <div id="ITEDescription" class="ml-10 text-caption">
+          An Infant and Toddler specialization requires successful completion of an infant and toddler educator training program recognized by the ECE Registry.
+        </div>
+        <v-checkbox
+          v-model="certificationTypeStore.subSelection"
+          color="primary"
+          label="Special Needs Educator (SNE)"
+          value="Sne"
+          hide-details="auto"
+          aria-describedby="SNEDescription"
+        />
+        <div id="SNEDescription" class="ml-10 text-caption">
+          A Special Needs specialization requires successful completion of a special needs early childhood educator training program recognized by the ECE
+          Registry.
+        </div>
       </v-col>
     </v-row>
   </v-container>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEFiveYearRequirements.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEFiveYearRequirements.vue
@@ -1,6 +1,6 @@
 <template>
   <v-col cols="12">
-    <h1>Requirements for ECE Five Year Certification</h1>
+    <h1 :class="$vuetify.display.mobile ? 'mobile-header' : ''">{{ generateTitle() }}</h1>
   </v-col>
   <v-col cols="12">
     <p>Before you proceed, please make sure that you meet the following requirements:</p>
@@ -28,6 +28,7 @@
         <li>Can speak to your character and has known you for at least 6 months</li>
         <li>Can speak to your ability to educate and care for young children</li>
         <li>Is not a relative, partner, spouse, or yourself</li>
+        <li>Is not the same person you provide as your 500-hour work experience reference</li>
         <li>(Recommended) is a certified ECE who has directly observed you working with young children</li>
       </ul>
     </v-col>
@@ -60,7 +61,36 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 
+import { useApplicationStore } from "@/store/application";
+import type { Components } from "@/types/openapi";
+
 export default defineComponent({
   name: "ECEFiveYearRequirements",
+  setup() {
+    const applicationStore = useApplicationStore();
+    return { applicationStore };
+  },
+  methods: {
+    generateTitle() {
+      if (this.hasCertificationType("Ite") && this.hasCertificationType("Sne")) {
+        return "Requirements for ECE Five Year Certification, SNE and ITE";
+      } else if (this.hasCertificationType("Ite")) {
+        return "Requirements for ECE Five Year Certification and ITE";
+      } else if (this.hasCertificationType("Sne")) {
+        return "Requirements for ECE Five Year Certification and SNE";
+      } else {
+        return "Requirements for ECE Five Year Certification";
+      }
+    },
+    hasCertificationType(type: Components.Schemas.CertificationType) {
+      return this.applicationStore.currentApplication.certificationTypes?.includes(type);
+    },
+  },
 });
 </script>
+
+<style>
+.mobile-header {
+  line-height: 1;
+}
+</style>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEOneYearRequirements.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEOneYearRequirements.vue
@@ -1,6 +1,6 @@
 <template>
   <v-col cols="12">
-    <h1>Requirements for ECE One Year Certification</h1>
+    <h1 :class="$vuetify.display.mobile ? 'mobile-header' : ''">Requirements for ECE One Year Certification</h1>
   </v-col>
   <v-col cols="12">
     <p>Before you proceed, please make sure that you meet the following requirements:</p>
@@ -41,3 +41,9 @@ export default defineComponent({
   name: "ECEOneYearRequirements",
 });
 </script>
+
+<style>
+.mobile-header {
+  line-height: 1;
+}
+</style>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ExpandSelect.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ExpandSelect.vue
@@ -10,13 +10,19 @@
           </v-col>
           <v-col v-if="option.id === 'FiveYears' && selection !== 'FiveYears'" cols="11" offset="1">
             <p class="small">If you are eligible for an ECE Five Year Certificate, you may also be eligible for one or both specializations:</p>
-            <v-checkbox v-model="certificationTypeStore.subSelection" color="primary" label="Infant and Toddler Educator (ITE)" value="Ite"></v-checkbox>
+            <v-checkbox
+              v-model="certificationTypeStore.subSelection"
+              color="primary"
+              label="Infant and Toddler Educator (ITE)"
+              value="Ite"
+              hide-details="auto"
+            ></v-checkbox>
             <v-checkbox
               v-model="certificationTypeStore.subSelection"
               color="primary"
               label="Special Needs Educator (SNE)"
               value="Sne"
-              class="mt-n8"
+              hide-details="auto"
             ></v-checkbox>
           </v-col>
         </v-row>


### PR DESCRIPTION
## Title
ECER-712: Addressing feedback on certificate selection screen. More spacing in mobile view for the checkboxes and also fixed label styling. 
ECER-882: Updating the title based on certificate type and adding in missing point for 5 year certificates. Also fixed a big with the mobile view squishing the title to be too close.


## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

![image](https://github.com/bcgov/ECC-ECER/assets/74216496/c1dcd42f-abd4-4a79-9380-a4b6afbf376e)
