### PR TITLE
error message for certification types

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCertificationType.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCertificationType.vue
@@ -4,7 +4,7 @@
       <v-expansion-panel-title>
         <v-row no-gutters>
           <v-col cols="12">
-            <v-radio-group v-model="selection" :mandatory="true" :hide-details="true">
+            <v-radio-group v-model="selection" :mandatory="true" :hide-details="true" :error="errorState">
               <v-radio color="primary" :label="option.title" :value="option.id"></v-radio>
             </v-radio-group>
           </v-col>
@@ -31,6 +31,7 @@
         <Component :is="option.contentComponent" />
       </v-expansion-panel-text>
     </v-expansion-panel>
+    <div v-if="errorState" class="v-messages error-message" role="alert" aria-live="polite">Select a certificate type to begin your application</div>
   </v-expansion-panels>
   <div v-if="certificationTypeStore.mode == 'terms'">
     <v-row>
@@ -97,6 +98,7 @@ export default defineComponent({
   },
   emits: {
     "update:model-value": (_certificateTypeList: Components.Schemas.CertificationType[]) => true,
+    updatedValidation: (_errorState: boolean) => true,
   },
   setup: (props) => {
     const certificationTypeStore = useCertificationTypeStore();
@@ -132,11 +134,27 @@ export default defineComponent({
       },
     },
     ...mapState(useCertificationTypeStore, ["certificationTypes"]),
+    errorState() {
+      //this prevents the error state from being set to true on first load.
+      if (this.selection === null) {
+        return false;
+      }
+      return !this.selection;
+    },
   },
   watch: {
     certificationTypes(newValue: Components.Schemas.CertificationType[], _) {
       this.$emit("update:model-value", newValue);
     },
+    errorState() {
+      this.$emit("updatedValidation", this.errorState);
+    },
   },
 });
 </script>
+
+<style>
+.error-message {
+  color: rgb(var(--v-theme-error));
+}
+</style>


### PR DESCRIPTION


## Title
ECER-{1013}: Adding error messaging for certification types and preventing user from progressing without filling in all fields.

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

![image](https://github.com/bcgov/ECC-ECER/assets/74216496/fc420184-34f6-4398-beef-dfb6d5bb7994)
error
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/e77fe3ed-def7-4426-89bc-b9aeebb000a8)
