### PR TITLE
quick bug fix

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCertificationType.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCertificationType.vue
@@ -96,6 +96,12 @@ export default defineComponent({
       required: true,
     },
   },
+  mounted() {
+    //if user does not have a selection, default to EceAssistant.
+    if (!this.certificationTypeStore.selection) {
+      this.certificationTypeStore.selection = "EceAssistant";
+    }
+  },
   emits: {
     "update:model-value": (_certificateTypeList: Components.Schemas.CertificationType[]) => true,
     updatedValidation: (_errorState: boolean) => true,
@@ -135,10 +141,6 @@ export default defineComponent({
     },
     ...mapState(useCertificationTypeStore, ["certificationTypes"]),
     errorState() {
-      //this prevents the error state from being set to true on first load.
-      if (this.selection === null) {
-        return false;
-      }
       return !this.selection;
     },
   },


### PR DESCRIPTION
ECER-1013

Quick bug fix so that user wouldn't be able to progress to the next step without choosing a certificate type first. If user enters this page without a certificate type (first time entry or saved draft with empty certificate type) we will default to ECE assistant.

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.
