### PR TITLE
ECER-1292: The user should be able to create just one draft application

### DIFF
--- a/src/ECER.Tests/Integration/RegistryPortalWebAppScenarioBase.cs
+++ b/src/ECER.Tests/Integration/RegistryPortalWebAppScenarioBase.cs
@@ -1,7 +1,7 @@
-﻿using System.Globalization;
-using ECER.Utilities.DataverseSdk.Model;
+﻿using ECER.Utilities.DataverseSdk.Model;
 using ECER.Utilities.Security;
 using Microsoft.Extensions.DependencyInjection;
+using System.Globalization;
 using Xunit.Abstractions;
 
 namespace ECER.Tests.Integration;
@@ -28,6 +28,7 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
   public UserIdentity AuthenticatedBcscUserIdentity => authenticatedBcscUser.ecer_contact_ecer_authentication_455.Select(a => new UserIdentity(a.ecer_ExternalID, a.ecer_IdentityProvider)).First();
   public string AuthenticatedBcscUserId => authenticatedBcscUser.Id.ToString();
   public string communicationId => testCommunication.Id.ToString();
+  public string applicationId => testApplication.Id.ToString();
 
   public override async Task InitializeAsync()
   {

--- a/src/ECER.Tests/Integration/Resources/Applications/ApplicationRepositoryTests.cs
+++ b/src/ECER.Tests/Integration/Resources/Applications/ApplicationRepositoryTests.cs
@@ -1,5 +1,4 @@
 ﻿using Bogus;
-using ECER.Clients.RegistryPortal.Server.Applications;
 using ECER.Resources.Documents.Applications;
 using JasperFx.Core;
 using Microsoft.Extensions.DependencyInjection;
@@ -266,7 +265,7 @@ public class ApplicationRepositoryTests : RegistryPortalWebAppScenarioBase
     var updatedApplication = (await repository.Query(new ApplicationQuery { ById = applicationId })).ShouldHaveSingleItem();
     updatedApplication.CharacterReferences.ShouldBeEmpty();
   }
-  
+
   private CharacterReference CreateCharacterReference()
   {
     var faker = new Faker("en_CA");


### PR DESCRIPTION

## Title
ECER-1292: The user should be able to create just one draft application

## Description

- Revise the application handler to block the creation of new draft applications if the user already has an existing draft. 
- Update the integration tests to focus solely on testing the update functionality for draft applications within the application endpoint tests.

## Related Jira Issue(s)

- ECER-1292

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.
