### PR TITLE
removing auto selection of certificate type. In exchange, error message pops up right away on new application + other bug fixes

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Form.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Form.vue
@@ -41,18 +41,12 @@ export default defineComponent({
     updatedFormData: (_formData: Record<string, any>) => true,
     updatedValidation: (_validation: boolean | null) => true,
   },
-  mounted() {
-    setTimeout(this.resetFormValidation, 100);
-  },
   methods: {
     onInputChanged(id: string, value: any) {
       this.$emit("updatedFormData", { ...this.formData, [id]: value });
     },
     onFormValidationChanged(value: boolean | null) {
       this.$emit("updatedValidation", value);
-    },
-    resetFormValidation() {
-      (this.$refs[this.form.id] as VForm).resetValidation();
     },
   },
 });

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Form.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Form.vue
@@ -17,12 +17,12 @@
 
 <script lang="ts">
 import { defineComponent, type PropType } from "vue";
+import type { VForm } from "vuetify/components";
 
 import FormContainer from "@/components/FormContainer.vue";
 import PageContainer from "@/components/PageContainer.vue";
 import profileInformationForm from "@/config/profile-information-form";
 import type { Form } from "@/types/form";
-import type { VForm } from "vuetify/components";
 
 export default defineComponent({
   name: "EcerForm",
@@ -41,6 +41,9 @@ export default defineComponent({
     updatedFormData: (_formData: Record<string, any>) => true,
     updatedValidation: (_validation: boolean | null) => true,
   },
+  mounted() {
+    setTimeout(this.resetFormValidation, 100);
+  },
   methods: {
     onInputChanged(id: string, value: any) {
       this.$emit("updatedFormData", { ...this.formData, [id]: value });
@@ -51,9 +54,6 @@ export default defineComponent({
     resetFormValidation() {
       (this.$refs[this.form.id] as VForm).resetValidation();
     },
-  },
-  mounted() {
-    setTimeout(this.resetFormValidation, 100);
   },
 });
 </script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Form.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Form.vue
@@ -22,6 +22,7 @@ import FormContainer from "@/components/FormContainer.vue";
 import PageContainer from "@/components/PageContainer.vue";
 import profileInformationForm from "@/config/profile-information-form";
 import type { Form } from "@/types/form";
+import type { VForm } from "vuetify/components";
 
 export default defineComponent({
   name: "EcerForm",
@@ -47,6 +48,12 @@ export default defineComponent({
     onFormValidationChanged(value: boolean | null) {
       this.$emit("updatedValidation", value);
     },
+    resetFormValidation() {
+      (this.$refs[this.form.id] as VForm).resetValidation();
+    },
+  },
+  mounted() {
+    setTimeout(this.resetFormValidation, 100);
   },
 });
 </script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Wizard.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Wizard.vue
@@ -22,6 +22,7 @@
           <v-row>
             <v-col cols="12">
               <EceForm
+                v-if="step.form.id === wizardStore.currentStep.form.id"
                 :form="step.form"
                 :form-data="wizardStore.wizardData"
                 @updated-form-data="wizardStore.setWizardData"

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCertificationType.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCertificationType.vue
@@ -136,12 +136,6 @@ export default defineComponent({
       this.$emit("updatedValidation", this.errorState);
     },
   },
-  mounted() {
-    //if user does not have a selection, default to EceAssistant.
-    if (!this.certificationTypeStore.selection) {
-      this.certificationTypeStore.selection = "EceAssistant";
-    }
-  },
 });
 </script>
 

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReference.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReference.vue
@@ -56,7 +56,10 @@
     <v-col cols="12" md="8" lg="6" xl="4">
       <v-text-field
         v-model="emailAddress"
-        :rules="[Rules.required('Enter your reference\'s email in the format \'name@email.com\''), Rules.email('Enter your reference\'s email in the format \'name@email.com\'')]"
+        :rules="[
+          Rules.required('Enter your reference\'s email in the format \'name@email.com\''),
+          Rules.email('Enter your reference\'s email in the format \'name@email.com\''),
+        ]"
         label="Reference Email"
         variant="outlined"
         color="primary"
@@ -108,7 +111,6 @@ export default defineComponent({
       Rules,
     };
   },
-  created() {},
   methods: {
     async updateCharacterReference() {
       this.$emit("update:model-value", [

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
@@ -93,7 +93,7 @@
           <v-checkbox
             v-model="officialTranscriptReceived"
             color="primary"
-            label="The ECE Registry has already my official transcript for the course/program relevant to this application and certificate type"
+            label="The ECE Registry already has my official transcript for the course/program relevant to this application and certificate type"
           ></v-checkbox>
         </form>
       </v-col>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceWorkExperienceReferences.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceWorkExperienceReferences.vue
@@ -116,6 +116,11 @@
           <p class="small">You must enter 500 hours of work experience to submit your application.</p>
         </Alert>
       </v-col>
+      <v-col v-if="duplicateCharacterReference" sm="12" md="10" lg="8" xl="6">
+        <Alert type="error">
+          <p class="small">Your work experience reference(s) cannot be the same as your character reference</p>
+        </Alert>
+      </v-col>
       <v-col sm="12" md="10" lg="8" xl="6" class="my-6">
         <WorkExperienceReferenceProgressBar :references="modelValue" />
       </v-col>
@@ -142,6 +147,7 @@ import type { EceWorkExperienceReferencesProps } from "@/types/input";
 import type { Components } from "@/types/openapi";
 import { isNumber } from "@/utils/formInput";
 import * as Rules from "@/utils/formRules";
+import { useWizardStore } from "@/store/wizard";
 
 export default defineComponent({
   name: "EceEdducation",
@@ -161,9 +167,11 @@ export default defineComponent({
   },
   setup: () => {
     const alertStore = useAlertStore();
+    const wizardStore = useWizardStore();
 
     return {
       alertStore,
+      wizardStore,
     };
   },
   data: function () {
@@ -194,6 +202,17 @@ export default defineComponent({
     },
     newClientId() {
       return Object.keys(this.modelValue).length + 1;
+    },
+    duplicateCharacterReference() {
+      const check = Object.values(this.modelValue).some((workExperienceReference: Components.Schemas.WorkExperienceReference) => {
+        const characterReferenceKey = this.wizardStore.wizardConfig.steps.characterReferences.form.inputs.characterReferences.id;
+        return (
+          workExperienceReference.firstName === this.wizardStore.wizardData?.[characterReferenceKey][0].firstName &&
+          workExperienceReference.lastName === this.wizardStore.wizardData?.[characterReferenceKey][0].lastName &&
+          workExperienceReference.emailAddress === this.wizardStore.wizardData?.[characterReferenceKey][0].emailAddress
+        );
+      });
+      return check;
     },
   },
   mounted() {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceWorkExperienceReferences.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceWorkExperienceReferences.vue
@@ -207,9 +207,9 @@ export default defineComponent({
       const check = Object.values(this.modelValue).some((workExperienceReference: Components.Schemas.WorkExperienceReference) => {
         const characterReferenceKey = this.wizardStore.wizardConfig.steps.characterReferences.form.inputs.characterReferences.id;
         return (
-          workExperienceReference.firstName === this.wizardStore.wizardData?.[characterReferenceKey][0].firstName &&
-          workExperienceReference.lastName === this.wizardStore.wizardData?.[characterReferenceKey][0].lastName &&
-          workExperienceReference.emailAddress === this.wizardStore.wizardData?.[characterReferenceKey][0].emailAddress
+          workExperienceReference.firstName === this.wizardStore.wizardData?.[characterReferenceKey]?.[0]?.firstName &&
+          workExperienceReference.lastName === this.wizardStore.wizardData?.[characterReferenceKey]?.[0]?.lastName &&
+          workExperienceReference.emailAddress === this.wizardStore.wizardData?.[characterReferenceKey]?.[0]?.emailAddress
         );
       });
       return check;

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceWorkExperienceReferences.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceWorkExperienceReferences.vue
@@ -143,11 +143,11 @@ import Alert from "@/components/Alert.vue";
 import WorkExperienceReferenceList, { type WorkExperienceReferenceData } from "@/components/WorkExperienceReferenceList.vue";
 import WorkExperienceReferenceProgressBar from "@/components/WorkExperienceReferenceProgressBar.vue";
 import { useAlertStore } from "@/store/alert";
+import { useWizardStore } from "@/store/wizard";
 import type { EceWorkExperienceReferencesProps } from "@/types/input";
 import type { Components } from "@/types/openapi";
 import { isNumber } from "@/utils/formInput";
 import * as Rules from "@/utils/formRules";
-import { useWizardStore } from "@/store/wizard";
 
 export default defineComponent({
   name: "EceEdducation",

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/application.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/application.ts
@@ -78,6 +78,12 @@ export const useApplicationStore = defineStore("application", {
       ) {
         this.draftApplication.characterReferences =
           wizardStore.wizardData[wizardStore.wizardConfig.steps.characterReferences.form.inputs.characterReferences.id];
+      } else if (
+        wizardStore.wizardData[wizardStore.wizardConfig.steps.characterReferences.form.inputs.characterReferences.id]?.[0]?.firstName === "" &&
+        wizardStore.wizardData[wizardStore.wizardConfig.steps.characterReferences.form.inputs.characterReferences.id]?.[0]?.lastName === "" &&
+        wizardStore.wizardData[wizardStore.wizardConfig.steps.characterReferences.form.inputs.characterReferences.id]?.[0]?.emailAddress === ""
+      ) {
+        this.draftApplication.characterReferences = [];
       }
     },
     async upsertDraftApplication(): Promise<Components.Schemas.DraftApplicationResponse | null | undefined> {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/wizard.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/wizard.ts
@@ -53,10 +53,11 @@ export const useWizardStore = defineStore("wizard", {
       const duplicateCharacterReferenceFound = references.some((workExperienceReference: Components.Schemas.WorkExperienceReference) => {
         return (
           workExperienceReference.firstName ===
-            state.wizardData?.[this.wizardConfig.steps.characterReferences.form.inputs.characterReferences.id][0].firstName &&
-          workExperienceReference.lastName === state.wizardData?.[this.wizardConfig.steps.characterReferences.form.inputs.characterReferences.id][0].lastName &&
+            state.wizardData?.[this.wizardConfig.steps.characterReferences.form.inputs.characterReferences.id]?.[0]?.firstName &&
+          workExperienceReference.lastName ===
+            state.wizardData?.[this.wizardConfig.steps.characterReferences.form.inputs.characterReferences.id]?.[0]?.lastName &&
           workExperienceReference.emailAddress ===
-            state.wizardData?.[this.wizardConfig.steps.characterReferences.form.inputs.characterReferences.id][0].emailAddress
+            state.wizardData?.[this.wizardConfig.steps.characterReferences.form.inputs.characterReferences.id]?.[0]?.emailAddress
         );
       });
 

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/wizard.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/wizard.ts
@@ -50,6 +50,16 @@ export const useWizardStore = defineStore("wizard", {
         }, 0);
       }
 
+      const duplicateCharacterReferenceFound = references.some((workExperienceReference: Components.Schemas.WorkExperienceReference) => {
+        return (
+          workExperienceReference.firstName ===
+            state.wizardData?.[this.wizardConfig.steps.characterReferences.form.inputs.characterReferences.id][0].firstName &&
+          workExperienceReference.lastName === state.wizardData?.[this.wizardConfig.steps.characterReferences.form.inputs.characterReferences.id][0].lastName &&
+          workExperienceReference.emailAddress ===
+            state.wizardData?.[this.wizardConfig.steps.characterReferences.form.inputs.characterReferences.id][0].emailAddress
+        );
+      });
+
       return {
         CertificationType: (state.wizardData[this.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].length || []) > 0,
         Declaration:
@@ -58,7 +68,10 @@ export const useWizardStore = defineStore("wizard", {
         ContactInformation: true,
         Education: Object.values(state.wizardData[this.wizardConfig.steps.education.form.inputs.educationList.id]).length > 0,
         CharacterReferences: (state.wizardData[this.wizardConfig.steps.characterReferences.form.inputs.characterReferences.id].length || []) > 0,
-        WorkReferences: Object.values(state.wizardData[this.wizardConfig.steps.workReference.form.inputs.referenceList.id]).length > 0 && totalHours >= 500,
+        WorkReferences:
+          Object.values(state.wizardData[this.wizardConfig.steps.workReference.form.inputs.referenceList.id]).length > 0 &&
+          totalHours >= 500 &&
+          !duplicateCharacterReferenceFound,
         Review: true,
       };
     },


### PR DESCRIPTION
ECER-1013: Brief description of the changes

- Certificate form doesn't auto select a certification **(ECER-1013)**
- Bug fix where applicant could click back and forward to avoid form validation **(ECER-812)**. Added a v-if on forms to ensure they get remounted each time we travel through the stepper. 
- Updated wording for education checkbox **(ECER-716)**
- Alert box for duplicated character reference in work experience reference. **ECER-1040**
- Bug fix forms would fire off validation when switching between stepper. Showing error messages right away when we first arrive to the forms. (Had to do some setTimeout resetvalidation to prevent this jankiness. 
- Bug fix character reference doesn't get cleared out when user removes first name, last name and email. 

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

Screenshots 
Alert Box and Error on preview page for work experience reference 
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/6227aa4a-d108-4040-a18e-f41b96872ece)


![image](https://github.com/bcgov/ECC-ECER/assets/74216496/4dbd1ae9-b6a7-4aad-997b-bb2551d7e349)

