### PR TITLE
changing to use refs to validate form instead of submit buttons

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ProfileForm.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ProfileForm.vue
@@ -1,13 +1,8 @@
 <template>
   <v-col cols="12">
-    <EceForm
-      :form="profileInformationForm"
-      :form-data="formStore.formData"
-      @updated-form-data="formStore.setFormData"
-      @updated-validation="isFormValid = $event"
-    />
+    <EceForm ref="profileForm" :form="profileInformationForm" :form-data="formStore.formData" @updated-form-data="formStore.setFormData" />
     <v-row justify="end">
-      <v-btn :form="profileInformationForm.id" type="submit" rounded="lg" color="primary" @click="saveProfile">Save</v-btn>
+      <v-btn rounded="lg" color="primary" @click="saveProfile">Save</v-btn>
     </v-row>
   </v-col>
 </template>
@@ -61,12 +56,11 @@ export default defineComponent({
 
     return { profileInformationForm, formStore, alertStore, userStore };
   },
-  data: () => ({
-    isFormValid: null as boolean | null,
-  }),
   methods: {
     async saveProfile() {
-      if (!this.isFormValid) {
+      const { valid } = await (this.$refs.profileForm as typeof EceForm).$refs[profileInformationForm.id].validate();
+
+      if (!valid) {
         this.alertStore.setFailureAlert("You must enter all required fields in the valid format.");
       } else {
         const success = await putProfile({

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Wizard.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Wizard.vue
@@ -21,13 +21,7 @@
           <DeclarationStepContent v-if="step.stage == 'Declaration'" class="mt-6" />
           <v-row>
             <v-col cols="12">
-              <EceForm
-                v-if="step.form.id === wizardStore.currentStep.form.id"
-                :form="step.form"
-                :form-data="wizardStore.wizardData"
-                @updated-form-data="wizardStore.setWizardData"
-                @updated-validation="$emit('updatedValidation', $event)"
-              />
+              <EceForm :ref="step.form.id" :form="step.form" :form-data="wizardStore.wizardData" @updated-form-data="wizardStore.setWizardData" />
             </v-col>
           </v-row>
         </v-container>
@@ -60,9 +54,6 @@ export default defineComponent({
       type: Object as PropType<Wizard>,
       default: () => applicationWizard,
     },
-  },
-  emits: {
-    updatedValidation: (_validation: boolean | null) => true,
   },
   setup: async () => {
     const wizardStore = useWizardStore();

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCertificationType.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCertificationType.vue
@@ -4,7 +4,7 @@
       <v-expansion-panel-title>
         <v-row no-gutters>
           <v-col cols="12">
-            <v-radio-group v-model="selection" :mandatory="true" :hide-details="true" :error="errorState">
+            <v-radio-group v-model="selection" :mandatory="true" :hide-details="true" :error="errorState" :rules="[!errorState]">
               <v-radio color="primary" :label="option.title" :value="option.id"></v-radio>
             </v-radio-group>
           </v-col>
@@ -86,10 +86,6 @@ export default defineComponent({
       required: true,
     },
   },
-  emits: {
-    "update:model-value": (_certificateTypeList: Components.Schemas.CertificationType[]) => true,
-    updatedValidation: (_errorState: boolean) => true,
-  },
   setup: (props) => {
     const certificationTypeStore = useCertificationTypeStore();
     // If props.modelValue contains "Ite" or "Sne", set the subSelection to those values
@@ -131,9 +127,6 @@ export default defineComponent({
   watch: {
     certificationTypes(newValue: Components.Schemas.CertificationType[], _) {
       this.$emit("update:model-value", newValue);
-    },
-    errorState() {
-      this.$emit("updatedValidation", this.errorState);
     },
   },
 });


### PR DESCRIPTION
ECER-{###}: Refactored how we validate our forms while going through the stepper. Now we do not validate the next form in the sequence. 

Also removed updated-formvalidation emit since we are getting validation directly from the form. 

Removed type=submit for buttons with this refactor. 

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.