### PR TITLE
preventing special chaaracters being put for character reference last…

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReference.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReference.vue
@@ -16,12 +16,13 @@
     <v-col cols="12" md="8" lg="6" xl="4">
       <v-text-field
         v-model="firstName"
-        :rules="[Rules.required('Enter your reference\'s first name')]"
+        :rules="[Rules.required('Enter your reference\'s first name'), Rules.noSpecialCharactersContactName()]"
         label="Reference First Name"
         variant="outlined"
         color="primary"
         maxlength="100"
         @update:model-value="updateCharacterReference()"
+        @keypress="isNotSpecialCharacterName"
       ></v-text-field>
     </v-col>
   </v-row>
@@ -29,12 +30,13 @@
     <v-col cols="12" md="8" lg="6" xl="4">
       <v-text-field
         v-model="lastName"
-        :rules="[Rules.required('Enter your reference\'s last name')]"
+        :rules="[Rules.required('Enter your reference\'s last name'), Rules.noSpecialCharactersContactName()]"
         label="Reference Last Name"
         variant="outlined"
         color="primary"
         maxlength="100"
         @update:model-value="updateCharacterReference()"
+        @keypress="isNotSpecialCharacterName"
       ></v-text-field>
     </v-col>
   </v-row>
@@ -77,6 +79,7 @@ import { useAlertStore } from "@/store/alert";
 import type { EceCharacterReferenceProps } from "@/types/input";
 import type { Components } from "@/types/openapi";
 import * as Rules from "@/utils/formRules";
+import { isNotSpecialCharacterName } from "@/utils/formInput";
 
 import Alert from "../Alert.vue";
 export default defineComponent({
@@ -117,6 +120,7 @@ export default defineComponent({
         { firstName: this.firstName, lastName: this.lastName, emailAddress: this.emailAddress, phoneNumber: this.phoneNumber },
       ] as Components.Schemas.CharacterReference);
     },
+    isNotSpecialCharacterName,
   },
 });
 </script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReferencePreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReferencePreview.vue
@@ -22,7 +22,7 @@
           <p class="small">Reference Email</p>
         </v-col>
         <v-col>
-          <p class="small font>weight-bold">{{ characterReference.emailAddress }}</p>
+          <p class="small font-weight-bold">{{ characterReference.emailAddress }}</p>
         </v-col>
       </v-row>
       <v-row>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formInput.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formInput.ts
@@ -21,4 +21,18 @@ const isNumber = function (event: KeyboardEvent | InputEvent): void {
   }
 };
 
-export { isNumber };
+/**
+ * Will not allow special characters for names in an input field. Acceptable characters include ' and -
+ * @param {Object} event
+ * @returns void
+ */
+const isNotSpecialCharacterName = function (event: KeyboardEvent): void {
+  const charCode = event instanceof KeyboardEvent ? event.key : "";
+
+  // Check if the key pressed is not a number and not a valid input event
+  if (event instanceof KeyboardEvent && /[^A-Za-z\s-']/.test(charCode)) {
+    event.preventDefault();
+  }
+};
+
+export { isNumber, isNotSpecialCharacterName };

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formRules.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formRules.ts
@@ -54,6 +54,7 @@ const noSpecialCharactersContactName =
   (message = "Remove or replace any special characters in this field.") =>
   (v: string) =>
     !v || !/[^A-Za-z.'\s-]/.test(v) || message;
+
 /**
  * Rule for phone numbers also works for fax numbers too
  * @param {String} message


### PR DESCRIPTION
… name + first name. Fixed bolding for email in preview page

## Title
ECER-1041: Brief description of the changes

## Description

- no special characters allowed for character reference first name/last name
- bolding for emails in preview page
- Key press is disabled for special characters, but in case user copy and pastes values into there, they will see the error message.

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

![image](https://github.com/bcgov/ECC-ECER/assets/74216496/34d1183c-093b-458b-99c5-a7bf39584a01)
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/5d634ff6-1c14-49fa-bacf-ced6148b3479)
