### PR TITLE
bug fix for certification type to reflect in wizard header

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Form.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Form.vue
@@ -17,7 +17,6 @@
 
 <script lang="ts">
 import { defineComponent, type PropType } from "vue";
-import type { VForm } from "vuetify/components";
 
 import FormContainer from "@/components/FormContainer.vue";
 import PageContainer from "@/components/PageContainer.vue";

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Wizard.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Wizard.vue
@@ -1,5 +1,5 @@
 <template>
-  <WizardHeader class="mb-6" />
+  <slot name="header"></slot>
   <v-stepper v-model="wizardStore.step" min-height="100dvh" :alt-labels="true" :mobile="$vuetify.display.mobile">
     <v-stepper-header>
       <template v-for="(step, index) in Object.values(wizard.steps)" :key="step.stage">
@@ -46,7 +46,6 @@ import { defineComponent, type PropType } from "vue";
 
 import DeclarationStepContent from "@/components/DeclarationStepContent.vue";
 import EceForm from "@/components/Form.vue";
-import WizardHeader from "@/components/WizardHeader.vue";
 import applicationWizard from "@/config/application-wizard";
 import { useAlertStore } from "@/store/alert";
 import { useCertificationTypeStore } from "@/store/certificationType";
@@ -56,7 +55,7 @@ import type { Step, Wizard } from "@/types/wizard";
 
 export default defineComponent({
   name: "Wizard",
-  components: { WizardHeader, EceForm, DeclarationStepContent },
+  components: { EceForm, DeclarationStepContent },
   props: {
     wizard: {
       type: Object as PropType<Wizard>,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/WizardHeader.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/WizardHeader.vue
@@ -22,10 +22,18 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
+
 import { useWizardStore } from "@/store/wizard";
 
 export default defineComponent({
   name: "WizardHeader",
+  setup() {
+    const wizardStore = useWizardStore();
+
+    return {
+      wizardStore,
+    };
+  },
   data: () => ({
     items: [
       {
@@ -41,13 +49,6 @@ export default defineComponent({
       },
     ],
   }),
-  setup() {
-    const wizardStore = useWizardStore();
-
-    return {
-      wizardStore,
-    };
-  },
   computed: {
     certificationType() {
       let certificationType = "";

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/WizardHeader.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/WizardHeader.vue
@@ -11,7 +11,7 @@
     </v-row>
     <v-row justify="space-between" class="pb-6">
       <v-col offset-md="1" cols="12" sm="8">
-        <h3>Application for ECE Assistant Certification</h3>
+        <h3>{{ `Application for ${certificationType} Certification` }}</h3>
       </v-col>
       <v-col v-if="false" cols="auto" offset="1">
         <v-btn class="mr-2" rounded="lg" variant="outlined" color="primary">Cancel Application</v-btn>
@@ -22,6 +22,7 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
+import { useWizardStore } from "@/store/wizard";
 
 export default defineComponent({
   name: "WizardHeader",
@@ -40,5 +41,36 @@ export default defineComponent({
       },
     ],
   }),
+  setup() {
+    const wizardStore = useWizardStore();
+
+    return {
+      wizardStore,
+    };
+  },
+  computed: {
+    certificationType() {
+      let certificationType = "";
+      if (this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes("EceAssistant")) {
+        certificationType = "ECE Assistant";
+      } else if (this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes("OneYear")) {
+        certificationType = "One Year";
+      } else if (
+        this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes("FiveYears")
+      ) {
+        certificationType = "Five Year";
+
+        if (this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes("Sne")) {
+          certificationType += " & Special Needs Educator (SNE)";
+        }
+        if (this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes("Ite")) {
+          certificationType += " & Infant and Toddle Educator (ITE)";
+        }
+      } else {
+        certificationType += "ECE Assistant";
+      }
+      return certificationType;
+    },
+  },
 });
 </script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReference.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReference.vue
@@ -78,8 +78,8 @@ import { defineComponent } from "vue";
 import { useAlertStore } from "@/store/alert";
 import type { EceCharacterReferenceProps } from "@/types/input";
 import type { Components } from "@/types/openapi";
-import * as Rules from "@/utils/formRules";
 import { isNotSpecialCharacterName } from "@/utils/formInput";
+import * as Rules from "@/utils/formRules";
 
 import Alert from "../Alert.vue";
 export default defineComponent({

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Application.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Application.vue
@@ -1,5 +1,8 @@
 <template>
   <Wizard :ref="'wizard'" :wizard="applicationWizard">
+    <template #header>
+      <WizardHeader class="mb-6" />
+    </template>
     <template #PrintPreview>
       <ConfirmationDialog
         :config="{
@@ -68,10 +71,11 @@ import { useUserStore } from "@/store/user";
 import { useWizardStore } from "@/store/wizard";
 
 import { AddressType } from "../inputs/EceAddresses.vue";
+import WizardHeader from "../WizardHeader.vue";
 
 export default defineComponent({
   name: "Application",
-  components: { Wizard, ConfirmationDialog },
+  components: { Wizard, WizardHeader, ConfirmationDialog },
   setup: async () => {
     const wizardStore = useWizardStore();
     const userStore = useUserStore();

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formInput.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formInput.ts
@@ -35,4 +35,4 @@ const isNotSpecialCharacterName = function (event: KeyboardEvent): void {
   }
 };
 
-export { isNumber, isNotSpecialCharacterName };
+export { isNotSpecialCharacterName, isNumber };


### PR DESCRIPTION
## Title
ECER-1674: 

## Description

- Wizard header reflects the certification type.

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/50b91c26-5e6f-4553-8a6a-7a75838a7c95)
