### PR TITLE
ECER-1506 - BE provinces added to the configuration

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/ConfigurationEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/ConfigurationEndpoints.cs
@@ -21,6 +21,8 @@ public class ConfigurationEndpoints : IRegisterEndpoints
 public class ApplicationConfiguration
 {
   public Dictionary<string, OidcAuthenticationSettings> ClientAuthenticationMethods { get; set; } = [];
+
+  public Dictionary<string, string> ProvinceList { get; set; } = [];
 }
 
 #pragma warning restore CA2227 // Collection properties should be read only

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/appsettings.json
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/appsettings.json
@@ -85,5 +85,17 @@
         ]
       }
     }
+  },
+  "ProvinceList": {
+    "AB": "Alberta",
+    "BC": "British Columbia",
+    "MB": "Manitoba",
+    "NB": "New Brunswick",
+    "NL": "Newfoundland and Labrador",
+    "NS": "Nova Scotia",
+    "ON": "Ontario",
+    "PE": "Prince Edward Island",
+    "QC": "Quebec",
+    "SK": "Saskatchewan"
   }
 }

--- a/src/ECER.Tests/Integration/RegistryApi/ConfigurationTests.cs
+++ b/src/ECER.Tests/Integration/RegistryApi/ConfigurationTests.cs
@@ -1,0 +1,27 @@
+﻿using Alba;
+using Shouldly;
+using Xunit.Abstractions;
+
+namespace ECER.Tests.Integration.RegistryApi
+{
+  public class ConfigurationTests : RegistryPortalWebAppScenarioBase
+  {
+    public ConfigurationTests(ITestOutputHelper output, RegistryPortalWebAppFixture fixture) : base(output, fixture)
+    {
+    }
+
+    [Fact]
+    public async Task GetConfigurations_ReturnsConfigurations()
+    {
+      var configurationsResponse = await Host.Scenario(_ =>
+      {
+        _.WithExistingUser(this.Fixture.AuthenticatedBcscUserIdentity, this.Fixture.AuthenticatedBcscUserId);
+        _.Get.Url("/api/configuration");
+        _.StatusCodeShouldBeOk();
+      });
+
+      var configurations = await configurationsResponse.ReadAsJsonAsync<Clients.RegistryPortal.Server.ApplicationConfiguration>();
+      configurations.ShouldNotBeNull();
+    }
+  }
+}


### PR DESCRIPTION
## Title
ECER-1506: BE Extend configuration endpoint to include dropdown field values

## Description

BE Extend configuration endpoint to include dropdown field values for provinces

## Related Jira Issue(s)

- ECER-1506


## Checklist
- [x] I have tested these changes locally.
- [x] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.
