### PR TITLE
ECER-992: Protection key problem solved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 .vscode
+src/key-*.xml

--- a/src/ECER.Clients.Api/Properties/launchSettings.json
+++ b/src/ECER.Clients.Api/Properties/launchSettings.json
@@ -7,7 +7,9 @@
       "launchUrl": "swagger",
       "applicationUrl": "http://localhost:5051",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DataProtection__DirectoryPath": "../",
+        "DataProtection__ApplicationName": "ECER"
       }
     }
   }

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Properties/launchSettings.json
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Properties/launchSettings.json
@@ -9,7 +9,9 @@
       "applicationUrl": "http://localhost:5120",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.SpaProxy"
+        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.SpaProxy",
+        "DataProtection__DirectoryPath": "../../",
+        "DataProtection__ApplicationName": "ECER"
       }
     }
   }

--- a/src/ECER.Tests/Integration/RegistryPortalWebAppScenarioBase.cs
+++ b/src/ECER.Tests/Integration/RegistryPortalWebAppScenarioBase.cs
@@ -171,6 +171,18 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
     if (portalInvitation == null)
     {
       var guid = Guid.NewGuid();
+      var wpGuid = Guid.NewGuid();
+
+      var workexperienceReference = new ecer_WorkExperienceRef
+      {
+        Id = wpGuid,
+        ecer_WorkExperienceRefId = wpGuid,
+        ecer_Name = "Reference Test name",
+        ecer_FirstName = "Reference Test firstname",
+        ecer_LastName = "Reference Test lastname",
+        ecer_EmailAddress = "reference_test@test.com"
+      };
+
       portalInvitation = new ecer_PortalInvitation
       {
         Id = guid,
@@ -181,8 +193,11 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
         ecer_EmailAddress = "test@email.com",
       };
 
+      context.AddObject(workexperienceReference);
       context.AddObject(portalInvitation);
       context.AddLink(portalInvitation, ecer_PortalInvitation.Fields.ecer_portalinvitation_ApplicantId, registrant);
+      context.AddLink(portalInvitation, ecer_PortalInvitation.Fields.ecer_portalinvitation_ApplicationId, testApplication);
+      context.AddLink(portalInvitation, ecer_PortalInvitation.Fields.ecer_portalinvitation_WorkExperienceRefId, workexperienceReference);
     }
 
     return portalInvitation;


### PR DESCRIPTION
Protection key problem solved

## Title
ECER-992: Protection key problem solved

## Description

- Using the same key for encryption and decryption in API and Registry Backend Projects
- Links to applicant/application/workexperience reference added to portal invitation test
- etc.

## Related Jira Issue(s)

- ECER-922

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.