### PR TITLE
ECER-1758: Move checkboxes from education list to inside education entry

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationMapper.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationMapper.cs
@@ -24,6 +24,12 @@ public class ApplicationMapper : Profile
                opt => opt.MapFrom(src => src.StartDate))
       .ForCtorParam(nameof(Managers.Registry.Contract.Applications.Transcript.EndDate),
                opt => opt.MapFrom(src => src.EndDate))
+      .ForCtorParam(nameof(Managers.Registry.Contract.Applications.Transcript.IsECEAssistant),
+               opt => opt.MapFrom(src => src.IsECEAssistant))
+      .ForCtorParam(nameof(Managers.Registry.Contract.Applications.Transcript.DoesECERegistryHaveTranscript),
+               opt => opt.MapFrom(src => src.DoesECERegistryHaveTranscript))
+      .ForCtorParam(nameof(Managers.Registry.Contract.Applications.Transcript.IsOfficialTranscriptRequested),
+               opt => opt.MapFrom(src => src.IsOfficialTranscriptRequested))
       .ForMember(d => d.CampusLocation,
              opts => opts.MapFrom(src => src.CampusLocation))
       .ForMember(d => d.LanguageofInstruction,

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
@@ -173,6 +173,9 @@ public record Transcript()
   public DateTime StartDate { get; set; }
   [Required]
   public DateTime EndDate { get; set; }
+  public bool IsECEAssistant { get; set; }
+  public bool DoesECERegistryHaveTranscript { get; set; }
+  public bool IsOfficialTranscriptRequested { get; set; }
 }
 public record WorkExperienceReference([Required] string? FirstName, [Required] string? LastName, [Required] string? EmailAddress, [Required] int? Hours)
 {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
@@ -83,7 +83,7 @@
             color="primary"
             label="The ECE Registry already has my official transcript for the course/program relevant to this application and certificate type"
           ></v-checkbox>
-          <div v-if="!atLeastOneCheckedError" class="v-messages error-message mb-5" role="alert">Indicate the status of your transcript(s)</div>
+          <div v-if="!atLeastOneChecked" class="v-messages error-message mb-5" role="alert">Indicate the status of your transcript(s)</div>
         </v-row>
         <v-row justify="start" class="ml-1">
           <v-btn rounded="lg" color="alternate" class="mr-2" @click="handleSubmit">Save Education</v-btn>
@@ -164,7 +164,7 @@ export default defineComponent({
       return Object.keys(this.modelValue).length + 1;
     },
 
-    atLeastOneCheckedError() {
+    atLeastOneChecked(): boolean {
       return this.officialTranscriptRequested == true || this.officialTranscriptReceived == true;
     },
     getLabelOnCertificateType() {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
@@ -70,14 +70,12 @@
         ></v-text-field>
         <v-row>
           <v-checkbox
-            ref="refOfficialTranscriptRequested"
             v-model="officialTranscriptRequested"
             :rules="[atLeastOneCheckedRule]"
             color="primary"
             label="I have requested the official transcript from my education institution"
           ></v-checkbox>
           <v-checkbox
-            ref="refOfficialTranscriptReceived"
             v-model="officialTranscriptReceived"
             :rules="[atLeastOneCheckedRule]"
             color="primary"
@@ -163,7 +161,6 @@ export default defineComponent({
     newClientId() {
       return Object.keys(this.modelValue).length + 1;
     },
-
     atLeastOneChecked(): boolean {
       return this.officialTranscriptRequested == true || this.officialTranscriptReceived == true;
     },
@@ -281,7 +278,7 @@ export default defineComponent({
     },
     formatDate,
     atLeastOneCheckedRule() {
-      if (!this.officialTranscriptRequested && !this.officialTranscriptReceived) {
+      if (!this.atLeastOneChecked) {
         return "";
       }
       return true;

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
@@ -70,21 +70,21 @@
         ></v-text-field>
         <v-row>
           <v-checkbox
+            ref="refOfficialTranscriptRequested"
             v-model="officialTranscriptRequested"
-            :class="{ 'error-message': !atLeastOneChecked }"
+            :rules="[atLeastOneCheckedRule]"
             color="primary"
             label="I have requested the official transcript from my education institution"
           ></v-checkbox>
           <v-checkbox
+            ref="refOfficialTranscriptReceived"
             v-model="officialTranscriptReceived"
-            :class="{ 'error-message': !atLeastOneChecked }"
+            :rules="[atLeastOneCheckedRule]"
             color="primary"
             label="The ECE Registry already has my official transcript for the course/program relevant to this application and certificate type"
           ></v-checkbox>
-          <div v-if="!atLeastOneChecked" class="v-messages error-message" role="alert">Please select at least one Option</div>
+          <!-- <div v-if="!atLeastOneCheckedError" class="v-messages error-message" role="alert" aria-live="polite">Please select at least one Option</div> -->
         </v-row>
-        <!-- <v-checkbox v-model="isECEAssistant" color="primary" label="Is ECE assistant?"></v-checkbox> -->
-
         <v-row justify="start" class="ml-1">
           <v-btn rounded="lg" color="alternate" class="mr-2" @click="handleSubmit">Save Education</v-btn>
           <v-btn rounded="lg" variant="outlined" @click="handleCancel">Cancel</v-btn>
@@ -161,10 +161,12 @@ export default defineComponent({
     newClientId() {
       return Object.keys(this.modelValue).length + 1;
     },
-    atLeastOneChecked() {
+
+    atLeastOneCheckedError() {
       return this.officialTranscriptRequested == true || this.officialTranscriptReceived == true;
     },
   },
+
   mounted() {
     if (Object.keys(this.modelValue).length === 0) {
       this.mode = "add";
@@ -269,11 +271,13 @@ export default defineComponent({
       this.endYear = "";
     },
     formatDate,
+
+    atLeastOneCheckedRule() {
+      if (!this.officialTranscriptRequested && !this.officialTranscriptReceived) {
+        return "Select at least one";
+      }
+      return true;
+    },
   },
 });
 </script>
-<style>
-.error-message {
-  color: rgb(var(--v-theme-error));
-}
-</style>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
@@ -68,6 +68,23 @@
           maxlength="50"
           class="my-8"
         ></v-text-field>
+        <v-row>
+          <v-checkbox
+            v-model="officialTranscriptRequested"
+            :class="{ 'error-message': !atLeastOneChecked }"
+            color="primary"
+            label="I have requested the official transcript from my education institution"
+          ></v-checkbox>
+          <v-checkbox
+            v-model="officialTranscriptReceived"
+            :class="{ 'error-message': !atLeastOneChecked }"
+            color="primary"
+            label="The ECE Registry already has my official transcript for the course/program relevant to this application and certificate type"
+          ></v-checkbox>
+          <div v-if="!atLeastOneChecked" class="v-messages error-message" role="alert">Please select at least one Option</div>
+        </v-row>
+        <!-- <v-checkbox v-model="isECEAssistant" color="primary" label="Is ECE assistant?"></v-checkbox> -->
+
         <v-row justify="start" class="ml-1">
           <v-btn rounded="lg" color="alternate" class="mr-2" @click="handleSubmit">Save Education</v-btn>
           <v-btn rounded="lg" variant="outlined" @click="handleCancel">Cancel</v-btn>
@@ -82,20 +99,6 @@
         <v-row justify="start" class="ml-1">
           <v-btn prepend-icon="mdi-plus" rounded="lg" color="alternate" @click="handleAddEducation">Add Education</v-btn>
         </v-row>
-      </v-col>
-      <v-col class="mt-4" md="8">
-        <form ref="checkboxForm">
-          <v-checkbox
-            v-model="officialTranscriptRequested"
-            color="primary"
-            label="I have requested the official transcript from my education institution"
-          ></v-checkbox>
-          <v-checkbox
-            v-model="officialTranscriptReceived"
-            color="primary"
-            label="The ECE Registry already has my official transcript for the course/program relevant to this application and certificate type"
-          ></v-checkbox>
-        </form>
       </v-col>
     </div>
   </v-row>
@@ -158,6 +161,9 @@ export default defineComponent({
     newClientId() {
       return Object.keys(this.modelValue).length + 1;
     },
+    atLeastOneChecked() {
+      return this.officialTranscriptRequested == true || this.officialTranscriptReceived == true;
+    },
   },
   mounted() {
     if (Object.keys(this.modelValue).length === 0) {
@@ -183,6 +189,8 @@ export default defineComponent({
           languageofInstruction: this.language,
           startDate: this.startYear,
           endDate: this.endYear,
+          doesECERegistryHaveTranscript: this.officialTranscriptReceived,
+          isOfficialTranscriptRequested: this.officialTranscriptRequested,
         };
 
         // see if we already have a clientId (which is edit), if not use the newClientId (which is add)
@@ -229,6 +237,8 @@ export default defineComponent({
       this.language = educationData.education.languageofInstruction ?? "";
       this.startYear = formatDate(educationData.education.startDate) ?? "";
       this.endYear = formatDate(educationData.education.endDate) ?? "";
+      this.officialTranscriptRequested = educationData.education.isOfficialTranscriptRequested ?? false;
+      this.officialTranscriptReceived = educationData.education.doesECERegistryHaveTranscript ?? false;
       // Change mode to add
       this.mode = "add";
     },
@@ -262,3 +272,8 @@ export default defineComponent({
   },
 });
 </script>
+<style>
+.error-message {
+  color: rgb(var(--v-theme-error));
+}
+</style>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
@@ -83,7 +83,7 @@
             color="primary"
             label="The ECE Registry already has my official transcript for the course/program relevant to this application and certificate type"
           ></v-checkbox>
-          <!-- <div v-if="!atLeastOneCheckedError" class="v-messages error-message" role="alert" aria-live="polite">Please select at least one Option</div> -->
+          <div v-if="!atLeastOneCheckedError" class="v-messages error-message mb-5" role="alert">Indicate the status of your trnscript(s)</div>
         </v-row>
         <v-row justify="start" class="ml-1">
           <v-btn rounded="lg" color="alternate" class="mr-2" @click="handleSubmit">Save Education</v-btn>
@@ -271,10 +271,9 @@ export default defineComponent({
       this.endYear = "";
     },
     formatDate,
-
     atLeastOneCheckedRule() {
       if (!this.officialTranscriptRequested && !this.officialTranscriptReceived) {
-        return "Select at least one";
+        return "";
       }
       return true;
     },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
@@ -198,6 +198,9 @@ declare namespace Components {
       languageofInstruction?: string | null;
       startDate: string; // date-time
       endDate: string; // date-time
+      isECEAssistant?: boolean;
+      doesECERegistryHaveTranscript?: boolean;
+      isOfficialTranscriptRequested?: boolean;
     }
     export type UnabletoProvideReferenceReasons =
       | "Iamunabletoatthistime"

--- a/src/ECER.Managers.Registry.Contract/Applications/Contract.cs
+++ b/src/ECER.Managers.Registry.Contract/Applications/Contract.cs
@@ -59,7 +59,7 @@ public record Application(string? Id, string RegistrantId, ApplicationStatus Sta
   public IEnumerable<CharacterReference> CharacterReferences { get; set; } = Array.Empty<CharacterReference>();
 }
 
-public record Transcript(string? Id, string? EducationalInstitutionName, string? ProgramName, string? StudentName, string? StudentNumber, DateTime StartDate, DateTime EndDate)
+public record Transcript(string? Id, string? EducationalInstitutionName, string? ProgramName, string? StudentName, string? StudentNumber, DateTime StartDate, DateTime EndDate, bool IsECEAssistant, bool DoesECERegistryHaveTranscript, bool IsOfficialTranscriptRequested)
 {
   public string? CampusLocation { get; set; }
   public string? LanguageofInstruction { get; set; }

--- a/src/ECER.Resources.Documents/Applications/ApplicationRepositoryMapper.cs
+++ b/src/ECER.Resources.Documents/Applications/ApplicationRepositoryMapper.cs
@@ -65,7 +65,7 @@ internal class ApplicationRepositoryMapper : Profile
            .ForMember(d => d.ecer_EducationInstitutionFullName, opts => opts.MapFrom(s => s.EducationalInstitutionName))
            .ForMember(d => d.ecer_LanguageofInstruction, opts => opts.MapFrom(s => s.LanguageofInstruction))
            .ForMember(d => d.ecer_TranscriptId, opts => opts.MapFrom(s => s.Id))
-           .ForMember(d => d.ecer_iseceassistantName, opts => opts.MapFrom(s => s.IsECEAssistant))
+           .ForMember(d => d.ecer_IsECEAssistant, opts => opts.MapFrom(s => s.IsECEAssistant))
            .ForMember(d => d.ecer_DoesECERegistryHaveTranscript, opts => opts.MapFrom(s => s.DoesECERegistryHaveTranscript))
            .ForMember(d => d.ecer_IsOfficialTranscriptRequested, opts => opts.MapFrom(s => s.IsOfficialTranscriptRequested));
 
@@ -77,7 +77,7 @@ internal class ApplicationRepositoryMapper : Profile
           .ForCtorParam(nameof(Transcript.StudentNumber), opt => opt.MapFrom(src => src.ecer_StudentNumber))
           .ForCtorParam(nameof(Transcript.StartDate), opt => opt.MapFrom(src => src.ecer_StartDate))
           .ForCtorParam(nameof(Transcript.EndDate), opt => opt.MapFrom(src => src.ecer_EndDate))
-          .ForCtorParam(nameof(Transcript.IsECEAssistant), opt => opt.MapFrom(src => src.ecer_iseceassistantName))
+          .ForCtorParam(nameof(Transcript.IsECEAssistant), opt => opt.MapFrom(src => src.ecer_IsECEAssistant))
           .ForCtorParam(nameof(Transcript.DoesECERegistryHaveTranscript), opt => opt.MapFrom(src => src.ecer_DoesECERegistryHaveTranscript))
           .ForCtorParam(nameof(Transcript.IsOfficialTranscriptRequested), opt => opt.MapFrom(src => src.ecer_IsOfficialTranscriptRequested))
           .ForMember(d => d.CampusLocation, opts => opts.MapFrom(s => s.ecer_CampusLocation))

--- a/src/ECER.Resources.Documents/Applications/ApplicationRepositoryMapper.cs
+++ b/src/ECER.Resources.Documents/Applications/ApplicationRepositoryMapper.cs
@@ -64,7 +64,10 @@ internal class ApplicationRepositoryMapper : Profile
            .ForMember(d => d.ecer_StudentNumber, opts => opts.MapFrom(s => s.StudentNumber))
            .ForMember(d => d.ecer_EducationInstitutionFullName, opts => opts.MapFrom(s => s.EducationalInstitutionName))
            .ForMember(d => d.ecer_LanguageofInstruction, opts => opts.MapFrom(s => s.LanguageofInstruction))
-           .ForMember(d => d.ecer_TranscriptId, opts => opts.MapFrom(s => s.Id));
+           .ForMember(d => d.ecer_TranscriptId, opts => opts.MapFrom(s => s.Id))
+           .ForMember(d => d.ecer_iseceassistantName, opts => opts.MapFrom(s => s.IsECEAssistant))
+           .ForMember(d => d.ecer_DoesECERegistryHaveTranscript, opts => opts.MapFrom(s => s.DoesECERegistryHaveTranscript))
+           .ForMember(d => d.ecer_IsOfficialTranscriptRequested, opts => opts.MapFrom(s => s.IsOfficialTranscriptRequested));
 
     CreateMap<ecer_Transcript, Transcript>(MemberList.Source)
           .ForCtorParam(nameof(Transcript.Id), opt => opt.MapFrom(src => src.ecer_TranscriptId))
@@ -74,6 +77,9 @@ internal class ApplicationRepositoryMapper : Profile
           .ForCtorParam(nameof(Transcript.StudentNumber), opt => opt.MapFrom(src => src.ecer_StudentNumber))
           .ForCtorParam(nameof(Transcript.StartDate), opt => opt.MapFrom(src => src.ecer_StartDate))
           .ForCtorParam(nameof(Transcript.EndDate), opt => opt.MapFrom(src => src.ecer_EndDate))
+          .ForCtorParam(nameof(Transcript.IsECEAssistant), opt => opt.MapFrom(src => src.ecer_iseceassistantName))
+          .ForCtorParam(nameof(Transcript.DoesECERegistryHaveTranscript), opt => opt.MapFrom(src => src.ecer_DoesECERegistryHaveTranscript))
+          .ForCtorParam(nameof(Transcript.IsOfficialTranscriptRequested), opt => opt.MapFrom(src => src.ecer_IsOfficialTranscriptRequested))
           .ForMember(d => d.CampusLocation, opts => opts.MapFrom(s => s.ecer_CampusLocation))
           .ForMember(d => d.LanguageofInstruction, opts => opts.MapFrom(s => s.ecer_LanguageofInstruction))
     .ValidateMemberList(MemberList.Destination);

--- a/src/ECER.Resources.Documents/Applications/IApplicationRepository.cs
+++ b/src/ECER.Resources.Documents/Applications/IApplicationRepository.cs
@@ -42,7 +42,7 @@ public record Application(string? Id, string ApplicantId, IEnumerable<Certificat
   public IEnumerable<CharacterReference> CharacterReferences { get; set; } = Array.Empty<CharacterReference>();
 }
 
-public record Transcript(string? Id, string? EducationalInstitutionName, string? ProgramName, string? StudentName, string? StudentNumber, DateTime StartDate, DateTime EndDate)
+public record Transcript(string? Id, string? EducationalInstitutionName, string? ProgramName, string? StudentName, string? StudentNumber, DateTime StartDate, DateTime EndDate, bool IsECEAssistant, bool DoesECERegistryHaveTranscript, bool IsOfficialTranscriptRequested)
 {
   public string? CampusLocation { get; set; }
   public string? LanguageofInstruction { get; set; }

--- a/src/ECER.Tests/Integration/RegistryApi/ApplicationTests.cs
+++ b/src/ECER.Tests/Integration/RegistryApi/ApplicationTests.cs
@@ -226,7 +226,10 @@ public class ApplicationTests : RegistryPortalWebAppScenarioBase
       StudentName = null,
       StudentNumber = faker.Random.Number(1000, 9999).ToString(),
       StartDate = faker.Date.Recent(),
-      EndDate = faker.Date.Soon()
+      EndDate = faker.Date.Soon(),
+      IsECEAssistant = faker.Random.Bool(),
+      DoesECERegistryHaveTranscript = faker.Random.Bool(),
+      IsOfficialTranscriptRequested = faker.Random.Bool()
     };
 
     return invalidTranscript;

--- a/src/ECER.Tests/Integration/Resources/Applications/ApplicationRepositoryTests.cs
+++ b/src/ECER.Tests/Integration/Resources/Applications/ApplicationRepositoryTests.cs
@@ -401,7 +401,7 @@ public class ApplicationRepositoryTests : RegistryPortalWebAppScenarioBase
     var languages = new List<string> { "English", "French", "Spanish", "German", "Mandarin", "Japanese", "Russian", "Arabic", "Portuguese", "Hindi" };
 
     return new Transcript(null, faker.Company.CompanyName(), $"{faker.Hacker.Adjective()} Program",
-      faker.Name.FullName(), faker.Random.Number(10000000, 99999999).ToString(), faker.Date.Past(), faker.Date.Recent()
+      faker.Name.FullName(), faker.Random.Number(10000000, 99999999).ToString(), faker.Date.Past(), faker.Date.Recent(), faker.Random.Bool(), faker.Random.Bool(), faker.Random.Bool()
     )
     {
       LanguageofInstruction = faker.PickRandom(languages),

--- a/src/ECER.Tests/Unit/ApplicationSubmissionValidationEngineTests.cs
+++ b/src/ECER.Tests/Unit/ApplicationSubmissionValidationEngineTests.cs
@@ -147,7 +147,7 @@ namespace ECER.Tests.Unit
       }
 
       var faker = new Faker("en_CA");
-      var transcript = new Transcript(null, faker.Company.CompanyName(), $"{faker.Hacker.Adjective()} Program", faker.Name.FullName(), faker.Random.Number(10000000, 99999999).ToString(), startDate, endDate);
+      var transcript = new Transcript(null, faker.Company.CompanyName(), $"{faker.Hacker.Adjective()} Program", faker.Name.FullName(), faker.Random.Number(10000000, 99999999).ToString(), startDate, endDate, faker.Random.Bool(), faker.Random.Bool(), faker.Random.Bool());
 
       return transcript;
     }


### PR DESCRIPTION

Move checkboxes from education list to inside education entry
---
This PR aims at moving the education list to inside education entry


## Title
ECER-{1758}: Move checkboxes from education list to inside education entry

## Description

- Expose ecer_IsECEAssistant in endpoint and map to dynamics
- Expose ecer_DoesECERegistryHaveTranscript in endpoint and map to dynamics
- Expose ecer_IsOfficialTranscriptRequested in endpoint and map to dynamics
- FE - Move checkboxes from education list to inside education entry

## Related Jira Issue(s)

- ECER-{716}
- ECER-{1757}
- ECER-{1758}

## Checklist
- [x] I have tested these changes locally.
- [x] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Added to:
![image](https://github.com/bcgov/ECC-ECER/assets/160776397/a52e7bd5-2675-46b1-b3ce-e4bce1aa1c57)
Validation:
![image](https://github.com/bcgov/ECC-ECER/assets/160776397/7bd37a39-f1ed-4af5-b554-f8a4ca1ffdd3)
Removed from:
![image](https://github.com/bcgov/ECC-ECER/assets/160776397/2f11f7c6-9c5b-4b08-ae68-f547b6da831a)
