### PR TITLE
minor bug fixes after feedback received

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceCharacterReferenceDeclaration.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceCharacterReferenceDeclaration.vue
@@ -13,8 +13,8 @@
 
           <h2>Information you'll need</h2>
           <div>
-            It should take about 5 minutes to enter your reference. Make sure you get together all the information you need for you to continue. If you're not
-            ready now, you can come back later using the link in your email.
+            It should take about 5 minutes to enter your reference. Make sure you get together all the information before you need for you continue. If you're
+            not ready now, you can come back later using the link in your email.
           </div>
           <br />
 

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceCharacterReferenceDeclaration.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceCharacterReferenceDeclaration.vue
@@ -4,16 +4,16 @@
       <v-row no-gutters>
         <v-col>
           <div>
-            <b>{{ `${wizardStore.wizardData.applicantFirstName} ${wizardStore.wizardData.applicantLastName}` }}</b>
+            {{ `${wizardStore.wizardData.applicantFirstName} ${wizardStore.wizardData.applicantLastName}` }}
             is requesting a character reference for an
             <b>{{ certificationType }}.</b>
-            We'll review your reference when assessing if the applicant is eligible for certification
+            We'll review your reference when assessing if the applicant is eligible for certification.
           </div>
           <br />
 
           <h2>Information you'll need</h2>
           <div>
-            It should take about 5 minutes to enter your reference. Make sure you get together all the information you need for you continue. If you're not
+            It should take about 5 minutes to enter your reference. Make sure you get together all the information you need for you to continue. If you're not
             ready now, you can come back later using the link in your email.
           </div>
           <br />
@@ -21,7 +21,7 @@
           <p>You'll be asked to provide:</p>
           <ul class="ml-10">
             <li>Your contact information</li>
-            <li>Your ECE certification Information (optional)</li>
+            <li>Your ECE certification information (optional)</li>
             <li>How long you've known the applicant</li>
             <li>Your relationship with the applicant</li>
             <li>Your personal observations of the applicant</li>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceCharacterReferenceDeclaration.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceCharacterReferenceDeclaration.vue
@@ -13,8 +13,8 @@
 
           <h2>Information you'll need</h2>
           <div>
-            It should take about 5 minutes to enter your reference. Make sure you get together all the information before you need for you continue. If you're
-            not ready now, you can come back later using the link in your email.
+            It should take about 5 minutes to enter your reference. Make sure you get together all the information you need before you continue. If you're not
+            ready now, you can come back later using the link in your email.
           </div>
           <br />
 

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceCharacterReferenceDeclaration.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceCharacterReferenceDeclaration.vue
@@ -5,7 +5,7 @@
         <v-col>
           <div>
             {{ `${wizardStore.wizardData.applicantFirstName} ${wizardStore.wizardData.applicantLastName}` }}
-            is requesting a character reference for an
+            is requesting a character reference for
             <b>{{ certificationType }}.</b>
             We'll review your reference when assessing if the applicant is eligible for certification.
           </div>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceReferenceContact.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceReferenceContact.vue
@@ -61,7 +61,7 @@
         </v-col>
       </v-row>
       <h3 class="mt-5">ECE certification</h3>
-      <div role="doc-subtitle">If you are registered as an ECE in Canada, please provide your certification number if applicable.</div>
+      <div role="doc-subtitle">If you are registered as an ECE in Canada, please provide your certification number.</div>
       <v-row class="mt-5">
         <v-col cols="12" md="8" lg="6" xl="4">
           <v-autocomplete

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceReferenceContact.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceReferenceContact.vue
@@ -120,6 +120,7 @@ import type { VTextField } from "vuetify/components";
 
 import { useConfigStore } from "@/store/config";
 import type { Components } from "@/types/openapi";
+import { ProvinceTerritoryType } from "@/utils/constant";
 import { formatDate } from "@/utils/format";
 import { isNumber } from "@/utils/formInput";
 import * as Rules from "@/utils/formRules";
@@ -146,16 +147,9 @@ export default defineComponent({
     };
   },
   computed: {
-    provinces() {
-      return [
-        { title: "British Columbia", value: "BC" },
-        { title: "Alberta", value: "AB" },
-        { title: "Prince Edward Island", value: "PEI" },
-      ];
-    },
     userSelectProvinceIdBC(): boolean {
       const provinceName = this.configStore.provinceName(this.modelValue?.certificateProvinceId as string);
-      return provinceName === "British Columbia";
+      return provinceName === ProvinceTerritoryType.BC;
     },
     today() {
       return formatDate(DateTime.now().toString());

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceWorkExperienceReferenceDeclaration.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceWorkExperienceReferenceDeclaration.vue
@@ -12,7 +12,7 @@
 
           <h2>Information you'll need</h2>
           <p>
-            It should take about 5 minutes to enter your reference. Make sure you get together all the information you need for you continue. If you're not
+            It should take about 5 minutes to enter your reference. Make sure you get together all the information you need before you continue. If you're not
             ready now, you can come back later using the link in your email.
           </p>
           <br />

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceWorkExperienceReferenceDeclaration.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceWorkExperienceReferenceDeclaration.vue
@@ -4,9 +4,9 @@
       <v-row no-gutters>
         <v-col>
           <p>
-            <b>{{ `${wizardStore.wizardData.applicantFirstName} ${wizardStore.wizardData.applicantLastName}` }}</b>
-            is requesting a work reference for ECE 5 Year Certification. We'll review your reference when assessing if the applicant is eligible for
-            certification
+            {{ `${wizardStore.wizardData.applicantFirstName} ${wizardStore.wizardData.applicantLastName}` }}
+            is requesting a work experience reference for an ECE 5 Year Certification. We'll review your reference when assessing if the applicant is eligible
+            for certification
           </p>
           <br />
 

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceWorkExperienceReferenceDeclaration.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceWorkExperienceReferenceDeclaration.vue
@@ -5,8 +5,8 @@
         <v-col>
           <p>
             {{ `${wizardStore.wizardData.applicantFirstName} ${wizardStore.wizardData.applicantLastName}` }}
-            is requesting a work experience reference for an ECE 5 Year Certification. We'll review your reference when assessing if the applicant is eligible
-            for certification
+            is requesting a work experience reference for ECE 5 Year Certification. We'll review your reference when assessing if the applicant is eligible for
+            certification
           </p>
           <br />
 

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/config.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/config.ts
@@ -5,6 +5,7 @@ import { getConfiguration, getProvinceList } from "@/api/configuration";
 import oidcConfig from "@/oidc-config";
 import type { DropdownWrapper } from "@/types/form";
 import type { Components } from "@/types/openapi";
+import { ProvinceTerritoryType } from "@/utils/constant";
 import { sortArray } from "@/utils/functions";
 
 export interface UserState {
@@ -56,7 +57,7 @@ export const useConfigStore = defineStore("config", {
               title: province.provinceName as string,
             };
           })
-          .sort((a, b) => sortArray(a, b, "title", ["Other"]));
+          .sort((a, b) => sortArray(a, b, "title", [ProvinceTerritoryType.OTHER]));
       }
       return configuration;
     },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/config.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/config.ts
@@ -5,6 +5,7 @@ import { getConfiguration, getProvinceList } from "@/api/configuration";
 import oidcConfig from "@/oidc-config";
 import type { DropdownWrapper } from "@/types/form";
 import type { Components } from "@/types/openapi";
+import { sortArray } from "@/utils/functions";
 
 export interface UserState {
   applicationConfiguration: Components.Schemas.ApplicationConfiguration;
@@ -48,12 +49,14 @@ export const useConfigStore = defineStore("config", {
 
       const provinceList = await getProvinceList();
       if (provinceList !== null && provinceList !== undefined) {
-        this.provinceList = provinceList.map((province) => {
-          return {
-            value: province.provinceId as string,
-            title: province.provinceName as string,
-          };
-        });
+        this.provinceList = provinceList
+          .map((province) => {
+            return {
+              value: province.provinceId as string,
+              title: province.provinceName as string,
+            };
+          })
+          .sort((a, b) => sortArray(a, b, "title", ["Other"]));
       }
       return configuration;
     },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/constant.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/constant.ts
@@ -33,7 +33,7 @@ export const referenceRelationshipDropdown: DropdownWrapper<Components.Schemas.R
   { title: "Supervisor", value: "Supervisor" },
   { title: "Co Worker", value: "CoWorker" },
   { title: "Teacher", value: "Teacher" },
-  { title: "Parent Guardian of Child in Care", value: "ParentGuardianofChildinCare" },
+  { title: "Parent or Guardian of Child in Care", value: "ParentGuardianofChildinCare" },
   { title: "Other", value: "Other" },
 ];
 
@@ -54,7 +54,7 @@ export const workHoursTypeRadio: RadioButtonWrapper<Components.Schemas.WorkHours
 
 export const workReferenceRelationshipRadio: RadioButtonWrapper<Components.Schemas.ReferenceRelationship>[] = [
   { label: "Supervisor", value: "Supervisor" },
-  { label: "Co-Worker", value: "CoWorker" },
+  { label: "Co-worker", value: "CoWorker" },
   { label: "Other", value: "Other" },
 ];
 

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/constant.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/constant.ts
@@ -29,6 +29,11 @@ export enum PortalInviteType {
   CHARACTER = "CharacterReference",
 }
 
+export enum ProvinceTerritoryType {
+  BC = "British Columbia",
+  OTHER = "Other",
+}
+
 export const referenceRelationshipDropdown: DropdownWrapper<Components.Schemas.ReferenceRelationship>[] = [
   { title: "Supervisor", value: "Supervisor" },
   { title: "Co Worker", value: "CoWorker" },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/functions.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/functions.ts
@@ -22,3 +22,27 @@ export function areObjectsEqual(obj1: any, obj2: any): boolean {
 
   return true;
 }
+
+/**
+ * Sorts an array of objects by a specified key, while keeping exceptions at the end.
+ * @param {Array<Object>} a - The first object to compare.
+ * @param {Array<Object>} b - The second object to compare.
+ * @param {string} key - The key by which the objects should be sorted.
+ * @param {Array<string>} [exceptions=[]] - An array of strings representing exceptions that should be kept at the end of the sorted array.
+ * @returns {number} A negative value if a should come before b, a positive value if a should come after b, or 0 if they are equal.
+ */
+export function sortArray(a: any, b: any, key: string, exceptions: string[] = []) {
+  if (exceptions.includes(a[key])) {
+    return 1;
+  }
+
+  if (a[key] < b[key]) {
+    return -1;
+  }
+
+  if (a[key] > b[key]) {
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION

## Title various fixes based on user feedback after demo.


## Description

- add **before** on declaration page so the sentence makes sense.
- parent **OR** guardian dropdown option
- sort provinces alphabetically while keeping Other at the bottom.
- lower case ECE certification **i**nformation
- period at the end of requesting a character reference for an ECE
-sync up work reference and character reference. Do not bold the name. Add minor spelling changes.
-Change this in label text for certification number:
If you are registered as an ECE in Canada, please provide your certification number if applicable. 
To:
If you're registered as an ECE in Canada, please provide your certification number.


## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.
