### PR TITLE
Tasks/common radio

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/CheckboxMultiple.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/CheckboxMultiple.vue
@@ -37,7 +37,7 @@ export default defineComponent({
       default: "value",
     },
     rules: {
-      type: Array as PropType<any>,
+      type: Array as PropType<any[]>,
       default: () => [],
     },
     selectAll: {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/CheckboxMultiple.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/CheckboxMultiple.vue
@@ -38,7 +38,7 @@ export default defineComponent({
     },
     rules: {
       type: Array as PropType<any>,
-      default: null,
+      default: () => [],
     },
     selectAll: {
       type: Boolean,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/RadioWithAdditionalOption.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/RadioWithAdditionalOption.vue
@@ -1,0 +1,85 @@
+<template>
+  <slot name="radioLabel" :for="`${valueKey}Label`"></slot>
+  <v-radio-group id="`${valueKey}Label`" v-model="itemSelection" :rules="valueRules" hide-details="auto" @update:model-value="modalValueUpdated">
+    <v-radio v-for="(item, index) in items" :key="index" :label="item[itemLabel]" :value="item[itemValue]"></v-radio>
+  </v-radio-group>
+  <slot v-if="triggerForAdditionalInformation" name="textFieldLabel" :for="`${additionalInfoKey}Label`"></slot>
+  <v-text-field
+    v-if="triggerForAdditionalInformation"
+    :id="`${valueKey}Label`"
+    variant="outlined"
+    counter="1000"
+    color="primary"
+    maxlength="1000"
+    hide-details="auto"
+    :auto-grow="true"
+    :rules="additionalInfoRules"
+    @update:model-value="$emit('update:model-value', { [additionalInfoKey]: $event })"
+  ></v-text-field>
+</template>
+
+<script lang="ts">
+import type { PropType } from "vue";
+import { defineComponent } from "vue";
+import type { RadioWithAdditionalOption } from "@/types/input";
+
+export default defineComponent({
+  name: "RadioWithAdditionalOption",
+  props: {
+    items: {
+      type: Array as PropType<RadioWithAdditionalOption[]>,
+      required: true,
+    },
+    itemLabel: {
+      type: String,
+      default: "label",
+    },
+    itemValue: {
+      type: String,
+      default: "value",
+    },
+    valueRules: {
+      type: Array as PropType<any>,
+      default: () => [],
+    },
+    additionalInfoRules: {
+      type: Array as PropType<any>,
+      default: () => [],
+    },
+    triggerValues: {
+      type: Array,
+      default: () => [],
+    },
+    additionalInfoKey: {
+      type: String,
+      required: true,
+    },
+    valueKey: {
+      type: String,
+      required: true,
+    },
+  },
+  emits: {
+    "update:model-value": (_itemSelection: any) => true,
+  },
+  data() {
+    return {
+      itemSelection: undefined,
+    };
+  },
+  computed: {
+    triggerForAdditionalInformation() {
+      return this.triggerValues.includes(this?.itemSelection);
+    },
+  },
+  methods: {
+    modalValueUpdated(value: any) {
+      if (this.triggerForAdditionalInformation) {
+        this.$emit("update:model-value", { [this.valueKey]: value });
+      } else {
+        this.$emit("update:model-value", { [this.additionalInfoKey]: "", [this.valueKey]: value });
+      }
+    },
+  },
+});
+</script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/RadioWithAdditionalOption.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/RadioWithAdditionalOption.vue
@@ -18,6 +18,7 @@
 <script lang="ts">
 import type { PropType } from "vue";
 import { defineComponent } from "vue";
+
 import type { RadioWithAdditionalOption, RadioWithAdditionalOptionProps } from "@/types/input";
 
 export default defineComponent({
@@ -54,6 +55,7 @@ export default defineComponent({
     additionalInfoProps: {
       type: Object as PropType<RadioWithAdditionalOptionProps>,
       required: false,
+      default: () => {},
     },
   },
   emits: {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/RadioWithAdditionalOption.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/RadioWithAdditionalOption.vue
@@ -25,7 +25,8 @@ export default defineComponent({
   name: "RadioWithAdditionalOption",
   props: {
     modelValue: {
-      type: String as PropType<any>,
+      type: String,
+      default: undefined,
     },
     items: {
       type: Array as PropType<RadioWithAdditionalOption[]>,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/RadioWithAdditionalOption.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/RadioWithAdditionalOption.vue
@@ -1,27 +1,24 @@
 <template>
   <slot name="radioLabel" :for="`${valueKey}Label`"></slot>
-  <v-radio-group id="`${valueKey}Label`" v-model="itemSelection" :rules="valueRules" hide-details="auto" @update:model-value="modalValueUpdated">
+  <v-radio-group id="`${valueKey}Label`" v-model="itemSelection" :rules="radioRules" hide-details="auto" @update:model-value="modalValueUpdated">
     <v-radio v-for="(item, index) in items" :key="index" :label="item[itemLabel]" :value="item[itemValue]"></v-radio>
   </v-radio-group>
-  <slot v-if="triggerForAdditionalInformation" name="textFieldLabel" :for="`${additionalInfoKey}Label`"></slot>
-  <v-text-field
+  <slot v-if="triggerForAdditionalInformation" name="textAreaLabel" :for="`${additionalInfoKey}Label`"></slot>
+  <v-textarea
     v-if="triggerForAdditionalInformation"
+    v-bind="additionalInfoProps"
     :id="`${valueKey}Label`"
-    variant="outlined"
-    counter="1000"
     color="primary"
-    maxlength="1000"
+    variant="outlined"
     hide-details="auto"
-    :auto-grow="true"
-    :rules="additionalInfoRules"
     @update:model-value="$emit('update:model-value', { [additionalInfoKey]: $event })"
-  ></v-text-field>
+  ></v-textarea>
 </template>
 
 <script lang="ts">
 import type { PropType } from "vue";
 import { defineComponent } from "vue";
-import type { RadioWithAdditionalOption } from "@/types/input";
+import type { RadioWithAdditionalOption, RadioWithAdditionalOptionProps } from "@/types/input";
 
 export default defineComponent({
   name: "RadioWithAdditionalOption",
@@ -38,12 +35,8 @@ export default defineComponent({
       type: String,
       default: "value",
     },
-    valueRules: {
-      type: Array as PropType<any>,
-      default: () => [],
-    },
-    additionalInfoRules: {
-      type: Array as PropType<any>,
+    radioRules: {
+      type: Array as PropType<any[]>,
       default: () => [],
     },
     triggerValues: {
@@ -57,6 +50,10 @@ export default defineComponent({
     valueKey: {
       type: String,
       required: true,
+    },
+    additionalInfoProps: {
+      type: Object as PropType<RadioWithAdditionalOptionProps>,
+      required: false,
     },
   },
   emits: {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/RadioWithAdditionalOption.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/RadioWithAdditionalOption.vue
@@ -1,6 +1,6 @@
 <template>
   <slot name="radioLabel" :for="`${valueKey}Label`"></slot>
-  <v-radio-group id="`${valueKey}Label`" v-model="itemSelection" :rules="radioRules" hide-details="auto" @update:model-value="modalValueUpdated">
+  <v-radio-group id="`${valueKey}Label`" :rules="radioRules" hide-details="auto" @update:model-value="modalValueUpdated">
     <v-radio v-for="(item, index) in items" :key="index" :label="item[itemLabel]" :value="item[itemValue]"></v-radio>
   </v-radio-group>
   <slot v-if="triggerForAdditionalInformation" name="textAreaLabel" :for="`${additionalInfoKey}Label`"></slot>
@@ -24,6 +24,9 @@ import type { RadioWithAdditionalOption, RadioWithAdditionalOptionProps } from "
 export default defineComponent({
   name: "RadioWithAdditionalOption",
   props: {
+    modelValue: {
+      type: String as PropType<any>,
+    },
     items: {
       type: Array as PropType<RadioWithAdditionalOption[]>,
       required: true,
@@ -61,14 +64,9 @@ export default defineComponent({
   emits: {
     "update:model-value": (_itemSelection: any) => true,
   },
-  data() {
-    return {
-      itemSelection: undefined,
-    };
-  },
   computed: {
     triggerForAdditionalInformation() {
-      return this.triggerValues.includes(this?.itemSelection);
+      return this.triggerValues.includes(this.modelValue);
     },
   },
   methods: {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/input.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/input.d.ts
@@ -57,6 +57,10 @@ interface CheckboxMultipleDropdownItems {
   [key: string]: any;
 }
 
+interface RadioWithAdditionalOption {
+  [key: string]: any;
+}
+
 interface EceCertificateTypeProps {
   options: ExpandSelectOption[];
 }

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/input.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/input.d.ts
@@ -61,6 +61,13 @@ interface RadioWithAdditionalOption {
   [key: string]: any;
 }
 
+interface RadioWithAdditionalOptionProps {
+  rules?: readonly ValidationRule$1[];
+  maxlength?: string | number;
+  counter?: string | number | true;
+  autoGrow?: boolean;
+}
+
 interface EceCertificateTypeProps {
   options: ExpandSelectOption[];
 }


### PR DESCRIPTION
## Creating a common component for input fields that require a radio and additional info based on a value. 

## Description

- Small fix to common checkbox group component for the default rule
- Created a common component to render radio options and then trigger additional info required if user selects certain options. 
- When user changes their selection, an event will be emitted which will clean up data or emit data. 


## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
can be used like this in a component
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/348407d0-a8eb-4186-9de4-8f40de8bf7a4)

objects emitted when options are changed 
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/b3f44b22-3d1b-40dd-adeb-b32bbaf5b093)
when cleanup is required. 
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/9ce8d5df-2b2a-4987-86c0-2431ed919f23)

error states
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/311500ab-d552-43a4-bb50-0e1e748c5f8f)
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/ebac2d3f-7225-4f9f-9eb5-a693c7a6c0df)