### PR TITLE
fixing education input error and changing variables to a single constant

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/WizardHeader.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/WizardHeader.vue
@@ -10,7 +10,14 @@
     <v-row justify="space-between" class="pb-6">
       <v-col offset-md="1" cols="12" sm="8">
         <h3>{{ `Application for ECE ${certificationType} Certification` }}</h3>
-        <div v-if="certificationType === 'Five Year'" role="doc-subtitle">{{ certificationTypeSubtitleForFiveYear }}</div>
+        <div
+          v-if="
+            wizardStore.wizardData[wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes(CertificationType.FIVE_YEAR)
+          "
+          role="doc-subtitle"
+        >
+          {{ certificationTypeSubtitleForFiveYear }}
+        </div>
       </v-col>
       <v-col v-if="false" cols="auto" offset="1">
         <v-btn class="mr-2" rounded="lg" variant="outlined" color="primary">Cancel Application</v-btn>
@@ -23,6 +30,7 @@
 import { defineComponent } from "vue";
 
 import { useWizardStore } from "@/store/wizard";
+import { CertificationType } from "@/utils/constant";
 
 export default defineComponent({
   name: "WizardHeader",
@@ -31,6 +39,7 @@ export default defineComponent({
 
     return {
       wizardStore,
+      CertificationType,
     };
   },
   data: () => ({
@@ -51,12 +60,22 @@ export default defineComponent({
   computed: {
     certificationType() {
       let certificationType = "";
-      if (this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes("EceAssistant")) {
+      if (
+        this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes(
+          CertificationType.ECE_ASSISTANT,
+        )
+      ) {
         certificationType = "Assistant";
-      } else if (this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes("OneYear")) {
+      } else if (
+        this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes(
+          CertificationType.ONE_YEAR,
+        )
+      ) {
         certificationType = "One Year";
       } else if (
-        this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes("FiveYears")
+        this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes(
+          CertificationType.FIVE_YEAR,
+        )
       ) {
         certificationType = "Five Year";
       }
@@ -65,13 +84,19 @@ export default defineComponent({
     certificationTypeSubtitleForFiveYear() {
       let certificationTypeSubtitle = "";
       if (
-        this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes("Ite") &&
-        this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes("Sne")
+        this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes(
+          CertificationType.ITE,
+        ) &&
+        this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes(CertificationType.SNE)
       ) {
         certificationTypeSubtitle = "Including certification for Special Needs Education (SNE) and Infant and Toddler Educator (ITE)";
-      } else if (this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes("Sne")) {
+      } else if (
+        this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes(CertificationType.SNE)
+      ) {
         certificationTypeSubtitle = "Including certification for Special Needs Educator (SNE)";
-      } else if (this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes("Ite")) {
+      } else if (
+        this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes(CertificationType.ITE)
+      ) {
         certificationTypeSubtitle = "Including certification for Infant and Toddler Eductor (ITE)";
       }
 

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCertificationType.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCertificationType.vue
@@ -8,20 +8,20 @@
               <v-radio color="primary" :label="option.title" :value="option.id"></v-radio>
             </v-radio-group>
           </v-col>
-          <v-col v-if="option.id === 'FiveYears' && selection !== 'FiveYears'" cols="11" offset="1">
+          <v-col v-if="option.id === CertificationType.FIVE_YEAR && selection !== CertificationType.FIVE_YEAR" cols="11" offset="1">
             <p class="small">If you are eligible for an ECE Five Year Certificate, you may also be eligible for one or both specializations:</p>
             <v-checkbox
               v-model="certificationTypeStore.subSelection"
               color="primary"
               label="Infant and Toddler Educator (ITE)"
-              value="Ite"
+              :value="CertificationType.ITE"
               hide-details="auto"
             ></v-checkbox>
             <v-checkbox
               v-model="certificationTypeStore.subSelection"
               color="primary"
               label="Special Needs Educator (SNE)"
-              value="Sne"
+              :value="CertificationType.SNE"
               hide-details="auto"
             ></v-checkbox>
           </v-col>
@@ -35,19 +35,19 @@
   </v-expansion-panels>
   <div v-if="certificationTypeStore.mode == 'terms'">
     <div v-for="certificationType in certificationTypes" :key="certificationType">
-      <template v-if="certificationType === 'EceAssistant'">
+      <template v-if="certificationType === CertificationType.ECE_ASSISTANT">
         <ECEAssistantRequirements />
       </template>
-      <template v-if="certificationType === 'OneYear'">
+      <template v-if="certificationType === CertificationType.ONE_YEAR">
         <ECEOneYearRequirements />
       </template>
-      <template v-if="certificationType === 'FiveYears'">
+      <template v-if="certificationType === CertificationType.FIVE_YEAR">
         <ECEFiveYearRequirements />
       </template>
-      <template v-if="certificationType === 'Sne'">
+      <template v-if="certificationType === CertificationType.SNE">
         <SneRequirements />
       </template>
-      <template v-if="certificationType === 'Ite'">
+      <template v-if="certificationType === CertificationType.ITE">
         <IteRequirements />
       </template>
     </div>
@@ -66,6 +66,7 @@ import SneRequirements from "@/components/SneRequirements.vue";
 import { useCertificationTypeStore } from "@/store/certificationType";
 import type { EceCertificateTypeProps } from "@/types/input";
 import type { Components } from "@/types/openapi";
+import { CertificationType } from "@/utils/constant";
 
 export default defineComponent({
   name: "EceCertificationType",
@@ -89,23 +90,23 @@ export default defineComponent({
   setup: (props) => {
     const certificationTypeStore = useCertificationTypeStore();
     // If props.modelValue contains "Ite" or "Sne", set the subSelection to those values
-    if (props.modelValue.includes("Ite")) {
-      certificationTypeStore.subSelection.push("Ite");
+    if (props.modelValue.includes(CertificationType.ITE)) {
+      certificationTypeStore.subSelection.push(CertificationType.ITE);
     }
-    if (props.modelValue.includes("Sne")) {
-      certificationTypeStore.subSelection.push("Sne");
+    if (props.modelValue.includes(CertificationType.SNE)) {
+      certificationTypeStore.subSelection.push(CertificationType.SNE);
     }
 
     // Set selection to value in props.modelValue
-    if (props.modelValue.includes("FiveYears")) {
-      certificationTypeStore.selection = "FiveYears";
-    } else if (props.modelValue.includes("EceAssistant")) {
-      certificationTypeStore.selection = "EceAssistant";
-    } else if (props.modelValue.includes("OneYear")) {
-      certificationTypeStore.selection = "OneYear";
+    if (props.modelValue.includes(CertificationType.FIVE_YEAR)) {
+      certificationTypeStore.selection = CertificationType.FIVE_YEAR;
+    } else if (props.modelValue.includes(CertificationType.ECE_ASSISTANT)) {
+      certificationTypeStore.selection = CertificationType.ECE_ASSISTANT;
+    } else if (props.modelValue.includes(CertificationType.ONE_YEAR)) {
+      certificationTypeStore.selection = CertificationType.ONE_YEAR;
     }
 
-    return { certificationTypeStore };
+    return { certificationTypeStore, CertificationType };
   },
   computed: {
     selection: {
@@ -113,7 +114,7 @@ export default defineComponent({
         return this.certificationTypeStore.selection;
       },
       set(newValue: Components.Schemas.CertificationType) {
-        if (newValue !== "FiveYears") {
+        if (newValue !== CertificationType.FIVE_YEAR) {
           this.certificationTypeStore.subSelection = [];
         }
         this.certificationTypeStore.selection = newValue;

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCertificationTypePreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCertificationTypePreview.vue
@@ -19,6 +19,7 @@ import { defineComponent } from "vue";
 import PreviewCard from "@/components/PreviewCard.vue";
 import { useWizardStore } from "@/store/wizard";
 import type { EcePreviewProps } from "@/types/input";
+import { CertificationType } from "@/utils/constant";
 export default defineComponent({
   name: "EceCertificationTypePreview",
   components: {
@@ -39,19 +40,37 @@ export default defineComponent({
   computed: {
     certificationType() {
       let certificationType = "";
-      if (this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes("EceAssistant")) {
+      if (
+        this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes(
+          CertificationType.ECE_ASSISTANT,
+        )
+      ) {
         certificationType = "ECE Assistant";
-      } else if (this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes("OneYear")) {
+      } else if (
+        this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes(
+          CertificationType.ONE_YEAR,
+        )
+      ) {
         certificationType = "One Year";
       } else if (
-        this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes("FiveYears")
+        this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes(
+          CertificationType.FIVE_YEAR,
+        )
       ) {
         certificationType = "Five Year";
 
-        if (this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes("Sne")) {
+        if (
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes(
+            CertificationType.SNE,
+          )
+        ) {
           certificationType += " and Special Needs Educator (SNE)";
         }
-        if (this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes("Ite")) {
+        if (
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].includes(
+            CertificationType.ITE,
+          )
+        ) {
           certificationType += " and Infant and Toddler Educator (ITE)";
         }
       }

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
@@ -111,6 +111,7 @@ import { useAlertStore } from "@/store/alert";
 import { useWizardStore } from "@/store/wizard";
 import type { EceEducationProps } from "@/types/input";
 import type { Components } from "@/types/openapi";
+import { CertificationType } from "@/utils/constant";
 import { formatDate } from "@/utils/format";
 import * as Rules from "@/utils/formRules";
 export default defineComponent({
@@ -165,7 +166,7 @@ export default defineComponent({
       return this.officialTranscriptRequested == true || this.officialTranscriptReceived == true;
     },
     getLabelOnCertificateType() {
-      if (this.wizardStore.wizardData.certificationSelection.includes("FiveYears")) {
+      if (this.wizardStore.wizardData.certificationSelection.includes(CertificationType.FIVE_YEAR)) {
         return "Program";
       } else {
         return "Course";

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducationPreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducationPreview.vue
@@ -76,6 +76,7 @@ import PreviewCard from "@/components/PreviewCard.vue";
 import { useWizardStore } from "@/store/wizard";
 import type { EcePreviewProps } from "@/types/input";
 import type { Components } from "@/types/openapi";
+import { CertificationType } from "@/utils/constant";
 import { formatDate } from "@/utils/format";
 
 export default defineComponent({
@@ -100,7 +101,7 @@ export default defineComponent({
       return this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.education.form.inputs.educationList.id];
     },
     getLabelOnCertificateType() {
-      if (this.wizardStore.wizardData.certificationSelection.includes("FiveYears")) {
+      if (this.wizardStore.wizardData.certificationSelection.includes(CertificationType.FIVE_YEAR)) {
         return "Program";
       } else {
         return "Course";

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceCharacterReferenceDeclaration.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceCharacterReferenceDeclaration.vue
@@ -62,6 +62,7 @@
 import { defineComponent } from "vue";
 
 import { useWizardStore } from "@/store/wizard";
+import { CertificationType } from "@/utils/constant";
 import * as Rules from "@/utils/formRules";
 
 export default defineComponent({
@@ -83,11 +84,11 @@ export default defineComponent({
   computed: {
     certificationType() {
       let certificationType = "Certificate type not found";
-      if (this.wizardStore.wizardData.certificationTypes?.includes("EceAssistant")) {
+      if (this.wizardStore.wizardData.certificationTypes?.includes(CertificationType.ECE_ASSISTANT)) {
         certificationType = "ECE Assistant certificate";
-      } else if (this.wizardStore.wizardData.certificationTypes?.includes("OneYear")) {
+      } else if (this.wizardStore.wizardData.certificationTypes?.includes(CertificationType.ONE_YEAR)) {
         certificationType = "ECE One Year certificate";
-      } else if (this.wizardStore.wizardData.certificationTypes?.includes("FiveYears")) {
+      } else if (this.wizardStore.wizardData.certificationTypes?.includes(CertificationType.FIVE_YEAR)) {
         certificationType = "ECE Five Year certificate";
       }
       return certificationType;

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/wizard.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/wizard.ts
@@ -3,6 +3,7 @@ import { defineStore } from "pinia";
 import type { Components } from "@/types/openapi";
 import type { ReferenceStage, Step, Wizard } from "@/types/wizard";
 import { AddressType } from "@/utils/constant";
+import { CertificationType } from "@/utils/constant";
 
 import { useOidcStore } from "./oidc";
 import { useUserStore } from "./user";
@@ -64,13 +65,19 @@ export const useWizardStore = defineStore("wizard", {
         );
       });
 
+      let numOfEducationRequired = 1;
+      state.wizardData[this.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id]?.includes(CertificationType.SNE) &&
+        numOfEducationRequired++;
+      state.wizardData[this.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id]?.includes(CertificationType.ITE) &&
+        numOfEducationRequired++;
+
       return {
         CertificationType: (state.wizardData[this.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].length || []) > 0,
         Declaration:
           state.wizardData[this.wizardConfig.steps.declaration.form.inputs.signedDate.id] !== null &&
           state.wizardData[this.wizardConfig.steps.declaration.form.inputs.consentCheckbox.id] === true,
         ContactInformation: true,
-        Education: Object.values(state.wizardData[this.wizardConfig.steps.education.form.inputs.educationList.id]).length > 0,
+        Education: Object.values(state.wizardData[this.wizardConfig.steps.education.form.inputs.educationList.id]).length > numOfEducationRequired,
         CharacterReferences: (state.wizardData[this.wizardConfig.steps.characterReferences.form.inputs.characterReferences.id].length || []) > 0,
         WorkReferences:
           Object.values(state.wizardData[this.wizardConfig.steps.workReference.form.inputs.referenceList.id]).length > 0 &&

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/constant.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/constant.ts
@@ -34,6 +34,14 @@ export enum ProvinceTerritoryType {
   OTHER = "Other",
 }
 
+export enum CertificationType {
+  ITE = "Ite",
+  SNE = "Sne",
+  FIVE_YEAR = "FiveYears",
+  ONE_YEAR = "OneYear",
+  ECE_ASSISTANT = "EceAssistant",
+}
+
 export const referenceRelationshipDropdown: DropdownWrapper<Components.Schemas.ReferenceRelationship>[] = [
   { title: "Supervisor", value: "Supervisor" },
   { title: "Co Worker", value: "CoWorker" },


### PR DESCRIPTION


## Title
ECER-{1914}: Bug fix where user was able to submit application without meeting the required number of educations. 

## Description

- Changed references to CertificationTypes to a constant enum. 
- Made it so SNE and ITE required an additional education transcript to be submitted. This matches the backend validation logic. 

ex. One Year = 1 education required 
Five Year + SNE = 2 
Five Year + ITE = 2 
Five Year + ITE + SNE = 3

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/c4bc259f-ff2f-4e0e-ba19-edb3c8f3de45)


