### PR TITLE
ECER-1214: F.E: Work Experience Reference can preview their responses before submitting.

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/Reference.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/Reference.vue
@@ -39,7 +39,7 @@
               color="primary"
               @click="handleSubmit"
             >
-              Submit
+              Submit Reference
             </v-btn>
             <v-btn v-else rounded="lg" variant="flat" color="primary" @click="handleContinue">Continue</v-btn>
           </v-col>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceCharacterReferenceEvaluation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceCharacterReferenceEvaluation.vue
@@ -26,6 +26,7 @@
             label="Specify your relationship with applicant"
             variant="outlined"
             color="primary"
+            maxlength="100"
             :rules="[Rules.required('Enter your relationship with the applicant')]"
             hide-details="auto"
             @update:model-value="updateField('referenceRelationshipOther', $event)"

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceCharacterReferenceEvaluationPreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceCharacterReferenceEvaluationPreview.vue
@@ -5,7 +5,7 @@
         <v-col cols="4">
           <p class="small">What is your relationship with the applicant?</p>
         </v-col>
-        <v-col>
+        <v-col cols="8">
           <p class="small font-weight-bold">{{ evaluation.referenceRelationship }}</p>
         </v-col>
       </v-row>
@@ -13,7 +13,7 @@
         <v-col cols="4">
           <p class="small">Specify your relationship with the applicant</p>
         </v-col>
-        <v-col>
+        <v-col cols="8">
           <p class="small font-weight-bold">{{ evaluation.referenceRelationshipOther }}</p>
         </v-col>
       </v-row>
@@ -21,7 +21,7 @@
         <v-col cols="4">
           <p class="small">How long have you known the applicant?</p>
         </v-col>
-        <v-col>
+        <v-col cols="8">
           <p class="small font-weight-bold">{{ evaluation.lengthOfAcquaintance }}</p>
         </v-col>
       </v-row>
@@ -29,7 +29,7 @@
         <v-col cols="4">
           <p class="small">Have you observed the applicant working with young children?</p>
         </v-col>
-        <v-col>
+        <v-col cols="8">
           <p class="small font-weight-bold">{{ evaluation.workedWithChildren ? "Yes" : "No" }}</p>
         </v-col>
       </v-row>
@@ -43,7 +43,7 @@
             }}
           </p>
         </v-col>
-        <v-col>
+        <v-col cols="8">
           <p class="small font-weight-bold">{{ evaluation.childInteractionObservations }}</p>
         </v-col>
       </v-row>
@@ -51,7 +51,7 @@
         <v-col cols="4">
           <p class="small">Explain why you consider the applicant to have the temperament and ability to manage or work with young children.</p>
         </v-col>
-        <v-col>
+        <v-col cols="8">
           <p class="small font-weight-bold">{{ evaluation.applicantTemperamentAssessment }}</p>
         </v-col>
       </v-row>
@@ -62,7 +62,7 @@
             Do you believe/think the applicant should be granted authorization to be an ECE or ECE Assistant
           </p>
         </v-col>
-        <v-col>
+        <v-col cols="8">
           <p class="small font-weight-bold">{{ evaluation.applicantShouldNotBeECE ? "No" : "Yes" }}</p>
         </v-col>
       </v-row>
@@ -70,7 +70,7 @@
         <v-col cols="4">
           <p class="small">Why do you think the applicant should NOT be granted authorization to be an ECE or ECE Assistant</p>
         </v-col>
-        <v-col>
+        <v-col cols="8">
           <p class="small font-weight-bold">{{ evaluation.applicantNotQualifiedReason }}</p>
         </v-col>
       </v-row>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceReferenceContactPreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceReferenceContactPreview.vue
@@ -33,6 +33,14 @@
           <p class="small font-weight-bold">{{ reference.phoneNumber }}</p>
         </v-col>
       </v-row>
+      <v-row v-if="reference.certificateProvinceId">
+        <v-col cols="4">
+          <p class="small">Province/Territory Certified/Registered In</p>
+        </v-col>
+        <v-col>
+          <p class="small font-weight-bold">{{ reference.certificateProvinceId }}</p>
+        </v-col>
+      </v-row>
       <v-row v-if="reference.certificateNumber">
         <v-col cols="4">
           <p class="small">ECE Certification/Registration Number</p>
@@ -41,12 +49,12 @@
           <p class="small font-weight-bold">{{ reference.certificateNumber }}</p>
         </v-col>
       </v-row>
-      <v-row v-if="reference.certificateProvinceId">
+      <v-row v-if="reference.dateOfBirth">
         <v-col cols="4">
-          <p class="small">Province/Territory Certified/Registered In</p>
+          <p class="small">Your date of birth</p>
         </v-col>
         <v-col>
-          <p class="small font-weight-bold">{{ reference.certificateProvinceId }}</p>
+          <p class="small font-weight-bold">{{ formatDate(reference.dateOfBirth, "LLLL dd, yyyy") }}</p>
         </v-col>
       </v-row>
     </template>
@@ -61,6 +69,7 @@ import { useConfigStore } from "@/store/config";
 import { useWizardStore } from "@/store/wizard";
 import type { EcePreviewProps } from "@/types/input";
 import type { Components } from "@/types/openapi";
+import { formatDate } from "@/utils/format";
 
 export default defineComponent({
   name: "EceReferenceContactPreview",
@@ -98,8 +107,13 @@ export default defineComponent({
             ?.certificateProvinceOther,
         certificateNumber:
           this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.contactInformation.form.inputs.referenceContactInformation.id]?.certificateNumber,
+        dateOfBirth:
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.contactInformation.form.inputs.referenceContactInformation.id]?.dateOfBirth,
       };
     },
+  },
+  methods: {
+    formatDate,
   },
 });
 </script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceWorkExperienceReferenceAssessmentPreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceWorkExperienceReferenceAssessmentPreview.vue
@@ -1,0 +1,207 @@
+<template>
+  <ReferencePreviewCard
+    :is-valid="true"
+    title="Competencies assessment"
+    subtitle="How competent you think the applicant is in following areas."
+    reference-stage="Assessment"
+  >
+    <template #content>
+      <v-row>
+        <v-col cols="4">
+          <p class="small">Child development</p>
+        </v-col>
+        <v-col cols="8">
+          <p class="small font-weight-bold">{{ assessment.childDevelopment }}</p>
+          <p v-if="assessment.childDevelopmentReason" class="small">{{ assessment.childDevelopmentReason }}</p>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="4">
+          <p class="small">Child guidance</p>
+        </v-col>
+        <v-col cols="8">
+          <p class="small font-weight-bold">{{ assessment.childGuidance }}</p>
+          <p v-if="assessment.childGuidanceReason" class="small">{{ assessment.childGuidanceReason }}</p>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="4">
+          <p class="small">Health, safety and nutiriton</p>
+        </v-col>
+        <v-col cols="8">
+          <p class="small font-weight-bold">{{ assessment.healthSafetyAndNutrition }}</p>
+          <p v-if="assessment.healthSafetyAndNutritionReason" class="small">{{ assessment.healthSafetyAndNutritionReason }}</p>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="4">
+          <p class="small">Developing an early childhood education curriculum</p>
+        </v-col>
+        <v-col cols="8">
+          <p class="small font-weight-bold">{{ assessment.developAnEceCurriculum }}</p>
+          <p v-if="assessment.developAnEceCurriculumReason" class="small">{{ assessment.developAnEceCurriculumReason }}</p>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="4">
+          <p class="small">Implementing an early childhood education curriculum</p>
+        </v-col>
+        <v-col cols="8">
+          <p class="small font-weight-bold">{{ assessment.implementAnEceCurriculum }}</p>
+          <p v-if="assessment.implementAnEceCurriculumReason" class="small">{{ assessment.implementAnEceCurriculumReason }}</p>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="4">
+          <p class="small">Fostering positive relationships with children under their care</p>
+        </v-col>
+        <v-col cols="8">
+          <p class="small font-weight-bold">{{ assessment.fosteringPositiveRelationChild }}</p>
+          <p v-if="assessment.fosteringPositiveRelationChildReason" class="small">{{ assessment.fosteringPositiveRelationChildReason }}</p>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="4">
+          <p class="small">Fostering positive relationships with the families of children</p>
+        </v-col>
+        <v-col cols="8">
+          <p class="small font-weight-bold">{{ assessment.fosteringPositiveRelationFamily }}</p>
+          <p v-if="assessment.fosteringPositiveRelationFamilyReason" class="small">{{ assessment.fosteringPositiveRelationFamilyReason }}</p>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="4">
+          <p class="small">Fostering positive relationships with co-workers</p>
+        </v-col>
+        <v-col cols="8">
+          <p class="small font-weight-bold">{{ assessment.fosteringPositiveRelationCoworker }}</p>
+          <p v-if="assessment.fosteringPositiveRelationCoworkerReason" class="small">
+            {{ assessment.fosteringPositiveRelationCoworkerReason }}
+          </p>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="4">
+          <p class="small">You believe the applicant has the personality, ability and temperament necessary to work with children</p>
+        </v-col>
+        <v-col cols="8">
+          <p class="small font-weight-bold">{{ assessment.isApplicantQualified ? "Yes" : "No" }}</p>
+          <p v-if="!assessment.isApplicantQualified" class="small">{{ assessment.applicantNotQualifiedReason }}</p>
+        </v-col>
+      </v-row>
+    </template>
+  </ReferencePreviewCard>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+import ReferencePreviewCard from "@/components/reference/inputs/ReferencePreviewCard.vue";
+import { useWizardStore } from "@/store/wizard";
+import type { EcePreviewProps } from "@/types/input";
+import type { Components } from "@/types/openapi";
+import { likertScaleRadio } from "@/utils/constant";
+
+export default defineComponent({
+  name: "EceWorkExperienceReferenceAssessmentPreview",
+  components: {
+    ReferencePreviewCard,
+  },
+  props: {
+    props: {
+      type: Object as () => EcePreviewProps,
+      required: true,
+    },
+  },
+  setup: () => {
+    const wizardStore = useWizardStore();
+    return {
+      wizardStore,
+    };
+  },
+  computed: {
+    assessment(): Components.Schemas.WorkExperienceReferenceCompetenciesAssessment {
+      const childDevelopmentDisplay = likertScaleRadio.find(
+        (value) =>
+          value.value === this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.assessment.form.inputs.workExperienceAssessment.id]?.childDevelopment,
+      )?.label;
+
+      const childGuidanceDisplay = likertScaleRadio.find(
+        (value) =>
+          value.value === this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.assessment.form.inputs.workExperienceAssessment.id]?.childGuidance,
+      )?.label;
+
+      const healthSafetyAndNutritionDisplay = likertScaleRadio.find(
+        (value) =>
+          value.value ===
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.assessment.form.inputs.workExperienceAssessment.id]?.healthSafetyAndNutrition,
+      )?.label;
+
+      const developAnEceCurriculumDisplay = likertScaleRadio.find(
+        (value) =>
+          value.value ===
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.assessment.form.inputs.workExperienceAssessment.id]?.developAnEceCurriculum,
+      )?.label;
+
+      const implementAnEceCurriculumDisplay = likertScaleRadio.find(
+        (value) =>
+          value.value ===
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.assessment.form.inputs.workExperienceAssessment.id]?.implementAnEceCurriculum,
+      )?.label;
+
+      const fosteringPositiveRelationChildDisplay = likertScaleRadio.find(
+        (value) =>
+          value.value ===
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.assessment.form.inputs.workExperienceAssessment.id]?.fosteringPositiveRelationChild,
+      )?.label;
+
+      const fosteringPositiveRelationFamilyDisplay = likertScaleRadio.find(
+        (value) =>
+          value.value ===
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.assessment.form.inputs.workExperienceAssessment.id]?.fosteringPositiveRelationFamily,
+      )?.label;
+
+      const fosteringPositiveRelationCoworkerDisplay = likertScaleRadio.find(
+        (value) =>
+          value.value ===
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.assessment.form.inputs.workExperienceAssessment.id]
+            ?.fosteringPositiveRelationCoworker,
+      )?.label;
+
+      return {
+        childDevelopment: childDevelopmentDisplay as Components.Schemas.LikertScale,
+        childGuidance: childGuidanceDisplay as Components.Schemas.LikertScale,
+        healthSafetyAndNutrition: healthSafetyAndNutritionDisplay as Components.Schemas.LikertScale,
+        developAnEceCurriculum: developAnEceCurriculumDisplay as Components.Schemas.LikertScale,
+        implementAnEceCurriculum: implementAnEceCurriculumDisplay as Components.Schemas.LikertScale,
+        fosteringPositiveRelationChild: fosteringPositiveRelationChildDisplay as Components.Schemas.LikertScale,
+        fosteringPositiveRelationFamily: fosteringPositiveRelationFamilyDisplay as Components.Schemas.LikertScale,
+        fosteringPositiveRelationCoworker: fosteringPositiveRelationCoworkerDisplay as Components.Schemas.LikertScale,
+        isApplicantQualified:
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.assessment.form.inputs.workExperienceAssessment.id]?.isApplicantQualified,
+        childDevelopmentReason:
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.assessment.form.inputs.workExperienceAssessment.id]?.childDevelopmentReason,
+        childGuidanceReason:
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.assessment.form.inputs.workExperienceAssessment.id]?.childGuidanceReason,
+        healthSafetyAndNutritionReason:
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.assessment.form.inputs.workExperienceAssessment.id]?.healthSafetyAndNutritionReason,
+        developAnEceCurriculumReason:
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.assessment.form.inputs.workExperienceAssessment.id]?.developAnEceCurriculumReason,
+        implementAnEceCurriculumReason:
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.assessment.form.inputs.workExperienceAssessment.id]?.implementAnEceCurriculumReason,
+        fosteringPositiveRelationChildReason:
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.assessment.form.inputs.workExperienceAssessment.id]
+            ?.fosteringPositiveRelationChildReason,
+        fosteringPositiveRelationFamilyReason:
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.assessment.form.inputs.workExperienceAssessment.id]
+            ?.fosteringPositiveRelationFamilyReason,
+        fosteringPositiveRelationCoworkerReason:
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.assessment.form.inputs.workExperienceAssessment.id]
+            ?.fosteringPositiveRelationCoworkerReason,
+        applicantNotQualifiedReason:
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.assessment.form.inputs.workExperienceAssessment.id]?.applicantNotQualifiedReason,
+      };
+    },
+  },
+});
+</script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceWorkExperienceReferenceEvaluationPreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceWorkExperienceReferenceEvaluationPreview.vue
@@ -1,0 +1,148 @@
+<template>
+  <ReferencePreviewCard :is-valid="true" title="Work experience hours of applicant" reference-stage="ReferenceEvaluation">
+    <template #content>
+      <v-row>
+        <v-col cols="4">
+          <p class="small">Total hours you observed applicant</p>
+        </v-col>
+        <v-col cols="8">
+          <p class="small font-weight-bold">{{ evaluation.hours }}</p>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="4">
+          <p class="small">How often the applicant worked or volunteered</p>
+        </v-col>
+        <v-col cols="8">
+          <p class="small font-weight-bold">{{ evaluation.workHoursType }}</p>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="4">
+          <p class="small">Name of child care program</p>
+        </v-col>
+        <v-col cols="8">
+          <p class="small font-weight-bold">{{ evaluation.childrenProgramName }}</p>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="4">
+          <p class="small">Type of child care program</p>
+        </v-col>
+        <v-col cols="8">
+          <p class="small font-weight-bold">{{ evaluation.childrenProgramType }}</p>
+          <p v-if="evaluation.childrenProgramType === 'Other'" class="small">{{ evaluation.childrenProgramTypeOther }}</p>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="4">
+          <p class="small">Ages of children present</p>
+        </v-col>
+        <v-col cols="8">
+          <p class="small font-weight-bold">{{ evaluation.childcareAgeRanges ? evaluation.childcareAgeRanges.join(", ") : "" }}</p>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="4">
+          <p class="small">When applicant completed the hours</p>
+        </v-col>
+        <v-col cols="8">
+          <p class="small font-weight-bold">
+            {{ formatDate(evaluation.startDate!, "LLLL dd, yyyy") }} to {{ formatDate(evaluation.endDate!, "LLLL dd, yyyy") }}
+          </p>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="4">
+          <p class="small">Your relationship to applicant</p>
+        </v-col>
+        <v-col cols="8">
+          <p class="small font-weight-bold">{{ evaluation.referenceRelationship }}</p>
+          <p v-if="evaluation.referenceRelationship === 'Other'" class="small">{{ evaluation.referenceRelationshipOther }}</p>
+        </v-col>
+      </v-row>
+    </template>
+  </ReferencePreviewCard>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+import ReferencePreviewCard from "@/components/reference/inputs/ReferencePreviewCard.vue";
+import { useWizardStore } from "@/store/wizard";
+import type { EcePreviewProps } from "@/types/input";
+import type { Components } from "@/types/openapi";
+import { childcareAgeRangesCheckBox, childrenProgramTypeDropdown, workHoursTypeRadio, workReferenceRelationshipRadio } from "@/utils/constant";
+import { formatDate } from "@/utils/format";
+
+export default defineComponent({
+  name: "EceWorkExperienceReferenceEvaluationPreview",
+  components: {
+    ReferencePreviewCard,
+  },
+  props: {
+    props: {
+      type: Object as () => EcePreviewProps,
+      required: true,
+    },
+  },
+  setup: () => {
+    const wizardStore = useWizardStore();
+    return {
+      wizardStore,
+    };
+  },
+  computed: {
+    evaluation(): Components.Schemas.WorkExperienceReferenceDetails {
+      const workHoursTypeDisplay = workHoursTypeRadio.find(
+        (value) =>
+          value.value ===
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.workExperienceEvaluation.form.inputs.workExperienceEvaluation.id]?.workHoursType,
+      )?.label;
+      const childrenProgramTypeDisplay = childrenProgramTypeDropdown.find(
+        (value) =>
+          value.value ===
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.workExperienceEvaluation.form.inputs.workExperienceEvaluation.id]
+            ?.childrenProgramType,
+      )?.title;
+
+      const childcareAgeRangesDisplay = childcareAgeRangesCheckBox
+        .filter((value) =>
+          this.wizardStore.wizardData[
+            this.wizardStore.wizardConfig.steps.workExperienceEvaluation.form.inputs.workExperienceEvaluation.id
+          ]?.childcareAgeRanges.includes(value.value),
+        )
+        .map((value) => value.label);
+
+      const referenceRelationshipDisplay = workReferenceRelationshipRadio.find(
+        (value) =>
+          value.value ===
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.workExperienceEvaluation.form.inputs.workExperienceEvaluation.id]
+            ?.referenceRelationship,
+      )?.label;
+
+      return {
+        hours: this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.workExperienceEvaluation.form.inputs.workExperienceEvaluation.id]?.hours,
+        workHoursType: workHoursTypeDisplay as Components.Schemas.WorkHoursType,
+        childrenProgramName:
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.workExperienceEvaluation.form.inputs.workExperienceEvaluation.id]
+            ?.childrenProgramName,
+        childrenProgramType: childrenProgramTypeDisplay as Components.Schemas.ChildrenProgramType,
+        childrenProgramTypeOther:
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.workExperienceEvaluation.form.inputs.workExperienceEvaluation.id]
+            ?.childrenProgramTypeOther,
+        childcareAgeRanges: childcareAgeRangesDisplay as Components.Schemas.ChildcareAgeRanges[],
+        startDate: this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.workExperienceEvaluation.form.inputs.workExperienceEvaluation.id]?.startDate,
+        endDate: this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.workExperienceEvaluation.form.inputs.workExperienceEvaluation.id]?.endDate,
+        referenceRelationship: referenceRelationshipDisplay as Components.Schemas.ReferenceRelationship,
+        referenceRelationshipOther:
+          this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.workExperienceEvaluation.form.inputs.workExperienceEvaluation.id]
+            ?.referenceRelationshipOther,
+      };
+    },
+  },
+  methods: {
+    formatDate,
+  },
+});
+</script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/ReferencePreviewCard.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/ReferencePreviewCard.vue
@@ -12,6 +12,7 @@
       <v-row align="center">
         <v-col>
           <h3 :class="isValid ? 'text-black' : 'text-error'">{{ title }}</h3>
+          <div class="small text-black">{{ subtitle }}</div>
           <p v-if="!isValid" class="small text-error">
             <v-icon icon="mdi-alert-circle" color="error" class="mr-2"></v-icon>
             You must enter all required information in a valid format before submitting your application
@@ -41,6 +42,10 @@ export default defineComponent({
     title: {
       type: String,
       required: true,
+    },
+    subtitle: {
+      type: String,
+      default: "",
     },
     referenceStage: {
       type: String as PropType<ReferenceStage>,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/character-reference-wizard.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/character-reference-wizard.ts
@@ -28,7 +28,7 @@ const characterReferenceWizardConfig: Wizard = {
       key: "item.3",
     },
     review: {
-      title: "Review",
+      title: "Preview",
       stage: "Review",
       form: characterReferenceReviewForm,
       key: "item.4",

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/work-experience-reference-review-form.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/work-experience-reference-review-form.ts
@@ -1,14 +1,52 @@
-import EceTextField from "@/components/inputs/EceTextField.vue";
+import EceCheckbox from "@/components/inputs/EceCheckbox.vue";
+import EceReferenceContactPreview from "@/components/reference/inputs/EceReferenceContactPreview.vue";
+import EceWorkExperienceReferenceAssessmentPreview from "@/components/reference/inputs/EceWorkExperienceReferenceAssessmentPreview.vue";
+import EceWorkExperienceReferenceEvaluationPreview from "@/components/reference/inputs/EceWorkExperienceReferenceEvaluationPreview.vue";
 import type { Form } from "@/types/form";
+import { hasCheckbox } from "@/utils/formRules";
 
 const workExperienceReviewForm: Form = {
   id: "reviewForm",
   title: "Review form",
   inputs: {
-    review: {
-      id: "review",
-      component: EceTextField,
-      props: { label: "review form this does not work should be end for stepper" },
+    eceReferenceContactPreview: {
+      id: "eceReferenceContactPreview",
+      component: EceReferenceContactPreview,
+      props: {},
+      cols: {
+        md: 12,
+        lg: 12,
+        xl: 12,
+      },
+    },
+    eceWorkExperienceReferenceEvaluationPreview: {
+      id: "eceWorkExperienceReferenceEvaluationPreview",
+      component: EceWorkExperienceReferenceEvaluationPreview,
+      props: {},
+      cols: {
+        md: 12,
+        lg: 12,
+        xl: 12,
+      },
+    },
+    eceWorkExperienceReferenceAssessmentPreview: {
+      id: "eceWorkExperienceReferenceAssessmentPreview",
+      component: EceWorkExperienceReferenceAssessmentPreview,
+      props: {},
+      cols: {
+        md: 12,
+        lg: 12,
+        xl: 12,
+      },
+    },
+    confirmProvidedInformationIsRight: {
+      id: "confirmProvidedInformationIsRight",
+      component: EceCheckbox,
+      props: {
+        label:
+          "To the best of my knowledge the provided information is complete and correct. I am aware the ECE Registry may contact me to verify or clarify the provided information.",
+        rules: [hasCheckbox("You must agree with the above statement to submit your reference")],
+      },
       cols: {
         md: 12,
         lg: 12,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/work-experience-reference-wizard.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/work-experience-reference-wizard.ts
@@ -35,7 +35,7 @@ const workExperienceReferenceWizardConfig: Wizard = {
       key: "item.4",
     },
     review: {
-      title: "Review",
+      title: "Preview",
       stage: "Review",
       form: workExperienceReviewForm,
       key: "item.5",

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/format.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/format.d.ts
@@ -1,1 +1,1 @@
-type DateFormat = "yyyy-MMM-dd" | "yyyy-MM-ddZhh:mm:ss" | "yyyy-MM-dd" | "LLL dd, yyyy t" | "LLL dd, yyyy";
+type DateFormat = "yyyy-MMM-dd" | "yyyy-MM-ddZhh:mm:ss" | "yyyy-MM-dd" | "LLL dd, yyyy t" | "LLL dd, yyyy" | "LLLL dd, yyyy";


### PR DESCRIPTION
---
name: ECER-1214: F.E: Work Experience Reference can preview their responses before submitting.
about: F.E: Work Experience Reference can preview their responses before submitting.
---

## Title
ECER-1214: F.E: Work experience reference submission - Preview page

## Description

- F.E: Work Experience Reference can preview their responses before submitting.
- F.E: Work Experience Reference can preview their responses before submitting. - error handling
- Work Experience Reference must be able to check-off a declaration

## Related Jira Issue(s)

- ECER-1214
- ECER-1271

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)

![image](https://github.com/bcgov/ECC-ECER/assets/160776397/3d853108-a4e7-493f-b278-99d335223564)
![image](https://github.com/bcgov/ECC-ECER/assets/160776397/02177c67-ffb4-4dab-8289-1c935f986625)
![image](https://github.com/bcgov/ECC-ECER/assets/160776397/3d68c96f-b879-4912-9378-46f29d9e73c4)
![image](https://github.com/bcgov/ECC-ECER/assets/160776397/e823b473-0af3-4f63-9662-73c4cc8a2796)


