### PR TITLE
ECER-869 : Work reference must be able to complete work experience hours information

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/PortalInvitations/PortalInvitationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/PortalInvitations/PortalInvitationsEndpoints.cs
@@ -40,7 +40,7 @@ public record PortalInvitation(string? Id, string Name, string ReferenceFirstNam
   public string? WorkexperienceReferenceId { get; set; }
   public string? CharacterReferenceId { get; set; }
   public InviteType? InviteType { get; set; }
-  public int? WorkExperinceReferenceHours { get; set; }
+  public int? WorkExperienceReferenceHours { get; set; }
 }
 
 public enum InviteType

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/PortalInvitations/PortalInvitationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/PortalInvitations/PortalInvitationsEndpoints.cs
@@ -40,6 +40,7 @@ public record PortalInvitation(string? Id, string Name, string ReferenceFirstNam
   public string? WorkexperienceReferenceId { get; set; }
   public string? CharacterReferenceId { get; set; }
   public InviteType? InviteType { get; set; }
+  public int? WorkExperinceReferenceHours { get; set; }
 }
 
 public enum InviteType

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceWorkExperienceReferenceDeclaration.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceWorkExperienceReferenceDeclaration.vue
@@ -5,8 +5,9 @@
         <v-col>
           <p>
             {{ `${wizardStore.wizardData.applicantFirstName} ${wizardStore.wizardData.applicantLastName}` }}
-            is requesting a work experience reference for ECE 5 Year certification. We'll review your reference when assessing if the applicant is eligible for
-            certification
+            is requesting a work experience reference for
+            <b>{{ certificationType }}.</b>
+            We'll review your reference when assessing if the applicant is eligible for certification
           </p>
           <br />
 
@@ -39,7 +40,7 @@
           <h2>Requirements to be a reference</h2>
           <p>You need to:</p>
           <ul class="ml-10">
-            <li>Have directly supervised (observed) all hours during which the applicant worked or volunteer</li>
+            <li>Have directly supervised (observed) all hours during which the applicant worked or volunteered</li>
             <li>Have held a valid Canadian ECE certification/registration during the hours you supervised the applicant</li>
             <li>Be able to speak to the applicant's knowledge, skills, and ability (competencies) as an ECE</li>
           </ul>
@@ -62,6 +63,7 @@
 import { defineComponent } from "vue";
 
 import { useWizardStore } from "@/store/wizard";
+import { CertificationType } from "@/utils/constant";
 import * as Rules from "@/utils/formRules";
 
 export default defineComponent({
@@ -79,6 +81,19 @@ export default defineComponent({
       selection: undefined,
       Rules,
     };
+  },
+  computed: {
+    certificationType() {
+      let certificationType = "Certificate type not found";
+      if (this.wizardStore.wizardData.certificationTypes?.includes(CertificationType.ECE_ASSISTANT)) {
+        certificationType = "ECE Assistant certificate";
+      } else if (this.wizardStore.wizardData.certificationTypes?.includes(CertificationType.ONE_YEAR)) {
+        certificationType = "ECE One Year certificate";
+      } else if (this.wizardStore.wizardData.certificationTypes?.includes(CertificationType.FIVE_YEAR)) {
+        certificationType = "ECE Five Year certificate";
+      }
+      return certificationType;
+    },
   },
 });
 </script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceWorkExperienceReferenceEvaluation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceWorkExperienceReferenceEvaluation.vue
@@ -6,7 +6,7 @@
       <v-row class="mt-5">
         <v-col cols="12" md="8" lg="6" xl="4">
           Applicant indicated you observed them work:
-          <b>{{ `${wizardStore.wizardData.workExperinceReferenceHours}` }} hours</b>
+          <b>{{ `${wizardStore.wizardData.workExperienceReferenceHours}` }} hours</b>
         </v-col>
       </v-row>
       <v-row>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceWorkExperienceReferenceEvaluation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceWorkExperienceReferenceEvaluation.vue
@@ -6,7 +6,7 @@
       <v-row class="mt-5">
         <v-col cols="12" md="8" lg="6" xl="4">
           Applicant indicated you observed them work:
-          <b>50 hours</b>
+          <b>{{ `${wizardStore.wizardData.workExperinceReferenceHours}` }} hours</b>
         </v-col>
       </v-row>
       <v-row>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/wizard.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/wizard.ts
@@ -180,6 +180,8 @@ export const useWizardStore = defineStore("wizard", {
         applicantFirstName: portalInvitation.applicantFirstName,
         applicantLastName: portalInvitation.applicantLastName,
         inviteType: portalInvitation.inviteType,
+        certificationTypes: portalInvitation.certificationTypes,
+        workExperinceReferenceHours: portalInvitation.workExperinceReferenceHours,
         [wizard.steps.contactInformation.form.inputs.referenceContactInformation.id]: {} as Components.Schemas.ReferenceContactInformation,
         [wizard.steps.workExperienceEvaluation.form.inputs.workExperienceEvaluation.id]: {} as Components.Schemas.WorkExperienceReferenceDetails,
         [wizard.steps.assessment.form.inputs.workExperienceAssessment.id]: {} as Components.Schemas.WorkExperienceReferenceCompetenciesAssessment,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/wizard.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/wizard.ts
@@ -181,7 +181,7 @@ export const useWizardStore = defineStore("wizard", {
         applicantLastName: portalInvitation.applicantLastName,
         inviteType: portalInvitation.inviteType,
         certificationTypes: portalInvitation.certificationTypes,
-        workExperinceReferenceHours: portalInvitation.workExperinceReferenceHours,
+        workExperienceReferenceHours: portalInvitation.workExperienceReferenceHours,
         [wizard.steps.contactInformation.form.inputs.referenceContactInformation.id]: {} as Components.Schemas.ReferenceContactInformation,
         [wizard.steps.workExperienceEvaluation.form.inputs.workExperienceEvaluation.id]: {} as Components.Schemas.WorkExperienceReferenceDetails,
         [wizard.steps.assessment.form.inputs.workExperienceAssessment.id]: {} as Components.Schemas.WorkExperienceReferenceCompetenciesAssessment,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
@@ -184,7 +184,7 @@ declare namespace Components {
       workexperienceReferenceId?: string | null;
       characterReferenceId?: string | null;
       inviteType?: InviteType;
-      workExperinceReferenceHours?: number | null;
+      workExperienceReferenceHours?: number | null;
     }
     export interface PortalInvitationQueryResult {
       portalInvitation?: PortalInvitation;

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
@@ -184,6 +184,7 @@ declare namespace Components {
       workexperienceReferenceId?: string | null;
       characterReferenceId?: string | null;
       inviteType?: InviteType;
+      workExperinceReferenceHours?: number | null;
     }
     export interface PortalInvitationQueryResult {
       portalInvitation?: PortalInvitation;

--- a/src/ECER.Managers.Registry.Contract/PortalInvitations/Contract.cs
+++ b/src/ECER.Managers.Registry.Contract/PortalInvitations/Contract.cs
@@ -27,6 +27,7 @@ public record PortalInvitation(string? Id, string Name, string ReferenceFirstNam
   public string? CharacterReferenceId { get; set; }
   public InviteType? InviteType { get; set; }
   public PortalInvitationStatusCode? StatusCode { get; set; }
+  public int? WorkExperinceReferenceHours { get; set; }
 }
 
 public enum InviteType

--- a/src/ECER.Managers.Registry.Contract/PortalInvitations/Contract.cs
+++ b/src/ECER.Managers.Registry.Contract/PortalInvitations/Contract.cs
@@ -27,7 +27,7 @@ public record PortalInvitation(string? Id, string Name, string ReferenceFirstNam
   public string? CharacterReferenceId { get; set; }
   public InviteType? InviteType { get; set; }
   public PortalInvitationStatusCode? StatusCode { get; set; }
-  public int? WorkExperinceReferenceHours { get; set; }
+  public int? WorkExperienceReferenceHours { get; set; }
 }
 
 public enum InviteType

--- a/src/ECER.Managers.Registry/PortalInvitationHandlers.cs
+++ b/src/ECER.Managers.Registry/PortalInvitationHandlers.cs
@@ -38,7 +38,7 @@ public class PortalInvitationHandlers(IPortalInvitationTransformationEngine tran
         var workExRef = application.WorkExperienceReferences.SingleOrDefault(work => work.Id == portalInvitation.WorkexperienceReferenceId);
         if (workExRef != null)
         {
-          result.WorkExperinceReferenceHours = workExRef.Hours;
+          result.WorkExperienceReferenceHours = workExRef.Hours;
         }
       }
     }

--- a/src/ECER.Managers.Registry/PortalInvitationHandlers.cs
+++ b/src/ECER.Managers.Registry/PortalInvitationHandlers.cs
@@ -33,6 +33,11 @@ public class PortalInvitationHandlers(IPortalInvitationTransformationEngine tran
     if (application != null)
     {
       result.CertificationTypes = mapper.Map<Contract.Applications.Application>(application)!.CertificationTypes!;
+      var workExRef = application.WorkExperienceReferences.SingleOrDefault(work => work.Id == portalInvitation.WorkexperienceReferenceId);
+      if (workExRef != null)
+      {
+        result.WorkExperinceReferenceHours = workExRef.Hours;
+      }
     }
     return PortalInvitationVerificationQueryResult.Success(result);
   }

--- a/src/ECER.Managers.Registry/PortalInvitationHandlers.cs
+++ b/src/ECER.Managers.Registry/PortalInvitationHandlers.cs
@@ -33,10 +33,13 @@ public class PortalInvitationHandlers(IPortalInvitationTransformationEngine tran
     if (application != null)
     {
       result.CertificationTypes = mapper.Map<Contract.Applications.Application>(application)!.CertificationTypes!;
-      var workExRef = application.WorkExperienceReferences.SingleOrDefault(work => work.Id == portalInvitation.WorkexperienceReferenceId);
-      if (workExRef != null)
+      if (result.InviteType == Contract.PortalInvitations.InviteType.WorkExperienceReference)
       {
-        result.WorkExperinceReferenceHours = workExRef.Hours;
+        var workExRef = application.WorkExperienceReferences.SingleOrDefault(work => work.Id == portalInvitation.WorkexperienceReferenceId);
+        if (workExRef != null)
+        {
+          result.WorkExperinceReferenceHours = workExRef.Hours;
+        }
       }
     }
     return PortalInvitationVerificationQueryResult.Success(result);

--- a/src/ECER.Managers.Registry/PortalInvitationMapper.cs
+++ b/src/ECER.Managers.Registry/PortalInvitationMapper.cs
@@ -11,7 +11,7 @@ public class PortalInvitationMapper : Profile
          .ForMember(dest => dest.ApplicantFirstName, opt => opt.Ignore())
          .ForMember(dest => dest.ApplicantLastName, opt => opt.Ignore())
          .ForMember(dest => dest.CertificationTypes, opt => opt.Ignore())
-         .ForMember(dest => dest.WorkExperinceReferenceHours, opt => opt.Ignore());
+         .ForMember(dest => dest.WorkExperienceReferenceHours, opt => opt.Ignore());
 
   }
 }

--- a/src/ECER.Managers.Registry/PortalInvitationMapper.cs
+++ b/src/ECER.Managers.Registry/PortalInvitationMapper.cs
@@ -10,6 +10,8 @@ public class PortalInvitationMapper : Profile
     CreateMap<PortalInvitation, Contract.PortalInvitations.PortalInvitation>()
          .ForMember(dest => dest.ApplicantFirstName, opt => opt.Ignore())
          .ForMember(dest => dest.ApplicantLastName, opt => opt.Ignore())
-         .ForMember(dest => dest.CertificationTypes, opt => opt.Ignore());
+         .ForMember(dest => dest.CertificationTypes, opt => opt.Ignore())
+         .ForMember(dest => dest.WorkExperinceReferenceHours, opt => opt.Ignore());
+
   }
 }


### PR DESCRIPTION
---
name: ECER-869 : Work reference must be able to complete work experience hours information
about: Work reference must be able to complete work experience hours information
---

## Title
ECER-869: Work reference must be able to complete work experience hours information

## Description

- FE: bind value to BE - Applicant indicated you observed them work: %number entered by applicant% hours
- work experience reference -> Declaration page corrections


## Related Jira Issue(s)

- ECER-869
- ECER-2080

## Checklist
- [x] I have tested these changes locally.
- [x] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
![image](https://github.com/bcgov/ECC-ECER/assets/160776397/ad44b358-8faa-4bb5-81e3-f25ef0954522)
