### PR TITLE
fixing indentation issues in preview screens

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/PreviewCard.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/PreviewCard.vue
@@ -1,25 +1,27 @@
 <template>
   <v-card variant="outlined" :color="cardColor" rounded="lg">
-    <div class="float-right">
-      <v-tooltip v-model="show" location="top">
-        <template #activator="{ props }">
-          <v-btn icon="mdi-pencil" v-bind="props" :color="isValid ? 'primary' : 'error'" variant="plain" @click="setWizard(portalStage)" />
-        </template>
-        <span>Edit {{ title }}</span>
-      </v-tooltip>
-    </div>
-    <v-container>
-      <v-row align="center">
-        <v-col>
-          <h3 :class="isValid ? 'text-black' : 'text-error'">{{ title }}</h3>
-          <p v-if="!isValid" class="small text-error">
+    <v-card-title>
+      <div class="d-flex justify-space-between align-center">
+        <div>
+          <h3 class="text-wrap" :class="isValid ? 'text-black' : 'text-error'">{{ title }}</h3>
+          <p v-if="!isValid" class="small text-error text-wrap">
             <v-icon icon="mdi-alert-circle" color="error" class="mr-2"></v-icon>
             You must enter all required information in a valid format before submitting your application
           </p>
-        </v-col>
-      </v-row>
+        </div>
+        <div>
+          <v-tooltip v-model="show" location="top">
+            <template #activator="{ props }">
+              <v-btn icon="mdi-pencil" v-bind="props" :color="isValid ? 'primary' : 'error'" variant="plain" @click="setWizard(portalStage)" />
+            </template>
+            <span>Edit {{ title }}</span>
+          </v-tooltip>
+        </div>
+      </div>
+    </v-card-title>
+    <v-card-text>
       <slot name="content"></slot>
-    </v-container>
+    </v-card-text>
   </v-card>
 </template>
 

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducationPreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducationPreview.vue
@@ -5,7 +5,7 @@
         <v-divider v-if="index !== 0" :thickness="2" color="grey-lightest" class="border-opacity-100 my-6" />
         <v-row>
           <v-col>
-            <h4 class="text-black">{{ education.educationalInstitutionName }}</h4>
+            <h4>{{ education.educationalInstitutionName }}</h4>
           </v-col>
         </v-row>
         <v-row>


### PR DESCRIPTION
## Title
ECER-1933: Bugfix for indentation oddities in preview screen

## Description

- Made it so titles aren't indented forwards
- Also made it so the first line for work experience + education isn't indented. 
- Tested for mobile + error states

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Before (Note indented first line for transcripts/work experience reference
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/adb839d4-6ca7-4afd-870d-d058def5ed8e)
After
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/b08fe9dc-b969-4d3e-8612-b53b2adb38de)
Multiple Refrences
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/7b490018-a259-45a1-a5b7-49ce44968875)
Mobile
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/1c8adbca-a31f-4b92-83e1-ee2b0633fe78)
