### PR TITLE
ECER-2144 - BE: Adjustments to get application status endpoint Add ec…

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationMapper.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationMapper.cs
@@ -58,6 +58,8 @@ public class ApplicationMapper : Profile
       .ForMember(d => d.RegistrantId, opts => opts.Ignore())
       .ForMember(d => d.CreatedOn, opts => opts.Ignore())
       .ForMember(d => d.SubmittedOn, opts => opts.Ignore())
+      .ForMember(d => d.SubStatus, opts => opts.Ignore())
+      .ForMember(d => d.ReadyForAssessmentDate, opts => opts.Ignore())
       .ForMember(d => d.Transcripts, opts => opts.MapFrom(s => s.Transcripts))
       .ForMember(d => d.WorkExperienceReferences, opts => opts.MapFrom(s => s.WorkExperienceReferences))
       .ForCtorParam(nameof(Managers.Registry.Contract.Applications.Application.Id), opts => opts.MapFrom(s => s.Id))
@@ -78,6 +80,10 @@ public class ApplicationMapper : Profile
         opt => opt.MapFrom(s => s.SubmittedOn))
       .ForCtorParam(nameof(SubmittedApplicationStatus.Status),
         opt => opt.MapFrom(s => s.Status))
+      .ForCtorParam(nameof(SubmittedApplicationStatus.SubStatus),
+        opt => opt.MapFrom(s => s.SubStatus))
+      .ForCtorParam(nameof(SubmittedApplicationStatus.ReadyForAssessmentDate),
+        opt => opt.MapFrom(s => s.ReadyForAssessmentDate))
       .ForMember(d => d.TranscriptsStatus, opts => opts.MapFrom(s => s.Transcripts))
       .ForMember(d => d.WorkExperienceReferencesStatus, opts => opts.MapFrom(s => s.WorkExperienceReferences))
       .ForMember(d => d.CharacterReferencesStatus, opts => opts.MapFrom(s => s.CharacterReferences));

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
@@ -257,12 +257,31 @@ public enum ApplicationStatus
   ReconsiderationDecision
 }
 
+public enum ApplicationStatusReasonDetail
+{
+  Actioned,
+  BeingAssessed,
+  Certified,
+  Denied,
+  ForReview,
+  InvestigationsConsultationNeeded,
+  MoreInformationRequired,
+  OperationSupervisorManagerofCertificationsConsultationNeeded,
+  PendingDocuments,
+  ProgramAnalystReview,
+  ReadyforAssessment,
+  ReceivedPending,
+  ReceivePhysicalTranscripts,
+  SupervisorConsultationNeeded,
+  ValidatingIDs,
+}
+
 public record CharacterReference([Required] string? FirstName, [Required] string? LastName, string? PhoneNumber, [Required] string? EmailAddress)
 {
   public string? Id { get; set; }
 }
 
-public record SubmittedApplicationStatus(string Id, DateTime SubmittedOn, ApplicationStatus Status)
+public record SubmittedApplicationStatus(string Id, DateTime SubmittedOn, DateTime ReadyForAssessmentDate, ApplicationStatus Status, ApplicationStatusReasonDetail SubStatus)
 {
 
   public IEnumerable<TranscriptStatus> TranscriptsStatus { get; set; } = Array.Empty<TranscriptStatus>();

--- a/src/ECER.Managers.Registry.Contract/Applications/Contract.cs
+++ b/src/ECER.Managers.Registry.Contract/Applications/Contract.cs
@@ -56,6 +56,8 @@ public record Application(string? Id, string RegistrantId, ApplicationStatus Sta
   public IEnumerable<WorkExperienceReference> WorkExperienceReferences { get; set; } = Array.Empty<WorkExperienceReference>();
   public PortalStage Stage { get; set; }
   public IEnumerable<CharacterReference> CharacterReferences { get; set; } = Array.Empty<CharacterReference>();
+  public ApplicationStatusReasonDetail SubStatus { get; set; }
+  public DateTime? ReadyForAssessmentDate { get; set; }
 }
 
 public record Transcript(string? Id, string? EducationalInstitutionName, string? ProgramName, string? StudentName, string? StudentNumber, DateTime StartDate, DateTime EndDate, bool IsECEAssistant, bool DoesECERegistryHaveTranscript, bool IsOfficialTranscriptRequested)
@@ -126,6 +128,25 @@ public enum ApplicationStatus
   InProgress,
   PendingQueue,
   ReconsiderationDecision
+}
+
+public enum ApplicationStatusReasonDetail
+{
+  Actioned,
+  BeingAssessed,
+  Certified,
+  Denied,
+  ForReview,
+  InvestigationsConsultationNeeded,
+  MoreInformationRequired,
+  OperationSupervisorManagerofCertificationsConsultationNeeded,
+  PendingDocuments,
+  ProgramAnalystReview,
+  ReadyforAssessment,
+  ReceivedPending,
+  ReceivePhysicalTranscripts,
+  SupervisorConsultationNeeded,
+  ValidatingIDs,
 }
 
 public record CharacterReferenceSubmissionRequest(string Token, bool WillProvideReference, ReferenceContactInformation ReferenceContactInformation, CharacterReferenceEvaluation ReferenceEvaluation, bool ConfirmProvidedInformationIsRight);

--- a/src/ECER.Resources.Documents/Applications/ApplicationRepositoryMapper.cs
+++ b/src/ECER.Resources.Documents/Applications/ApplicationRepositoryMapper.cs
@@ -16,6 +16,8 @@ internal class ApplicationRepositoryMapper : Profile
        .ForSourceMember(s => s.Transcripts, opts => opts.DoNotValidate())
        .ForSourceMember(s => s.WorkExperienceReferences, opts => opts.DoNotValidate())
        .ForSourceMember(s => s.CharacterReferences, opts => opts.DoNotValidate())
+       .ForSourceMember(s => s.SubStatus, opts => opts.DoNotValidate())
+       .ForSourceMember(s => s.ReadyForAssessmentDate, opts => opts.DoNotValidate())
        .ForMember(d => d.ecer_ApplicationId, opts => opts.MapFrom(s => s.Id))
        .ForMember(d => d.StatusCode, opts => opts.MapFrom(s => s.Status))
        .ForMember(d => d.ecer_IsECEAssistant, opts => opts.MapFrom(s => s.CertificationTypes.Contains(CertificationType.EceAssistant)))
@@ -31,11 +33,13 @@ internal class ApplicationRepositoryMapper : Profile
        .ForCtorParam(nameof(Application.ApplicantId), opts => opts.MapFrom(s => s.ecer_Applicantid.Id.ToString()))
        .ForCtorParam(nameof(Application.CertificationTypes), opts => opts.MapFrom(s => s))
        .ForMember(d => d.Status, opts => opts.MapFrom(s => s.StatusCode))
+       .ForMember(d => d.SubStatus, opts => opts.MapFrom(s => s.ecer_StatusReasonDetail))
        .ForMember(d => d.SubmittedOn, opts => opts.MapFrom(s => s.ecer_DateSubmitted))
        .ForMember(d => d.SignedDate, opts => opts.MapFrom(s => s.ecer_DateSigned))
        .ForMember(d => d.Transcripts, opts => opts.MapFrom(s => s.ecer_transcript_Applicationid))
        .ForMember(d => d.WorkExperienceReferences, opts => opts.MapFrom(s => s.ecer_workexperienceref_Applicationid_ecer))
-       .ForMember(d => d.CharacterReferences, opts => opts.MapFrom(s => s.ecer_characterreference_Applicationid));
+       .ForMember(d => d.CharacterReferences, opts => opts.MapFrom(s => s.ecer_characterreference_Applicationid))
+       .ForMember(d => d.ReadyForAssessmentDate, opts => opts.MapFrom(s => s.ecer_ReadyforAssessmentDate));
 
     CreateMap<ecer_Application, IEnumerable<CertificationType>>()
         .ConstructUsing((s, _) =>
@@ -52,6 +56,10 @@ internal class ApplicationRepositoryMapper : Profile
     CreateMap<ApplicationStatus, ecer_Application_StatusCode>()
         .ConvertUsingEnumMapping(opts => opts.MapByName(true))
         .ReverseMap();
+
+    CreateMap<ApplicationStatusReasonDetail, ecer_ApplicationStatusReasonDetail>()
+    .ConvertUsingEnumMapping(opts => opts.MapByName(true))
+    .ReverseMap();
 
     CreateMap<Transcript, ecer_Transcript>(MemberList.Source)
            .ForSourceMember(s => s.StartDate, opts => opts.DoNotValidate())

--- a/src/ECER.Resources.Documents/Applications/IApplicationRepository.cs
+++ b/src/ECER.Resources.Documents/Applications/IApplicationRepository.cs
@@ -28,6 +28,7 @@ public record ApplicationQuery
 public record Application(string? Id, string ApplicantId, IEnumerable<CertificationType> CertificationTypes)
 {
   public ApplicationStatus Status { get; set; }
+  public ApplicationStatusReasonDetail SubStatus { get; set; }
   public DateTime CreatedOn { get; set; }
   public DateTime? SignedDate { get; set; }
   public DateTime? SubmittedOn { get; set; }
@@ -35,6 +36,7 @@ public record Application(string? Id, string ApplicantId, IEnumerable<Certificat
   public IEnumerable<Transcript> Transcripts { get; set; } = Array.Empty<Transcript>();
   public IEnumerable<WorkExperienceReference> WorkExperienceReferences { get; set; } = Array.Empty<WorkExperienceReference>();
   public IEnumerable<CharacterReference> CharacterReferences { get; set; } = Array.Empty<CharacterReference>();
+  public DateTime? ReadyForAssessmentDate { get; set; }
 }
 
 public record Transcript(string? Id, string? EducationalInstitutionName, string? ProgramName, string? StudentName, string? StudentNumber, DateTime StartDate, DateTime EndDate, bool IsECEAssistant, bool DoesECERegistryHaveTranscript, bool IsOfficialTranscriptRequested)
@@ -88,6 +90,25 @@ public enum ApplicationStatus
   PendingQueue,
   ReconsiderationDecision,
   AppealDecision
+}
+
+public enum ApplicationStatusReasonDetail
+{
+  Actioned,
+  BeingAssessed,
+  Certified,
+  Denied,
+  ForReview,
+  InvestigationsConsultationNeeded,
+  MoreInformationRequired,
+  OperationSupervisorManagerofCertificationsConsultationNeeded,
+  PendingDocuments,
+  ProgramAnalystReview,
+  ReadyforAssessment,
+  ReceivedPending,
+  ReceivePhysicalTranscripts,
+  SupervisorConsultationNeeded,
+  ValidatingIDs,
 }
 
 public record CharacterReference(string? FirstName, string? LastName, string? PhoneNumber, string? EmailAddress)


### PR DESCRIPTION
…er_StatusReasonDetail and Add ecer_ReadyforAssessmentDate

---
name: BE: Adjustments to get application status endpoint
about: BE: Adjustments to get application status endpoint - Expose 2 new props
---

## Title
ECER-2144: BE: Adjustments to get application status endpoint

## Description

- Add ecer_StatusReasonDetail 
- Add ecer_ReadyforAssessmentDate
- Mapped two props in all layers

## Related Jira Issue(s)

- ECER-2144
- ECER-2011

## Checklist
- [x] I have tested these changes locally.
- [x] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.
