### PR TITLE
ECER-1305: Handle invalid portal invitations

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Banner.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Banner.vue
@@ -1,0 +1,50 @@
+<template>
+  <v-card :rounded="'0'" flat :color="backgroundColour" :style="{ 'min-height': '200px' }" class="d-flex flex-column justify-center">
+    <v-container>
+      <div class="d-flex">
+        <svg xmlns="http://www.w3.org/2000/svg" width="75" height="75" viewBox="0 0 75 75" fill="none">
+          <path
+            d="M41.25 41.25H33.75V18.75H41.25M41.25 56.25H33.75V48.75H41.25M37.5 0C32.5754 0 27.6991 0.969966 23.1494 2.85452C18.5997 4.73907 14.4657 7.5013 10.9835 10.9835C3.95088 18.0161 0 27.5544 0 37.5C0 47.4456 3.95088 56.9839 10.9835 64.0165C14.4657 67.4987 18.5997 70.2609 23.1494 72.1455C27.6991 74.03 32.5754 75 37.5 75C47.4456 75 56.9839 71.0491 64.0165 64.0165C71.0491 56.9839 75 47.4456 75 37.5C75 32.5754 74.03 27.6991 72.1455 23.1494C70.2609 18.5997 67.4987 14.4657 64.0165 10.9835C60.5343 7.5013 56.4003 4.73907 51.8506 2.85452C47.3009 0.969966 42.4246 0 37.5 0Z"
+            fill="#CE3E39"
+          />
+        </svg>
+        <h2 class="align-self-center ml-6">{{ title }}</h2>
+      </div>
+    </v-container>
+  </v-card>
+</template>
+
+<script lang="ts">
+import type { PropType } from "vue";
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "Banner",
+  props: {
+    type: {
+      type: String as PropType<"error" | "warning" | "info" | "success">,
+      required: true,
+    },
+    title: {
+      type: String,
+      required: true,
+    },
+  },
+  computed: {
+    backgroundColour() {
+      switch (this.type) {
+        case "error":
+          return "alert-error";
+        case "warning":
+          return "alert-warning";
+        case "info":
+          return "alert-info";
+        case "success":
+          return "alert-success";
+        default:
+          return "alert-info";
+      }
+    },
+  },
+});
+</script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/Invalid.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/Invalid.vue
@@ -1,0 +1,14 @@
+<template>
+  <Banner type="error" title="Sorry, this link is no longer valid" />
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+import Banner from "@/components/Banner.vue";
+
+export default defineComponent({
+  name: "Invalid",
+  components: { Banner },
+});
+</script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/Reference.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/Reference.vue
@@ -59,7 +59,7 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
-import { useRoute } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 
 import { getReference, optOutReference, postCharacterReference, postWorkExperienceReference } from "@/api/reference";
 import characterReferenceWizardConfig from "@/config/character-reference-wizard";
@@ -77,7 +77,13 @@ export default defineComponent({
   components: { Wizard },
   async setup() {
     const route = useRoute();
-    const { data } = await getReference(route.params.token as string);
+    const router = useRouter();
+    const { data, error } = await getReference(route.params.token as string);
+
+    if (error) {
+      router.push("/invalid-reference");
+    }
+
     const wizardStore = useWizardStore();
     const loadingStore = useLoadingStore();
     const alertStore = useAlertStore();

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/router.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/router.ts
@@ -103,6 +103,11 @@ const router = createRouter({
       meta: { requiresAuth: false },
     },
     {
+      path: "/invalid-reference",
+      component: () => import("./components/reference/Invalid.vue"),
+      meta: { requiresAuth: false },
+    },
+    {
       path: "/reference-submitted",
       component: () => import("./components/pages/ReferenceSubmitted.vue"),
       meta: { requiresAuth: false },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/styles/ecer-theme.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/styles/ecer-theme.ts
@@ -14,6 +14,10 @@ const ecerTheme: ThemeDefinition = {
     error: "#D8292F",
     success: "#2E8540",
     warning: "#FFC72C",
+    "alert-info": "#D4EAFF",
+    "alert-warning": "#FEF1D8",
+    "alert-error": "#F4E1E2",
+    "alert-success": "#99ff99",
   },
 };
 

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/apiResultHandler.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/apiResultHandler.ts
@@ -33,8 +33,9 @@ class ApiResultHandler {
     if (error.response) {
       const status = error.response.status;
       if (status === 400) {
+        console.log(error.response.data);
         // Extract error message from server's response
-        const errorMessage = error.response.data.message || "Bad request. Please check your input.";
+        const errorMessage = error.response.data.message || error.response.data.detail || "Bad request. Please check your input.";
         this.showErrorMessage(errorMessage);
       } else if (status === 404) {
         // Handle 404 Not Found

--- a/src/ECER.Managers.Registry/PortalInvitationHandlers.cs
+++ b/src/ECER.Managers.Registry/PortalInvitationHandlers.cs
@@ -37,11 +37,13 @@ public class PortalInvitationHandlers(IPortalInvitationTransformationEngine tran
     switch (result.StatusCode)
     {
       case PortalInvitationStatusCode.Completed:
-        return PortalInvitationVerificationQueryResult.Failure("Reference already submitted");
+        return PortalInvitationVerificationQueryResult.Failure("Reference has already been submitted.");
       case PortalInvitationStatusCode.Expired:
-        return PortalInvitationVerificationQueryResult.Failure("Reference expired");
+        return PortalInvitationVerificationQueryResult.Failure("Reference has expired.");
       case PortalInvitationStatusCode.Cancelled:
-        return PortalInvitationVerificationQueryResult.Failure("Reference cancelled");
+        return PortalInvitationVerificationQueryResult.Failure("Reference has been cancelled.");
+      case PortalInvitationStatusCode.Failed:
+        return PortalInvitationVerificationQueryResult.Failure("Reference has failed.");
     }
     
     if (result.InviteType == Contract.PortalInvitations.InviteType.WorkExperienceReference)

--- a/src/ECER.Managers.Registry/PortalInvitationHandlers.cs
+++ b/src/ECER.Managers.Registry/PortalInvitationHandlers.cs
@@ -6,6 +6,8 @@ using ECER.Resources.Accounts.Registrants;
 using ECER.Resources.Documents.Applications;
 using ECER.Resources.Documents.PortalInvitations;
 using MediatR;
+using InviteType = ECER.Managers.Registry.Contract.PortalInvitations.InviteType;
+using PortalInvitationStatusCode = ECER.Managers.Registry.Contract.PortalInvitations.PortalInvitationStatusCode;
 
 namespace ECER.Managers.Registry;
 
@@ -19,29 +21,43 @@ public class PortalInvitationHandlers(IPortalInvitationTransformationEngine tran
     if (response.PortalInvitation == Guid.Empty) return PortalInvitationVerificationQueryResult.Failure("Invalid Token");
 
     var portalInvitation = await portalInvitationRepository.Query(new PortalInvitationQuery(response.PortalInvitation), cancellationToken);
+    if (portalInvitation == null) return PortalInvitationVerificationQueryResult.Failure("Portal Invitation not found");
+
     var registrantResult = await registrantRepository.Query(new RegistrantQuery() { ByUserId = portalInvitation.ApplicantId }, cancellationToken);
 
     var applicant = registrantResult.SingleOrDefault();
     if (applicant == null) return PortalInvitationVerificationQueryResult.Failure("Applicant not found");
 
-    var result = mapper.Map<Contract.PortalInvitations.PortalInvitation>(portalInvitation)!;
+    var applications = await applicationRepository.Query(new ApplicationQuery() { ById = portalInvitation.ApplicationId }, cancellationToken);
+    var application = applications.SingleOrDefault();
+    if (application == null) return PortalInvitationVerificationQueryResult.Failure("Application not found");
+
+    var result = mapper.Map<Contract.PortalInvitations.PortalInvitation>(portalInvitation);
+    
+    switch (result.StatusCode)
+    {
+      case PortalInvitationStatusCode.Completed:
+        return PortalInvitationVerificationQueryResult.Failure("Reference already submitted");
+      case PortalInvitationStatusCode.Expired:
+        return PortalInvitationVerificationQueryResult.Failure("Reference expired");
+      case PortalInvitationStatusCode.Cancelled:
+        return PortalInvitationVerificationQueryResult.Failure("Reference cancelled");
+    }
+    
+    if (result.InviteType == Contract.PortalInvitations.InviteType.WorkExperienceReference)
+    {
+      var workExRef =
+        application.WorkExperienceReferences.SingleOrDefault(work =>
+          work.Id == portalInvitation.WorkexperienceReferenceId);
+      if (workExRef != null)
+      {
+        result.WorkExperienceReferenceHours = workExRef.Hours;
+      }
+    }
+    result.CertificationTypes = mapper.Map<Contract.Applications.Application>(application)!.CertificationTypes!;
     result.ApplicantFirstName = applicant.Profile.FirstName;
     result.ApplicantLastName = applicant.Profile.LastName;
 
-    var applications = await applicationRepository.Query(new ApplicationQuery() { ById = portalInvitation.ApplicationId }, cancellationToken);
-    var application = applications.SingleOrDefault();
-    if (application != null)
-    {
-      result.CertificationTypes = mapper.Map<Contract.Applications.Application>(application)!.CertificationTypes!;
-      if (result.InviteType == Contract.PortalInvitations.InviteType.WorkExperienceReference)
-      {
-        var workExRef = application.WorkExperienceReferences.SingleOrDefault(work => work.Id == portalInvitation.WorkexperienceReferenceId);
-        if (workExRef != null)
-        {
-          result.WorkExperienceReferenceHours = workExRef.Hours;
-        }
-      }
-    }
     return PortalInvitationVerificationQueryResult.Success(result);
   }
 }

--- a/src/ECER.Tests/Integration/RegistryApi/PortalInvitationTests.cs
+++ b/src/ECER.Tests/Integration/RegistryApi/PortalInvitationTests.cs
@@ -50,15 +50,14 @@ public class PortalInvitationTests : RegistryPortalWebAppScenarioBase
     var token = packingResponse.VerificationLink.Split('/')[2];
     var verifyResponse = await bus.Send(new PortalInvitationVerificationQuery(token), CancellationToken.None);
 
-    verifyResponse.Invitation!.Id.ShouldBe(portalInvitation.ToString());
+    verifyResponse.Invitation.ShouldBeNull();
+    verifyResponse.ErrorMessage.ShouldBe("Reference already submitted");
+    verifyResponse.IsSuccess.ShouldBeFalse();
 
-    var inviteLinkResponse = await Host.Scenario(_ =>
+    await Host.Scenario(_ =>
     {
       _.Get.Url($"/api/PortalInvitations/{token}");
-      _.StatusCodeShouldBeOk();
+      _.StatusCodeShouldBe(400);
     });
-
-    var queryResult = await inviteLinkResponse.ReadAsJsonAsync<PortalInvitationQueryResult>();
-    queryResult.ShouldBeNull();
   }
 }


### PR DESCRIPTION
## Description

- Check for existence of associated applicant, application and portal invitation 
- Check status of portal invitation to return 400 for invalid states
- Banner component
- /invalid-reference page
- Redirect to /invalid reference page when token verification fails
- Adjusted portal error handling to display 'detail' field if present

## Related Jira Issue(s)

- [ECER-1305](https://eccbc.atlassian.net/browse/ECER-1305)

## Checklist
- [X] I have tested these changes locally.
- [X] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
![image](https://github.com/bcgov/ECC-ECER/assets/10508230/8592dd1f-609e-4fac-a079-5483c3c68515)
