### PR TITLE
Tasks/ecer 2011

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationMapper.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationMapper.cs
@@ -82,8 +82,7 @@ public class ApplicationMapper : Profile
         opt => opt.MapFrom(s => s.Status))
       .ForCtorParam(nameof(SubmittedApplicationStatus.SubStatus),
         opt => opt.MapFrom(s => s.SubStatus))
-      .ForCtorParam(nameof(SubmittedApplicationStatus.ReadyForAssessmentDate),
-        opt => opt.MapFrom(s => s.ReadyForAssessmentDate))
+      .ForMember(d => d.ReadyForAssessmentDate, opts => opts.MapFrom(s => s.ReadyForAssessmentDate))
       .ForMember(d => d.TranscriptsStatus, opts => opts.MapFrom(s => s.Transcripts))
       .ForMember(d => d.WorkExperienceReferencesStatus, opts => opts.MapFrom(s => s.WorkExperienceReferences))
       .ForMember(d => d.CharacterReferencesStatus, opts => opts.MapFrom(s => s.CharacterReferences));

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
@@ -281,7 +281,7 @@ public record CharacterReference([Required] string? FirstName, [Required] string
   public string? Id { get; set; }
 }
 
-public record SubmittedApplicationStatus(string Id, DateTime SubmittedOn, DateTime ReadyForAssessmentDate, ApplicationStatus Status, ApplicationStatusReasonDetail SubStatus)
+public record SubmittedApplicationStatus(string Id, DateTime SubmittedOn, DateTime? ReadyForAssessmentDate, ApplicationStatus Status, ApplicationStatusReasonDetail SubStatus)
 {
 
   public IEnumerable<TranscriptStatus> TranscriptsStatus { get; set; } = Array.Empty<TranscriptStatus>();

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
@@ -281,9 +281,9 @@ public record CharacterReference([Required] string? FirstName, [Required] string
   public string? Id { get; set; }
 }
 
-public record SubmittedApplicationStatus(string Id, DateTime SubmittedOn, DateTime? ReadyForAssessmentDate, ApplicationStatus Status, ApplicationStatusReasonDetail SubStatus)
+public record SubmittedApplicationStatus(string Id, DateTime SubmittedOn, ApplicationStatus Status, ApplicationStatusReasonDetail SubStatus)
 {
-
+  public DateTime? ReadyForAssessmentDate { get; set; }
   public IEnumerable<TranscriptStatus> TranscriptsStatus { get; set; } = Array.Empty<TranscriptStatus>();
   public IEnumerable<ReferenceStatus> WorkExperienceReferencesStatus { get; set; } = Array.Empty<ReferenceStatus>();
   public IEnumerable<ReferenceStatus> CharacterReferencesStatus { get; set; } = Array.Empty<ReferenceStatus>();

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
@@ -122,7 +122,52 @@ public class ApplicationsEndpoints : IRegisterEndpoints
        .RequireAuthorization()
        .WithParameterValidation();
 
+    endpointRouteBuilder.MapPost("/api/applications/{applicationId}/character-reference/{referenceId}", async Task<Results<Ok<ResendReferenceInviteResponse>, BadRequest<ProblemDetails>>> (string applicationId, string referenceId, HttpContext ctx, CancellationToken ct, IMediator messageBus) =>
+    {
+      var userId = ctx.User.GetUserContext()?.UserId;
+
+      bool IdIsNotGuid = !Guid.TryParse(applicationId, out _); if (IdIsNotGuid)
+      {
+        return TypedResults.BadRequest(new ProblemDetails() { Title = "ApplicationId is not a valid guid" });
+      }
+
+      bool ReferenceIdIsNotGuid = !Guid.TryParse(referenceId, out _); if (ReferenceIdIsNotGuid)
+      {
+        return TypedResults.BadRequest(new ProblemDetails() { Title = "ReferenceId is not a valid guid" });
+      }
+
+      return TypedResults.Ok(new ResendReferenceInviteResponse(await messageBus.Send(new ResendReferenceInviteRequest(applicationId, referenceId, userId!, InviteType.WorkExperienceReference), ct)));
+    })
+   .WithOpenApi("Resend a character reference invite", "Changes character reference invite again status to true", "application_character_reference_resend_invite_post")
+   .RequireAuthorization()
+   .WithParameterValidation();
+
+    endpointRouteBuilder.MapPost("/api/applications/{applicationId}/work-experience-reference/{referenceId}", async Task<Results<Ok<ResendReferenceInviteResponse>, BadRequest<ProblemDetails>>> (string applicationId, string referenceId, HttpContext ctx, CancellationToken ct, IMediator messageBus) =>
+    {
+      var userId = ctx.User.GetUserContext()?.UserId;
+
+      bool IdIsNotGuid = !Guid.TryParse(applicationId, out _); if (IdIsNotGuid)
+      {
+        return TypedResults.BadRequest(new ProblemDetails() { Title = "ApplicationId is not a valid guid" });
+      }
+
+      bool ReferenceIdIsNotGuid = !Guid.TryParse(referenceId, out _); if (ReferenceIdIsNotGuid)
+      {
+        return TypedResults.BadRequest(new ProblemDetails() { Title = "ReferenceId is not a valid guid" });
+      }
+
+      return TypedResults.Ok(new ResendReferenceInviteResponse(await messageBus.Send(new ResendReferenceInviteRequest(applicationId, referenceId, userId!, InviteType.WorkExperienceReference), ct)));
+    })
+.WithOpenApi("Resend a work experience reference invite", "Changes work experience reference invite again status to true", "application_work_experience_reference_resend_invite_post")
+.RequireAuthorization()
+.WithParameterValidation();
+
+
   }
+
+
+
+
 }
 
 /// <summary>
@@ -156,6 +201,12 @@ public record SubmitApplicationResponse(string ApplicationId);
 /// </summary>
 /// <param name="Items">The found applications</param>
 public record ApplicationQueryResponse(IEnumerable<Application> Items);
+
+/// <summary>
+/// delete draft application response
+/// </summary>
+/// <param name="ReferenceId">The application id</param>
+public record ResendReferenceInviteResponse(string ReferenceId);
 
 public record DraftApplication
 {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ApplicationSummary.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ApplicationSummary.vue
@@ -49,37 +49,44 @@
         </div>
       </v-card-text>
     </v-card>
-    <ApplicationSummaryTranscriptReferenceListItem
-      v-for="transcript in applicationStatus?.transcriptsStatus"
-      :key="transcript.id?.toString()"
-      :name="transcript.educationalInstitutionName"
-      type="transcript"
-      :status="transcript.status"
-      :go-to="() => goTo(transcript.id?.toString())"
-    />
-    <ApplicationSummaryTranscriptReferenceListItem
-      v-for="reference in applicationStatus?.characterReferencesStatus"
-      :key="reference.id?.toString()"
-      :name="`${reference.firstName} ${reference.lastName}`"
-      type="character"
-      :status="reference.status"
-      :go-to="() => goTo(reference.id?.toString())"
-      :will-provide-reference="reference.willProvideReference"
-    />
-    <ApplicationSummaryTranscriptReferenceListItem
-      v-for="reference in applicationStatus?.workExperienceReferencesStatus"
-      :key="reference.id?.toString()"
-      :name="`${reference.firstName} ${reference.lastName}`"
-      type="workExperience"
-      :status="reference.status"
-      :go-to="() => goTo(reference.id?.toString())"
-      :will-provide-reference="reference.willProvideReference"
-    />
+    <div v-if="step2Progress !== COMPLETE">
+      <ApplicationSummaryTranscriptReferenceListItem
+        v-for="transcript in applicationStatus?.transcriptsStatus"
+        :key="transcript.id?.toString()"
+        :name="transcript.educationalInstitutionName"
+        type="transcript"
+        :status="transcript.status"
+        :go-to="() => goTo(transcript.id?.toString())"
+      />
+      <ApplicationSummaryTranscriptReferenceListItem
+        v-for="reference in applicationStatus?.characterReferencesStatus"
+        :key="reference.id?.toString()"
+        :name="`${reference.firstName} ${reference.lastName}`"
+        type="character"
+        :status="reference.status"
+        :go-to="() => goTo(reference.id?.toString())"
+        :will-provide-reference="reference.willProvideReference"
+      />
+      <ApplicationSummaryTranscriptReferenceListItem
+        v-for="reference in applicationStatus?.workExperienceReferencesStatus"
+        :key="reference.id?.toString()"
+        :name="`${reference.firstName} ${reference.lastName}`"
+        type="workExperience"
+        :status="reference.status"
+        :go-to="() => goTo(reference.id?.toString())"
+        :will-provide-reference="reference.willProvideReference"
+      />
+    </div>
+    <v-card v-if="step2Progress === COMPLETE" elevation="0" rounded="0" class="border-t border-b">
+      <v-card-text>
+        <div>Completed on {{ formatDate(applicationStatus?.readyForAssessmentDate as string, "LLL d, yyyy") }}</div>
+      </v-card-text>
+    </v-card>
     <!-- Step 2 End-->
     <!-- Step 3 Start-->
     <v-card
       elevation="0"
-      :color="step3Progress === IN_PROGRESS ? 'primary' : 'white-smoke'"
+      :color="step3Progress === IN_PROGRESS || step3Progress === ACTION_REQUIRED ? 'primary' : 'white-smoke'"
       class="mt-5"
       :class="[{ 'border-top': step3Progress !== IN_PROGRESS }]"
       rounded="0"
@@ -115,11 +122,62 @@ import { useDisplay } from "vuetify";
 import { getApplicationStatus } from "@/api/application";
 import { useAlertStore } from "@/store/alert";
 import { useApplicationStore } from "@/store/application";
+import type { Components } from "@/types/openapi";
 import { CertificationType } from "@/utils/constant";
 import { formatDate } from "@/utils/format";
 
 import ApplicationCertificationTypeHeader from "./ApplicationCertificationTypeHeader.vue";
 import ApplicationSummaryTranscriptReferenceListItem from "./ApplicationSummaryTranscriptReferenceListItem.vue";
+
+type ApplicationStepProgress = "complete" | "inProgress" | "actionRequired" | "notStarted";
+type ApplicationProcessMap = {
+  [key in Components.Schemas.ApplicationStatus]:
+    | { [key in Components.Schemas.ApplicationStatusReasonDetail]?: ApplicationStepProgress }
+    | ApplicationStepProgress
+    | undefined;
+};
+
+const Step2ApplicationStatusSubDetailMap: ApplicationProcessMap = {
+  Complete: undefined,
+  InProgress: { BeingAssessed: "complete" },
+  Draft: undefined,
+  Submitted: { PendingDocuments: "inProgress", ValidatingIDs: "inProgress", ReceivePhysicalTranscripts: "inProgress" },
+  Reconsideration: { Denied: undefined, Certified: undefined },
+  Cancelled: undefined,
+  Escalated: "complete",
+  Decision: { Certified: undefined, Denied: undefined },
+  Withdrawn: undefined,
+  Ready: { ReadyforAssessment: "complete" },
+  PendingQueue: {
+    MoreInformationRequired: "complete",
+    PendingDocuments: "complete",
+    SupervisorConsultationNeeded: "complete",
+    OperationSupervisorManagerofCertificationsConsultationNeeded: "complete",
+    InvestigationsConsultationNeeded: "complete",
+  },
+  ReconsiderationDecision: undefined,
+};
+
+const Step3ApplicationStatusSubDetailMap: ApplicationProcessMap = {
+  Complete: undefined,
+  InProgress: { BeingAssessed: "inProgress" },
+  Draft: undefined,
+  Submitted: { PendingDocuments: "notStarted", ValidatingIDs: "notStarted", ReceivePhysicalTranscripts: "notStarted" },
+  Reconsideration: { Denied: undefined, Certified: undefined },
+  Cancelled: undefined,
+  Escalated: "inProgress",
+  Decision: { Certified: undefined, Denied: undefined },
+  Withdrawn: undefined,
+  Ready: { ReadyforAssessment: "inProgress" },
+  PendingQueue: {
+    MoreInformationRequired: "actionRequired",
+    PendingDocuments: "actionRequired",
+    SupervisorConsultationNeeded: "inProgress",
+    OperationSupervisorManagerofCertificationsConsultationNeeded: "inProgress",
+    InvestigationsConsultationNeeded: "inProgress",
+  },
+  ReconsiderationDecision: undefined,
+};
 
 export default defineComponent({
   name: "ApplicationSummary",
@@ -132,11 +190,23 @@ export default defineComponent({
 
     await applicationStore.fetchApplications();
     const applicationStatus = (await getApplicationStatus(route.params.applicationId.toString()))?.data;
-    const IN_PROGRESS = "inProgress";
-    const NOT_STARTED = "notStarted";
-    const COMPLETE = "complete";
+    const IN_PROGRESS: ApplicationStepProgress = "inProgress";
+    const NOT_STARTED: ApplicationStepProgress = "notStarted";
+    const COMPLETE: ApplicationStepProgress = "complete";
+    const ACTION_REQUIRED: ApplicationStepProgress = "actionRequired";
 
-    return { applicationStore, alertStore, CertificationType, applicationStatus, smAndUp, formatDate, IN_PROGRESS, NOT_STARTED, COMPLETE };
+    return {
+      applicationStore,
+      alertStore,
+      CertificationType,
+      applicationStatus,
+      smAndUp,
+      formatDate,
+      IN_PROGRESS,
+      NOT_STARTED,
+      COMPLETE,
+      ACTION_REQUIRED,
+    };
   },
   data() {
     return {
@@ -176,17 +246,7 @@ export default defineComponent({
       }
     },
     step2Progress() {
-      switch (this.applicationStatus?.status) {
-        case "Submitted":
-        case "InProgress":
-          return this.IN_PROGRESS;
-        case "Ready":
-        case "PendingQueue":
-        case "Escalated":
-          return this.COMPLETE;
-        default:
-          return "";
-      }
+      return this.findStepProgress(Step2ApplicationStatusSubDetailMap, "step2");
     },
     step3RegistryAssessmentIcon() {
       switch (this.step3Progress) {
@@ -194,6 +254,8 @@ export default defineComponent({
           return "";
         case this.IN_PROGRESS:
           return "mdi-arrow-right";
+        case this.ACTION_REQUIRED:
+          return "mdi-alert-circle";
         default:
           return "";
       }
@@ -204,26 +266,43 @@ export default defineComponent({
           return "Not yet started";
         case this.IN_PROGRESS:
           return "In progress";
+        case this.ACTION_REQUIRED:
+          return "Action required";
         default:
           return "";
       }
     },
     step3Progress() {
-      switch (this.applicationStatus?.status) {
-        case "Submitted":
-        case "InProgress":
-          return this.NOT_STARTED;
-        case "Ready":
-        case "PendingQueue":
-          return this.IN_PROGRESS;
-        default:
-          return "";
-      }
+      return this.findStepProgress(Step3ApplicationStatusSubDetailMap, "step3");
     },
   },
   methods: {
     goTo(id: string | undefined) {
       this.alertStore.setSuccessAlert("not implemented yet this will go to another route " + id);
+    },
+    findStepProgress(applicationProcessMap: ApplicationProcessMap, step: string) {
+      const status = this.applicationStatus?.status;
+      const statusReasonDetail = this.applicationStatus?.subStatus;
+
+      if (status) {
+        const subDetail = applicationProcessMap[status];
+
+        //this checks if we have found the ApplicationStepProgress.
+        if (typeof subDetail === "string") {
+          return subDetail;
+        }
+
+        if (subDetail && statusReasonDetail) {
+          if (subDetail[statusReasonDetail]) {
+            return subDetail[statusReasonDetail];
+          }
+        }
+      }
+
+      console.warn(
+        `This should not happen, unmapped status and statusReasonDetail combination please check ApplicationStatusSubDetailMap for ${step} :: status: ${status} statusReasonDetail: ${statusReasonDetail}`,
+      );
+      return "";
     },
   },
 });

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ApplicationSummary.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ApplicationSummary.vue
@@ -246,7 +246,7 @@ export default defineComponent({
       }
     },
     step2Progress() {
-      return this.findStepProgress(Step2ApplicationStatusSubDetailMap, "step2");
+      return this.findApplicationStepProgress(Step2ApplicationStatusSubDetailMap, "step2");
     },
     step3RegistryAssessmentIcon() {
       switch (this.step3Progress) {
@@ -273,14 +273,14 @@ export default defineComponent({
       }
     },
     step3Progress() {
-      return this.findStepProgress(Step3ApplicationStatusSubDetailMap, "step3");
+      return this.findApplicationStepProgress(Step3ApplicationStatusSubDetailMap, "step3");
     },
   },
   methods: {
     goTo(id: string | undefined) {
       this.alertStore.setSuccessAlert("not implemented yet this will go to another route " + id);
     },
-    findStepProgress(applicationProcessMap: ApplicationProcessMap, step: string) {
+    findApplicationStepProgress(applicationProcessMap: ApplicationProcessMap, step: string) {
       const status = this.applicationStatus?.status;
       const statusReasonDetail = this.applicationStatus?.subStatus;
 

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
@@ -43,6 +43,22 @@ declare namespace Components {
       | "InProgress"
       | "PendingQueue"
       | "ReconsiderationDecision";
+    export type ApplicationStatusReasonDetail =
+      | "Actioned"
+      | "BeingAssessed"
+      | "Certified"
+      | "Denied"
+      | "ForReview"
+      | "InvestigationsConsultationNeeded"
+      | "MoreInformationRequired"
+      | "OperationSupervisorManagerofCertificationsConsultationNeeded"
+      | "PendingDocuments"
+      | "ProgramAnalystReview"
+      | "ReadyforAssessment"
+      | "ReceivedPending"
+      | "ReceivePhysicalTranscripts"
+      | "SupervisorConsultationNeeded"
+      | "ValidatingIDs";
     /**
      * Submit application request
      */
@@ -76,8 +92,6 @@ declare namespace Components {
       workedWithChildren?: boolean;
       childInteractionObservations?: string | null;
       applicantTemperamentAssessment?: string | null;
-      applicantShouldNotBeECE?: boolean;
-      applicantNotQualifiedReason?: string | null;
     }
     export interface CharacterReferenceSubmissionRequest {
       token?: string | null;
@@ -237,7 +251,9 @@ declare namespace Components {
     export interface SubmittedApplicationStatus {
       id?: string | null;
       submittedOn?: string; // date-time
+      readyForAssessmentDate?: string; // date-time
       status?: ApplicationStatus;
+      subStatus?: ApplicationStatusReasonDetail;
       transcriptsStatus?: TranscriptStatus[] | null;
       workExperienceReferencesStatus?: ReferenceStatus[] | null;
       characterReferencesStatus?: ReferenceStatus[] | null;

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
@@ -251,7 +251,7 @@ declare namespace Components {
     export interface SubmittedApplicationStatus {
       id?: string | null;
       submittedOn?: string; // date-time
-      readyForAssessmentDate?: string; // date-time
+      readyForAssessmentDate?: string | null; // date-time
       status?: ApplicationStatus;
       subStatus?: ApplicationStatusReasonDetail;
       transcriptsStatus?: TranscriptStatus[] | null;

--- a/src/ECER.Managers.Registry.Contract/Applications/Contract.cs
+++ b/src/ECER.Managers.Registry.Contract/Applications/Contract.cs
@@ -159,6 +159,8 @@ public record ReferenceContactInformation(string LastName, string FirstName, str
 public record CharacterReferenceEvaluation(ReferenceRelationship ReferenceRelationship, string ReferenceRelationshipOther, ReferenceKnownTime LengthOfAcquaintance, bool WorkedWithChildren, string ChildInteractionObservations, string ApplicantTemperamentAssessment);
 public record OptOutReferenceRequest(string Token, UnabletoProvideReferenceReasons UnabletoProvideReferenceReasons) : IRequest<ReferenceSubmissionResult>;
 
+public record ResendReferenceInviteRequest(string ApplicationId, string ReferenceId, string UserId, InviteType InviteType) : IRequest<string>;
+
 public enum UnabletoProvideReferenceReasons
 {
   Iamunabletoatthistime,
@@ -247,4 +249,9 @@ public enum StageStatus
   InComplete,
   InProgress,
   Rejected
+}
+public enum InviteType
+{
+  CharacterReference,
+  WorkExperienceReference
 }

--- a/src/ECER.Resources.Documents/Applications/ApplicationRepository.cs
+++ b/src/ECER.Resources.Documents/Applications/ApplicationRepository.cs
@@ -303,5 +303,37 @@ internal sealed class ApplicationRepository : IApplicationRepository
     return workexperienceReference.ecer_WorkExperienceRefId.ToString()!;
   }
 
+  public async Task<string> ResendCharacterReferenceInvite(ResendReferenceInviteRequest request, CancellationToken cancellationToken)
+  {
+    await Task.CompletedTask;
+    var characterReference = context.ecer_CharacterReferenceSet.Single(c => c.ecer_CharacterReferenceId == Guid.Parse(request.ReferenceId!));
+
+    if (characterReference == null) throw new InvalidOperationException($"Character reference '{request.ReferenceId}' not found");
+
+    if (characterReference.StatusCode == ecer_CharacterReference_StatusCode.Rejected || characterReference.StatusCode == ecer_CharacterReference_StatusCode.Submitted) throw new InvalidOperationException($"Character reference '{request.ReferenceId}' already responded");
+
+    mapper.Map(request, characterReference);
+    characterReference.ecer_InviteAgain = true;
+    context.UpdateObject(characterReference);
+    context.SaveChanges();
+
+    return characterReference.ecer_CharacterReferenceId.ToString()!;
+  }
+
+  public async Task<string> ResendWorkExperienceReferenceInvite(ResendReferenceInviteRequest request, CancellationToken cancellationToken)
+  {
+    await Task.CompletedTask;
+    var workexperienceReference = context.ecer_WorkExperienceRefSet.Single(c => c.ecer_WorkExperienceRefId == Guid.Parse(request.ReferenceId!));
+
+    if (workexperienceReference == null) throw new InvalidOperationException($"Work experience reference '{request.ReferenceId}' not found");
+
+    if (workexperienceReference.StatusCode == ecer_WorkExperienceRef_StatusCode.Rejected || workexperienceReference.StatusCode == ecer_WorkExperienceRef_StatusCode.Submitted) throw new InvalidOperationException($"Work experience reference '{request.ReferenceId}' already responded");
+
+    workexperienceReference.ecer_InviteAgain = true;
+    context.UpdateObject(workexperienceReference);
+    context.SaveChanges();
+    return workexperienceReference.ecer_WorkExperienceRefId.ToString()!;
+  }
+
   #endregion implementationDetails
 }

--- a/src/ECER.Resources.Documents/Applications/IApplicationRepository.cs
+++ b/src/ECER.Resources.Documents/Applications/IApplicationRepository.cs
@@ -16,6 +16,10 @@ public interface IApplicationRepository
 
   Task<string> OptOutReference(OptOutReferenceRequest request, CancellationToken cancellationToken);
 
+  Task<string> ResendCharacterReferenceInvite(ResendReferenceInviteRequest request, CancellationToken cancellationToken);
+
+  Task<string> ResendWorkExperienceReferenceInvite(ResendReferenceInviteRequest request, CancellationToken cancellationToken);
+
 }
 
 public record ApplicationQuery
@@ -122,6 +126,10 @@ public record CharacterReference(string? FirstName, string? LastName, string? Ph
 public record OptOutReferenceRequest(UnabletoProvideReferenceReasons UnabletoProvideReferenceReasons)
 {
   public PortalInvitation? PortalInvitation { get; set; }
+}
+
+public record ResendReferenceInviteRequest(string ReferenceId)
+{
 }
 
 public enum UnabletoProvideReferenceReasons


### PR DESCRIPTION
ECER-2011: Frontend changes for application summary based on application status + applicationStatusReasonDetail. 

- the styles and text for step 2 and step 3 will be driven by a combination of application status + application status reason detail. 
- using an object to map through the desired outcomes. 
- if there is a combination that isn't handled. Nothing will show, but a console.warning message will direct us where to look. 
- small fix for readyForAssessmentDate to return null value when application status endpoint is called. 

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Application status = ready 
Application status reason detail = pending documents 
Step2 should show completed with completed date 
Step3 should show in progress 
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/be89896b-49aa-4b7f-accd-8b64a8b3686b)


Application status = pending queue
Application status reason detail = MoreInformationRequired
Step2 should show completed with completed date 
Step 3 should show Action Required 
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/59c90f01-48ad-4ad6-8051-1f39889f255d)

Incorrect status combination (just in case) 
Show warning in chrome dev tools console helping the developer debug the issue 
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/f38288c7-b442-4047-b67b-e33eb9a960b4)

Previously null assessmentDate would return Jan 1 if there wasn't a value.
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/a1ecbcdb-9faa-4801-b44c-c569e1a329f2)

Now it returns null
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/dfce2b5d-0964-47f0-b5c4-111e7d4c72b6)
