### PR TITLE
ECER-2096 - [num] unread message on dashboard is not in bold - Fix

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/UnreadMessages.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/UnreadMessages.vue
@@ -4,7 +4,7 @@
     You have
     <template v-if="linkable">
       <!-- prettier-ignore -->
-      <router-link to="/messages">1 new message</router-link>
+      <router-link to="/messages"><b>1 new message</b></router-link>
       <span>.</span>
     </template>
     <template v-else>1 new message.</template>
@@ -12,7 +12,9 @@
   <template v-if="messageStore.unreadMessageCount > 1">
     You have
     <template v-if="linkable">
-      <router-link to="/messages">{{ messageStore.unreadMessageCount }} new messages</router-link>
+      <router-link to="/messages">
+        <b>{{ messageStore.unreadMessageCount }} new messages</b>
+      </router-link>
       <span>.</span>
     </template>
     <template v-else>{{ messageStore.unreadMessageCount }} new messages.</template>


### PR DESCRIPTION
---
name: ECER-2096 - [num] unread message on dashboard is not in bold 
about: Fix for ECER-2096 - [num] unread message on dashboard is not in bold
---

## Title
ECER-2096 - [num] unread message on dashboard is not in bold 

## Description

- Fix for  [num] unread message on dashboard is not in bold


## Related Jira Issue(s)

- ECER-2096


## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)

1 unread message:
![image](https://github.com/bcgov/ECC-ECER/assets/160776397/ff84fce8-44e3-4dd1-baf1-6857492f2463)

more than 1 unread message:
![image](https://github.com/bcgov/ECC-ECER/assets/160776397/f59303f4-a1be-442a-93b7-e775ab9a906e)

