### PR TITLE
ECER-2165 : BE: Extend update reference endpoints to allow for new submissions

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
@@ -192,7 +192,7 @@ public class ApplicationsEndpoints : IRegisterEndpoints
             var problemDetails = new ProblemDetails
             {
               Status = StatusCodes.Status400BadRequest,
-              Title = "Work Experience reference updation failed",
+              Title = "Character reference updation failed",
               Extensions = { ["errors"] = result.ErrorMessage }
             };
             return TypedResults.BadRequest(problemDetails);

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
@@ -121,7 +121,7 @@ public class ApplicationsEndpoints : IRegisterEndpoints
         .RequireAuthorization()
         .WithParameterValidation();
 
-    endpointRouteBuilder.MapPost("/api/applications/{application_id}/workexperiencereference/{reference_id}/update", async Task<Results<Ok<UpdateReferenceResponse>, BadRequest<ProblemDetails>, NotFound>> (string application_id, string? reference_id, WorkExperienceReference request, HttpContext ctx, CancellationToken ct, IMediator messageBus, IMapper mapper) =>
+    endpointRouteBuilder.MapPost("/api/applications/{application_id}/workexperiencereference/{reference_id?}", async Task<Results<Ok<UpdateReferenceResponse>, BadRequest<ProblemDetails>, NotFound>> (string application_id, string? reference_id, WorkExperienceReference request, HttpContext ctx, CancellationToken ct, IMediator messageBus, IMapper mapper) =>
         {
           var userId = ctx.User.GetUserContext()?.UserId;
           bool AppIdIsNotGuid = !Guid.TryParse(application_id, out _);
@@ -162,7 +162,7 @@ public class ApplicationsEndpoints : IRegisterEndpoints
         .RequireAuthorization()
         .WithParameterValidation();
 
-    endpointRouteBuilder.MapPost("/api/applications/{application_id}/characterreference/{reference_id}/update", async Task<Results<Ok<UpdateReferenceResponse>, BadRequest<ProblemDetails>, NotFound>> (string application_id, string? reference_id, CharacterReference request, HttpContext ctx, CancellationToken ct, IMediator messageBus, IMapper mapper) =>
+    endpointRouteBuilder.MapPost("/api/applications/{application_id}/characterreference/{reference_id?}", async Task<Results<Ok<UpdateReferenceResponse>, BadRequest<ProblemDetails>, NotFound>> (string application_id, string? reference_id, CharacterReference request, HttpContext ctx, CancellationToken ct, IMediator messageBus, IMapper mapper) =>
         {
           var userId = ctx.User.GetUserContext()?.UserId;
           bool AppIdIsNotGuid = !Guid.TryParse(application_id, out _);

--- a/src/ECER.Resources.Documents/Applications/ApplicationRepository.cs
+++ b/src/ECER.Resources.Documents/Applications/ApplicationRepository.cs
@@ -317,12 +317,16 @@ internal sealed class ApplicationRepository : IApplicationRepository
 
     var existingWorkExperiences = context.ecer_WorkExperienceRefSet.Where(t => t.ecer_Applicationid.Id == Guid.Parse(applicationId)).ToList();
 
-    var oldReference = existingWorkExperiences.SingleOrDefault(t => t.Id == Guid.Parse(referenceId));
-    // 1. Remove existing WorkExperienceReference
-
-    if (oldReference != null)
+    bool RefIdIsGuid = Guid.TryParse(referenceId, out Guid referenceIdGuid);
+    if (RefIdIsGuid)
     {
-      context.DeleteObject(oldReference);
+      var oldReference = existingWorkExperiences.SingleOrDefault(t => t.Id == referenceIdGuid);
+      // 1. Remove existing WorkExperienceReference
+
+      if (oldReference != null)
+      {
+        context.DeleteObject(oldReference);
+      }
     }
 
     // 2. Add New WorkExperienceReferences
@@ -352,15 +356,20 @@ internal sealed class ApplicationRepository : IApplicationRepository
 
     var existingCharacterReferences = context.ecer_CharacterReferenceSet.Where(t => t.ecer_Applicationid.Id == Guid.Parse(applicationId)).ToList();
 
-    var oldReference = existingCharacterReferences.SingleOrDefault(t => t.Id == Guid.Parse(referenceId));
-    // 1. Remove existing WorkExperienceReference
-
-    if (oldReference != null)
+    bool RefIdIsGuid = Guid.TryParse(referenceId, out Guid referenceIdGuid);
+    if (RefIdIsGuid)
     {
-      context.DeleteObject(oldReference);
+      var oldReference = existingCharacterReferences.SingleOrDefault(t => t.Id == referenceIdGuid);
+
+      // 1. Remove existing Character Reference
+
+      if (oldReference != null)
+      {
+        context.DeleteObject(oldReference);
+      }
     }
 
-    // 2. Add New WorkExperienceReferences
+    // 2. Add New Character Reference
 
     ecerCharacterReference.ecer_CharacterReferenceId = Guid.NewGuid();
     ecerCharacterReference.StatusCode = ecer_CharacterReference_StatusCode.ApplicationSubmitted;

--- a/src/ECER.Resources.Documents/Applications/ApplicationRepository.cs
+++ b/src/ECER.Resources.Documents/Applications/ApplicationRepository.cs
@@ -327,6 +327,10 @@ internal sealed class ApplicationRepository : IApplicationRepository
       {
         context.DeleteObject(oldReference);
       }
+      else
+      {
+        throw new InvalidOperationException($"Reference '{referenceIdGuid}' not found for application '{applicationId}'");
+      }
     }
 
     // 2. Add New WorkExperienceReferences
@@ -362,10 +366,13 @@ internal sealed class ApplicationRepository : IApplicationRepository
       var oldReference = existingCharacterReferences.SingleOrDefault(t => t.Id == referenceIdGuid);
 
       // 1. Remove existing Character Reference
-
       if (oldReference != null)
       {
         context.DeleteObject(oldReference);
+      }
+      else
+      {
+        throw new InvalidOperationException($"Reference '{referenceIdGuid}' not found for application '{applicationId}'");
       }
     }
 

--- a/src/ECER.Tests/Integration/RegistryApi/ApplicationTests.cs
+++ b/src/ECER.Tests/Integration/RegistryApi/ApplicationTests.cs
@@ -206,7 +206,7 @@ public class ApplicationTests : RegistryPortalWebAppScenarioBase
   }
 
   [Fact]
-  public async Task UpdateWorkExReference_ByReferenceId()
+  public async Task UpdateWorkExReference_ForSubmittedApplication_ByReferenceId()
   {
     var applicationId = this.Fixture.submittedTestApplicationId;
     var referenceId = this.Fixture.submittedTestApplicationWorkExperienceRefId;
@@ -214,7 +214,7 @@ public class ApplicationTests : RegistryPortalWebAppScenarioBase
     var UpdateWorkExRefResponse = await Host.Scenario(_ =>
     {
       _.WithExistingUser(this.Fixture.AuthenticatedBcscUserIdentity, this.Fixture.AuthenticatedBcscUserId);
-      _.Post.Json(newWork).ToUrl($"/api/applications/{applicationId}/workexperiencereference/{referenceId}/update");
+      _.Post.Json(newWork).ToUrl($"/api/applications/{applicationId}/workexperiencereference/{referenceId}");
       _.StatusCodeShouldBeOk();
     });
     var UpdateWorkExReferenceResponseId = await UpdateWorkExRefResponse.ReadAsJsonAsync<UpdateReferenceResponse>();
@@ -222,15 +222,45 @@ public class ApplicationTests : RegistryPortalWebAppScenarioBase
   }
 
   [Fact]
-  public async Task UpdateCharacterReference_ByReferenceId()
+  public async Task AddNewWorkExReference_ForSubmittedApplication()
   {
-    var applicationId = this.Fixture.submittedTestApplicationId2;
+    var applicationId = this.Fixture.submittedTestApplicationId4;
+    WorkExperienceReference newWork = CreateWorkExperienceReference();
+    var UpdateWorkExRefResponse = await Host.Scenario(_ =>
+    {
+      _.WithExistingUser(this.Fixture.AuthenticatedBcscUserIdentity, this.Fixture.AuthenticatedBcscUserId);
+      _.Post.Json(newWork).ToUrl($"/api/applications/{applicationId}/workexperiencereference");
+      _.StatusCodeShouldBeOk();
+    });
+    var UpdateWorkExReferenceResponseId = await UpdateWorkExRefResponse.ReadAsJsonAsync<UpdateReferenceResponse>();
+    UpdateWorkExReferenceResponseId!.ReferenceId.ShouldNotBeEmpty();
+  }
+
+  [Fact]
+  public async Task UpdateCharacterReference_ForSubmittedApplication_ByReferenceId()
+  {
+    var applicationId = this.Fixture.submittedTestApplicationId3;
     var referenceId = this.Fixture.submittedTestApplicationCharacterRefId;
     CharacterReference newCharacter = CreateCharacterReference();
     var UpdateCharacterRefResponse = await Host.Scenario(_ =>
     {
       _.WithExistingUser(this.Fixture.AuthenticatedBcscUserIdentity, this.Fixture.AuthenticatedBcscUserId);
-      _.Post.Json(newCharacter).ToUrl($"/api/applications/{applicationId}/characterreference/{referenceId}/update");
+      _.Post.Json(newCharacter).ToUrl($"/api/applications/{applicationId}/characterreference/{referenceId}");
+      _.StatusCodeShouldBeOk();
+    });
+    var UpdateCharacterRefResponseId = await UpdateCharacterRefResponse.ReadAsJsonAsync<UpdateReferenceResponse>();
+    UpdateCharacterRefResponseId!.ReferenceId.ShouldNotBeEmpty();
+  }
+
+  [Fact]
+  public async Task AddNewCharacterReference_ForSubmittedApplication()
+  {
+    var applicationId = this.Fixture.submittedTestApplicationId4;
+    CharacterReference newCharacter = CreateCharacterReference();
+    var UpdateCharacterRefResponse = await Host.Scenario(_ =>
+    {
+      _.WithExistingUser(this.Fixture.AuthenticatedBcscUserIdentity, this.Fixture.AuthenticatedBcscUserId);
+      _.Post.Json(newCharacter).ToUrl($"/api/applications/{applicationId}/characterreference");
       _.StatusCodeShouldBeOk();
     });
     var UpdateCharacterRefResponseId = await UpdateCharacterRefResponse.ReadAsJsonAsync<UpdateReferenceResponse>();
@@ -240,7 +270,7 @@ public class ApplicationTests : RegistryPortalWebAppScenarioBase
   [Fact]
   public async Task ResendWorkExperienceReferenceInvite_ShouldReturnOk()
   {
-    var applicationId = this.Fixture.submittedTestApplicationId3;
+    var applicationId = this.Fixture.submittedTestApplicationId2;
     var referenceId = this.Fixture.submittedTestApplicationWorkExperienceRefId2;
     await Host.Scenario(_ =>
     {
@@ -284,7 +314,7 @@ public class ApplicationTests : RegistryPortalWebAppScenarioBase
     var faker = new Faker("en_CA");
 
     return new CharacterReference(
-      faker.Name.FirstName(), faker.Name.LastName(), faker.Phone.PhoneNumber(), faker.Internet.Email()
+      faker.Name.FirstName(), faker.Name.LastName(), faker.Phone.PhoneNumber(), "Character_Reference@example.com"
     );
   }
 
@@ -293,7 +323,7 @@ public class ApplicationTests : RegistryPortalWebAppScenarioBase
     var faker = new Faker("en_CA");
 
     return new WorkExperienceReference(
-       faker.Name.FirstName(), faker.Name.FirstName(), faker.Internet.Email(), faker.Random.Number(10, 150)
+       faker.Name.FirstName(), faker.Name.FirstName(), "WorkExperience_Reference@example.com", faker.Random.Number(10, 150)
     )
     {
       PhoneNumber = faker.Phone.PhoneNumber()

--- a/src/ECER.Tests/Integration/RegistryPortalWebAppScenarioBase.cs
+++ b/src/ECER.Tests/Integration/RegistryPortalWebAppScenarioBase.cs
@@ -66,6 +66,7 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
   private ecer_Application submittedTestApplication = null!;
   private ecer_Application submittedTestApplication2 = null!;
   private ecer_Application submittedTestApplication3 = null!;
+  private ecer_Application submittedTestApplication4 = null!;
   private ecer_WorkExperienceRef submittedTestApplicationWorkExperienceRef = null!;
   private ecer_WorkExperienceRef submittedTestApplicationWorkExperienceRef2 = null!;
   private ecer_CharacterReference submittedTestApplicationCharacterRef = null!;
@@ -75,11 +76,11 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
   public string submittedTestApplicationId => submittedTestApplication.Id.ToString();
   public string submittedTestApplicationId2 => submittedTestApplication2.Id.ToString();
   public string submittedTestApplicationId3 => submittedTestApplication3.Id.ToString();
+  public string submittedTestApplicationId4 => submittedTestApplication4.Id.ToString();
   public string submittedTestApplicationWorkExperienceRefId => submittedTestApplicationWorkExperienceRef.Id.ToString();
   public string submittedTestApplicationWorkExperienceRefId2 => submittedTestApplicationWorkExperienceRef2.Id.ToString();
 
   public string submittedTestApplicationCharacterRefId => submittedTestApplicationCharacterRef.Id.ToString();
-
 
   protected override void AddAuthorizationOptions(AuthorizationOptions opts)
   {
@@ -117,9 +118,10 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
     submittedTestApplication = GetOrAddApplication(context, authenticatedBcscUser, ecer_Application_StatusCode.Submitted);
     submittedTestApplication2 = GetOrAddApplication(context, authenticatedBcscUser, ecer_Application_StatusCode.Submitted);
     submittedTestApplication3 = GetOrAddApplication(context, authenticatedBcscUser, ecer_Application_StatusCode.Submitted);
+    submittedTestApplication4 = GetOrAddApplication(context, authenticatedBcscUser, ecer_Application_StatusCode.Submitted);
     submittedTestApplicationWorkExperienceRef = AddWorkExperienceReferenceToApplication(context, submittedTestApplication);
-    submittedTestApplicationWorkExperienceRef2 = AddWorkExperienceReferenceToApplication(context, submittedTestApplication3);
-    submittedTestApplicationCharacterRef = AddCharacterReferenceToApplication(context, submittedTestApplication2);
+    submittedTestApplicationWorkExperienceRef2 = AddWorkExperienceReferenceToApplication(context, submittedTestApplication2);
+    submittedTestApplicationCharacterRef = AddCharacterReferenceToApplication(context, submittedTestApplication3);
     testCommunication1 = GetOrAddCommunication(context, inProgressTestApplication, "comm1");
     testCommunication2 = GetOrAddCommunication(context, inProgressTestApplication, "comm2");
     testCommunication3 = GetOrAddCommunication(context, inProgressTestApplication, "comm3");


### PR DESCRIPTION
---
name: ECER-2165 : BE: Extend update reference endpoints to allow for new submissions
about: BE: Extend update reference endpoints to allow for new submissions
---

## Title
ECER-2165 : BE: Extend update reference endpoints to allow for new submissions

## Description

- Extended update reference endpoints to allow for new reference submissions
- Added new automated tests for adding new references

## Related Jira Issue(s)

- ECER-2165
- ECER-1852

## Checklist
- [x] I have tested these changes locally.
- [x] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.
