### PR TITLE
ECER-2100 - Show manage application option on dashboard for applications under investigation

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
@@ -381,10 +381,12 @@ public enum ApplicationStatus
   Escalated,
   Decision,
   Withdrawn,
+  Pending,
   Ready,
   InProgress,
   PendingQueue,
-  ReconsiderationDecision
+  ReconsiderationDecision,
+  AppealDecision
 }
 
 public enum ApplicationStatusReasonDetail

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ApplicationCard.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ApplicationCard.vue
@@ -22,7 +22,9 @@
           applicationStore.applicationStatus === 'Submitted' ||
           applicationStore.applicationStatus === 'Ready' ||
           applicationStore.applicationStatus === 'InProgress' ||
-          applicationStore.applicationStatus === 'PendingQueue'
+          applicationStore.applicationStatus === 'PendingQueue' ||
+          applicationStore.applicationStatus === 'Pending' ||
+          applicationStore.applicationStatus === 'Escalated'
         "
         class="d-flex flex-row justify-start ga-3 flex-wrap"
       >

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ApplicationSummary.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ApplicationSummary.vue
@@ -162,6 +162,8 @@ const Step2ApplicationStatusSubDetailMap: ApplicationProcessMap = {
     InvestigationsConsultationNeeded: "complete",
   },
   ReconsiderationDecision: undefined,
+  Pending: undefined,
+  AppealDecision: undefined,
 };
 
 const Step3ApplicationStatusSubDetailMap: ApplicationProcessMap = {
@@ -183,6 +185,8 @@ const Step3ApplicationStatusSubDetailMap: ApplicationProcessMap = {
     InvestigationsConsultationNeeded: "inProgress",
   },
   ReconsiderationDecision: undefined,
+  Pending: undefined,
+  AppealDecision: undefined,
 };
 
 export default defineComponent({

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Dashboard.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Dashboard.vue
@@ -125,7 +125,9 @@ export default defineComponent({
         this.applicationStore.applicationStatus === "Submitted" ||
         this.applicationStore.applicationStatus === "Ready" ||
         this.applicationStore.applicationStatus === "InProgress" ||
-        this.applicationStore.applicationStatus === "PendingQueue"
+        this.applicationStore.applicationStatus === "PendingQueue" ||
+        this.applicationStore.applicationStatus === "Pending" ||
+        this.applicationStore.applicationStatus === "Escalated"
       );
     },
   },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
@@ -39,10 +39,12 @@ declare namespace Components {
       | "Escalated"
       | "Decision"
       | "Withdrawn"
+      | "Pending"
       | "Ready"
       | "InProgress"
       | "PendingQueue"
-      | "ReconsiderationDecision";
+      | "ReconsiderationDecision"
+      | "AppealDecision";
     export type ApplicationStatusReasonDetail =
       | "Actioned"
       | "BeingAssessed"
@@ -274,6 +276,8 @@ declare namespace Components {
       transcriptsStatus?: TranscriptStatus[] | null;
       workExperienceReferencesStatus?: WorkExperienceReferenceStatus[] | null;
       characterReferencesStatus?: CharacterReferenceStatus[] | null;
+      addMoreCharacterReference?: boolean | null;
+      addMoreWorkExperienceReference?: boolean | null;
     }
     export interface Transcript {
       id?: string | null;

--- a/src/ECER.Managers.Registry.Contract/Applications/Contract.cs
+++ b/src/ECER.Managers.Registry.Contract/Applications/Contract.cs
@@ -131,7 +131,8 @@ public enum ApplicationStatus
   Ready,
   InProgress,
   PendingQueue,
-  ReconsiderationDecision
+  ReconsiderationDecision,
+  AppealDecision
 }
 
 public enum ApplicationStatusReasonDetail


### PR DESCRIPTION
---
name: ECER-2100 - Show manage application option on dashboard for applications under investigation
about: Show manage application option on dashboard for applications under investigation
---

## Title
ECER-2100 - Show manage application option on dashboard for applications under investigation

## Description

- Added "Pending" and "Escalated" status to "get application status" in the BE
- npm run gen-api
- added required application status checks in the FE.
- added "Pending" and "AppealDecision" to ApplicationStatusSubDetailMaps in ApplicationSummary.vue to fix type-check problems causing build failure.

## Related Jira Issue(s)

- ECER-2100
- ECER-1379

## Checklist
- [x] I have tested these changes locally.
- [x] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)

"Manage Application" visible on Application status -> "Pending":
![image](https://github.com/bcgov/ECC-ECER/assets/160776397/bb67233a-29c6-4bae-93cc-97dc73f06c65)
