### PR TITLE
ECER-2197: Add validation to new references being added after application submitted to ensure they're different

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Alert.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Alert.vue
@@ -3,6 +3,8 @@
     :type="type"
     :color="type"
     :icon="icon"
+    :title="title"
+    :prominent="prominent"
     closable
     variant="outlined"
     :rounded="rounded ? 'lg' : 0"
@@ -35,6 +37,14 @@ export default defineComponent({
     rounded: {
       type: Boolean,
       default: true,
+    },
+    title: {
+      type: String,
+      default: "",
+    },
+    prominent: {
+      type: Boolean,
+      default: false,
     },
   },
 });

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/UpsertCharacterReference.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/UpsertCharacterReference.vue
@@ -5,12 +5,8 @@
     </v-breadcrumbs>
     <v-row>
       <v-col>
-        <Alert v-model="isDuplicateReference" type="error">
-          <p class="small">
-            <b>choose someone else</b>
-            <br />
-            This person is your work experience reference. Your character reference and work experience reference must be different people.
-          </p>
+        <Alert v-model="isDuplicateReference" type="error" title="choose someone else" prominent>
+          <p>This person is your work experience reference. Your character reference and work experience reference must be different people.</p>
         </Alert>
       </v-col>
     </v-row>
@@ -149,8 +145,20 @@ export default defineComponent({
       const { valid } = await (this.$refs.upsertCharacterReferenceForm as typeof EceForm).$refs[characterReferenceUpsertForm.id].validate();
       if (valid) {
         //check for duplicate reference
+
         this.isDuplicateReference = false;
-        if (this.applicationStatus?.workExperienceReferencesStatus?.some((reference) => reference.firstName === this.formStore.formData.firstName)) {
+
+        const refSet = new Set<string>();
+
+        if (this.applicationStatus?.workExperienceReferencesStatus) {
+          for (const ref of this.applicationStatus.workExperienceReferencesStatus) {
+            if (ref.status !== "Rejected") {
+              refSet.add(`${ref.firstName?.toLowerCase()} ${ref.lastName?.toLowerCase()}`);
+            }
+          }
+        }
+
+        if (refSet.has(`${this.formStore.formData.firstName.toLowerCase()} ${this.formStore.formData.lastName.toLowerCase()}`)) {
           this.isDuplicateReference = true;
           //scroll to top of page
           window.scrollTo({

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/UpsertWorkExperienceReference.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/UpsertWorkExperienceReference.vue
@@ -5,12 +5,8 @@
     </v-breadcrumbs>
     <v-row>
       <v-col>
-        <Alert v-model="isDuplicateReference" type="error">
-          <p class="small">
-            <b>choose someone else</b>
-            <br />
-            This person is already your character reference. Your work experience reference and character reference must be different people.
-          </p>
+        <Alert v-model="isDuplicateReference" type="error" title="choose someone else" prominent>
+          <p>This person is already your character reference. Your work experience reference and character reference must be different people.</p>
         </Alert>
       </v-col>
     </v-row>
@@ -153,7 +149,17 @@ export default defineComponent({
       if (valid) {
         //check for duplicate reference
         this.isDuplicateReference = false;
-        if (this.applicationStatus?.characterReferencesStatus?.some((reference) => reference.firstName === this.formStore.formData.firstName)) {
+        const refSet = new Set<string>();
+
+        if (this.applicationStatus?.characterReferencesStatus) {
+          for (const ref of this.applicationStatus.characterReferencesStatus) {
+            if (ref.status !== "Rejected") {
+              refSet.add(`${ref.firstName?.toLowerCase()} ${ref.lastName?.toLowerCase()}`);
+            }
+          }
+        }
+
+        if (refSet.has(`${this.formStore.formData.firstName.toLowerCase()} ${this.formStore.formData.lastName.toLowerCase()}`)) {
           this.isDuplicateReference = true;
           //scroll to top of page
           window.scrollTo({

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/application.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/application.ts
@@ -56,11 +56,11 @@ export const useApplicationStore = defineStore("application", {
       const refSet = new Set<string>();
 
       for (const ref of state.draftApplication.characterReferences) {
-        refSet.add(`${ref.firstName} ${ref.lastName} ${ref.emailAddress}`);
+        refSet.add(`${ref.firstName} ${ref.lastName}`);
       }
 
       for (const ref of state.draftApplication.workExperienceReferences) {
-        if (refSet.has(`${ref.firstName} ${ref.lastName} ${ref.emailAddress}`)) {
+        if (refSet.has(`${ref.firstName} ${ref.lastName}`)) {
           return true;
         }
       }


### PR DESCRIPTION
---
name: ECER-2197: Add validation to new references being added after application submitted to ensure they're different
about: Add validation to new references being added after application submitted to ensure they're different
---

## Title
ECER-2197: Add validation to new references being added after application submitted to ensure they're different

## Description

- Added checks to prevent duplicate references
- Updated application.ts to remove check for email address while checking for duplicate references
- Added and configured alert component for upsert character and work exp references 
- Alert component is configured as:
  - Alert with the error summary should got at the top of the page 
  - On submit, it will auto scroll user to the top of the page
  - Alert can be dismissed by the user by tapping on the x
  - Alert stays present until dismissed my the user or until the submit button is pressed
  - Even if the alert is dismissed by the user, on submit it must always show

## Related Jira Issue(s)

- ECER-2197


## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Check on upsert character reference:

![image](https://github.com/bcgov/ECC-ECER/assets/160776397/9ac47d42-fd4b-4a4d-a100-6bc907cd3c31)

Check on upsert work experience reference:

![image](https://github.com/bcgov/ECC-ECER/assets/160776397/91b0475a-6723-4a0a-8cec-0504c17581c9)


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.