### PR TITLE
ECER-2258 - FE: Portal User can Reply to messages sent from Registry.

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/api/message.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/api/message.ts
@@ -28,4 +28,9 @@ const markMessageAsRead = async (messageId: string): Promise<ApiResponse<Compone
   );
 };
 
-export { getMessages, getMessagesStatus, markMessageAsRead };
+const sendMessage = async (sendMessageRequest: Components.Schemas.SendMessageRequest): Promise<ApiResponse<Components.Schemas.SendMessageResponse>> => {
+  const client = await getClient();
+  return apiResultHandler.execute<Components.Schemas.SendMessageResponse>(client.message_post(null, sendMessageRequest), "message_post");
+};
+
+export { getMessages, getMessagesStatus, markMessageAsRead, sendMessage };

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Message.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Message.vue
@@ -12,6 +12,7 @@
           <v-btn prepend-icon="mdi-close" text="Close" @click="messageStore.currentMessage = null"></v-btn>
         </v-toolbar>
         <v-card-text>
+          <v-btn prepend-icon="mdi-reply" variant="text" color="primary" text="Reply" @click="handleMessageReply">Reply</v-btn>
           <h2>{{ messageStore.currentMessage?.subject }}</h2>
           <p class="small mt-2">{{ messageDate }}</p>
           <p class="small mt-6">
@@ -21,7 +22,8 @@
       </v-card>
     </v-dialog>
   </div>
-  <div v-if="mdAndUp">
+  <div v-if="mdAndUp && messageStore.currentMessage != null">
+    <v-btn prepend-icon="mdi-reply" variant="text" color="primary" text="Reply" @click="handleMessageReply">Reply</v-btn>
     <h2>{{ messageStore.currentMessage?.subject }}</h2>
     <p class="small mt-2">{{ messageDate }}</p>
     <p class="small mt-6">
@@ -53,6 +55,9 @@ export default defineComponent({
   },
   methods: {
     formatDate,
+    handleMessageReply() {
+      this.$router.push({ name: "replyToMessage", params: { messageId: this.messageStore.currentMessage?.id } });
+    },
   },
 });
 </script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ReplyToMessage.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ReplyToMessage.vue
@@ -1,0 +1,92 @@
+<template>
+  <PageContainer>
+    <v-row>
+      <v-col cols="12">
+        <v-btn prepend-icon="mdi-close" variant="text" text="Close" @click="showCloseDialog = true"></v-btn>
+
+        <hr class="w-full" />
+        <h1 class="mt-5">{{ messageStore.currentMessage?.subject }}</h1>
+        <v-row class="mt-5">
+          <v-col>
+            <div>Message</div>
+            <v-textarea
+              v-model="text"
+              class="mt-2"
+              auto-grow
+              counter="1000"
+              maxlength="1000"
+              color="primary"
+              variant="outlined"
+              hide-details="auto"
+              :rules="[Rules.required('Enter a message no longer than 1000 characters')]"
+            ></v-textarea>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col>
+            <v-btn size="large" color="primary" :loading="loadingStore.isLoading('message_post')" @click="handleReplyToMessage">Send</v-btn>
+          </v-col>
+        </v-row>
+      </v-col>
+    </v-row>
+  </PageContainer>
+  <ConfirmationDialog
+    :cancel-button-text="'Cancel'"
+    :accept-button-text="'Delete message'"
+    :title="'Delete Message?'"
+    :show="showCloseDialog"
+    @cancel="showCloseDialog = false"
+    @accept="router.push('/messages')"
+  >
+    <template #confirmation-text>
+      <p>Your message will be deleted. It will not be sent.</p>
+    </template>
+  </ConfirmationDialog>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { useRouter } from "vue-router";
+
+import { sendMessage } from "@/api/message";
+import ConfirmationDialog from "@/components/ConfirmationDialog.vue";
+import PageContainer from "@/components/PageContainer.vue";
+import { useAlertStore } from "@/store/alert";
+import { useLoadingStore } from "@/store/loading";
+import { useMessageStore } from "@/store/message";
+import * as Rules from "@/utils/formRules";
+
+export default defineComponent({
+  name: "ReplyToMessage",
+  components: { PageContainer, ConfirmationDialog },
+  setup() {
+    const messageStore = useMessageStore();
+    const loadingStore = useLoadingStore();
+    const alertStore = useAlertStore();
+    const router = useRouter();
+    return { messageStore, loadingStore, alertStore, router };
+  },
+  data() {
+    return {
+      text: " ",
+      Rules,
+      showCloseDialog: false,
+    };
+  },
+  methods: {
+    async handleReplyToMessage() {
+      if (this.text.trim().length > 0) {
+        const { error } = await sendMessage({ communication: { id: this.messageStore.currentMessage?.id, text: this.text } });
+        if (error) {
+          this.alertStore.setFailureAlert("Sorry, something went wrong and your changes could not be saved. Try again later.");
+        } else {
+          this.alertStore.setSuccessAlert("Message sent sucessfully.");
+          this.router.push("/messages");
+        }
+      } else {
+        this.alertStore.setFailureAlert("You must enter all required fields in the valid format to continue.");
+      }
+    },
+  },
+});
+</script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/router.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/router.ts
@@ -27,6 +27,12 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
+      path: "/messages/:messageId/reply",
+      name: "replyToMessage",
+      component: () => import("./components/ReplyToMessage.vue"),
+      meta: { requiresAuth: true },
+    },
+    {
       path: "/login",
       component: () => import("./components/pages/Login.vue"),
       meta: { requiresAuth: false },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
@@ -263,6 +263,21 @@ declare namespace Components {
     export interface SaveDraftApplicationRequest {
       draftApplication?: DraftApplication;
     }
+    /**
+     * Send Message Request
+     */
+    export interface SendMessageRequest {
+      communication?: Communication;
+    }
+    /**
+     * Send Message Response
+     */
+    export interface SendMessageResponse {
+      /**
+       *
+       */
+      communicationId?: string | null;
+    }
     export interface SubmitApplicationResponse {
       applicationId?: string | null;
     }
@@ -554,6 +569,14 @@ declare namespace Paths {
       export type $200 = Components.Schemas.Communication[];
     }
   }
+  namespace MessagePost {
+    export type RequestBody = /* Send Message Request */ Components.Schemas.SendMessageRequest;
+    namespace Responses {
+      export type $200 = /* Send Message Response */ Components.Schemas.SendMessageResponse;
+      export type $400 = Components.Schemas.ProblemDetails | Components.Schemas.HttpValidationProblemDetails;
+      export interface $404 {}
+    }
+  }
   namespace MessageStatusGet {
     namespace Responses {
       export type $200 = Components.Schemas.CommunicationsStatusResults;
@@ -706,6 +729,14 @@ export interface OperationMethods {
     data?: any,
     config?: AxiosRequestConfig,
   ): OperationResponse<Paths.MessageGet.Responses.$200>;
+  /**
+   * message_post - Handles message send request
+   */
+  "message_post"(
+    parameters?: Parameters<UnknownParamsObject> | null,
+    data?: Paths.MessagePost.RequestBody,
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.MessagePost.Responses.$200>;
   /**
    * communication_put - Marks a communication as seen
    */
@@ -892,6 +923,14 @@ export interface PathsDictionary {
      * message_get - Handles messages queries
      */
     "get"(parameters?: Parameters<UnknownParamsObject> | null, data?: any, config?: AxiosRequestConfig): OperationResponse<Paths.MessageGet.Responses.$200>;
+    /**
+     * message_post - Handles message send request
+     */
+    "post"(
+      parameters?: Parameters<UnknownParamsObject> | null,
+      data?: Paths.MessagePost.RequestBody,
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.MessagePost.Responses.$200>;
   };
   ["/api/messages/{id}/seen"]: {
     /**


### PR DESCRIPTION
---
name: ECER-2258 - FE: Create reply to message page and expose in header on message list view
about: FE: Create reply to message page and expose in header on message list view
---

## Title
ECER-2258 - FE: Create reply to message page and expose in header on message list view

## Description

- Added FE piece for sending messages
- Connect FE to BE for sending messages
- Added required validations
- Added required page redirections

## Related Jira Issue(s)

- ECER-2258
- ECER-1252

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)

![image](https://github.com/bcgov/ECC-ECER/assets/160776397/b375f08a-431a-4a71-bfa8-ae11c587c55e)

![image](https://github.com/bcgov/ECC-ECER/assets/160776397/1880fe3e-80f5-48fd-b390-7b52d8ce851a)

![image](https://github.com/bcgov/ECC-ECER/assets/160776397/889a432d-89d3-4a92-a548-625c5aca1354)

![image](https://github.com/bcgov/ECC-ECER/assets/160776397/4d418fc1-30c5-4725-8f41-113a72d3fa01)

