### PR TITLE
ECER-2316- ECER-2317- ECER-1254: Backend piece for communication

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Communications/CommunicationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Communications/CommunicationsEndpoints.cs
@@ -13,7 +13,7 @@ public class CommunicationsEndpoints : IRegisterEndpoints
 {
   public void Register(IEndpointRouteBuilder endpointRouteBuilder)
   {
-    endpointRouteBuilder.MapGet("/api/messages", async (HttpContext httpContext, IMediator messageBus, IMapper mapper, IOptions<PaginationSettings> paginationOptions) =>
+    endpointRouteBuilder.MapGet("/api/messages/{parentId?}", async (string? parentId, HttpContext httpContext, IMediator messageBus, IMapper mapper, IOptions<PaginationSettings> paginationOptions) =>
     {
       var userContext = httpContext.User.GetUserContext();
 
@@ -24,6 +24,7 @@ public class CommunicationsEndpoints : IRegisterEndpoints
       var query = new UserCommunicationQuery
       {
         ByRegistrantId = userContext!.UserId,
+        ByParentId = parentId,
         ByStatus = [ECER.Managers.Registry.Contract.Communications.CommunicationStatus.NotifiedRecipient, ECER.Managers.Registry.Contract.Communications.CommunicationStatus.Acknowledged],
         PageNumber = pageNumber,
         PageSize = pageSize

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Communications/CommunicationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Communications/CommunicationsEndpoints.cs
@@ -16,7 +16,7 @@ public class CommunicationsEndpoints : IRegisterEndpoints
     endpointRouteBuilder.MapGet("/api/messages/{parentId?}", async (string? parentId, HttpContext httpContext, IMediator messageBus, IMapper mapper, IOptions<PaginationSettings> paginationOptions) =>
     {
       var userContext = httpContext.User.GetUserContext();
-
+      bool IdIsNotGuid = !Guid.TryParse(parentId, out _); if (IdIsNotGuid && parentId != null) { parentId = null; }
       // Get pagination parameters from the query string with default values
       var pageNumber = int.TryParse(httpContext.Request.Query[paginationOptions.Value.PageProperty], out var page) ? page : paginationOptions.Value.DefaultPageNumber;
       var pageSize = int.TryParse(httpContext.Request.Query[paginationOptions.Value.PageSizeProperty], out var size) ? size : paginationOptions.Value.DefaultPageSize;

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Communications/CommunicationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Communications/CommunicationsEndpoints.cs
@@ -125,10 +125,17 @@ public record Communication
   public string Id { get; set; } = null!;
   public string Subject { get; set; } = null!;
   public string Text { get; set; } = null!;
-  public string From { get; set; } = string.Empty;
+  public InitiatedFrom From { get; set; }
   public bool Acknowledged { get; set; }
   public DateTime NotifiedOn { get; set; }
   public CommunicationStatus Status { get; set; }
+}
+
+public enum InitiatedFrom
+{
+  Investigation,
+  Registrant,
+  Registry,
 }
 
 public enum CommunicationStatus

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Communications/CommunicationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Communications/CommunicationsEndpoints.cs
@@ -125,6 +125,7 @@ public record Communication
   public string Id { get; set; } = null!;
   public string Subject { get; set; } = null!;
   public string Text { get; set; } = null!;
+  public string From { get; set; } = string.Empty;
   public bool Acknowledged { get; set; }
   public DateTime NotifiedOn { get; set; }
   public CommunicationStatus Status { get; set; }

--- a/src/ECER.Managers.Registry.Contract/Communications/Contract.cs
+++ b/src/ECER.Managers.Registry.Contract/Communications/Contract.cs
@@ -37,6 +37,7 @@ public record Communication
   public string Id { get; set; } = null!;
   public string Subject { get; set; } = null!;
   public string Text { get; set; } = null!;
+  public string From { get; set; } = null!;
   public DateTime NotifiedOn { get; set; }
   public bool Acknowledged { get; set; }
   public CommunicationStatus Status { get; set; }

--- a/src/ECER.Managers.Registry.Contract/Communications/Contract.cs
+++ b/src/ECER.Managers.Registry.Contract/Communications/Contract.cs
@@ -16,6 +16,7 @@ public record UserCommunicationQuery : IRequest<CommunicationsQueryResults>
 {
   public string? ById { get; set; }
   public string? ByRegistrantId { get; set; }
+  public string? ByParentId { get; set; }
   public IEnumerable<CommunicationStatus>? ByStatus { get; set; }
   public int PageNumber { get; set; }
   public int PageSize { get; set; }

--- a/src/ECER.Managers.Registry.Contract/Communications/Contract.cs
+++ b/src/ECER.Managers.Registry.Contract/Communications/Contract.cs
@@ -37,7 +37,7 @@ public record Communication
   public string Id { get; set; } = null!;
   public string Subject { get; set; } = null!;
   public string Text { get; set; } = null!;
-  public string From { get; set; } = null!;
+  public InitiatedFrom From { get; set; }
   public DateTime NotifiedOn { get; set; }
   public bool Acknowledged { get; set; }
   public CommunicationStatus Status { get; set; }
@@ -49,6 +49,13 @@ public enum CommunicationStatus
   NotifiedRecipient,
   Acknowledged,
   Inactive
+}
+
+public enum InitiatedFrom
+{
+  Investigation,
+  Registrant,
+  Registry,
 }
 
 public record CommunicationsStatusResults(CommunicationsStatus Status);

--- a/src/ECER.Managers.Registry/CommunicationHandlers.cs
+++ b/src/ECER.Managers.Registry/CommunicationHandlers.cs
@@ -41,6 +41,7 @@ public class CommunicationHandlers(ICommunicationRepository communicationReposit
     {
       ById = request.ById,
       ByRegistrantId = request.ByRegistrantId,
+      ByParentId = request.ByParentId,
       ByStatus = request.ByStatus?.Convert<Contract.Communications.CommunicationStatus, Resources.Accounts.Communications.CommunicationStatus>(),
       PageNumber = request.PageNumber,
       PageSize = request.PageSize,

--- a/src/ECER.Resources.Accounts/Communications/CommunicationRepository.cs
+++ b/src/ECER.Resources.Accounts/Communications/CommunicationRepository.cs
@@ -37,6 +37,16 @@ internal class CommunicationRepository : ICommunicationRepository
     // Filtering by registrant ID
     if (query.ByRegistrantId != null) communications = communications.Where(r => r.c.ecer_Registrantid.Id == Guid.Parse(query.ByRegistrantId));
 
+    // returning just child communications based on parent id
+    if (query.ByParentId != null)
+    {
+      communications = communications.Where(r => r.c.ecer_ParentCommunicationid.Id == Guid.Parse(query.ByParentId));
+    }
+    // otherwise returning just parent communications
+    else
+    {
+      communications = communications.Where(r => r.c.ecer_ParentCommunicationid == null);
+    }
     if (query.PageNumber > 0)
     {
       communications = communications.OrderByDescending(r => r.c.ecer_DateNotified).Skip((query.PageNumber - 1) * query.PageSize).Take(query.PageSize);
@@ -69,9 +79,7 @@ internal class CommunicationRepository : ICommunicationRepository
   public async Task<string> SendMessage(Communication communication, string userId, CancellationToken cancellationToken)
   {
     await Task.CompletedTask;
-    var existingCommunication = context.ecer_CommunicationSet.SingleOrDefault(
-      d => d.ecer_CommunicationId == Guid.Parse(communication.Id!)
-      );
+    var existingCommunication = context.ecer_CommunicationSet.SingleOrDefault(d => d.ecer_CommunicationId == Guid.Parse(communication.Id!));
     if (existingCommunication == null)
     {
       throw new InvalidOperationException($"Communication '{communication.Id}' not found");

--- a/src/ECER.Resources.Accounts/Communications/CommunicationRepository.cs
+++ b/src/ECER.Resources.Accounts/Communications/CommunicationRepository.cs
@@ -1,9 +1,7 @@
-﻿using AngleSharp.Io;
-using AutoMapper;
+﻿using AutoMapper;
 using ECER.Utilities.DataverseSdk.Model;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
-using System.Drawing.Printing;
 
 namespace ECER.Resources.Accounts.Communications;
 

--- a/src/ECER.Resources.Accounts/Communications/CommunicationRepository.cs
+++ b/src/ECER.Resources.Accounts/Communications/CommunicationRepository.cs
@@ -41,11 +41,6 @@ internal class CommunicationRepository : ICommunicationRepository
     // returning just child communications based on parent id
     if (query.ByParentId != null)
     {
-      bool IsNotGuid = !Guid.TryParse(query.ByParentId, out _);
-      if (IsNotGuid)
-      {
-        throw new InvalidOperationException($"Communication Id '{query.ByParentId}' is not valid");
-      }
       communications = communications.Where(r => r.c.ecer_ParentCommunicationid.Id == Guid.Parse(query.ByParentId));
     }
     // otherwise returning just parent communications

--- a/src/ECER.Resources.Accounts/Communications/CommunicationRepository.cs
+++ b/src/ECER.Resources.Accounts/Communications/CommunicationRepository.cs
@@ -1,4 +1,5 @@
-﻿using AutoMapper;
+﻿using AngleSharp.Io;
+using AutoMapper;
 using ECER.Utilities.DataverseSdk.Model;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
@@ -40,6 +41,11 @@ internal class CommunicationRepository : ICommunicationRepository
     // returning just child communications based on parent id
     if (query.ByParentId != null)
     {
+      bool IsNotGuid = !Guid.TryParse(query.ByParentId, out _);
+      if (IsNotGuid)
+      {
+        throw new InvalidOperationException($"Communication Id '{query.ByParentId}' is not valid");
+      }
       communications = communications.Where(r => r.c.ecer_ParentCommunicationid.Id == Guid.Parse(query.ByParentId));
     }
     // otherwise returning just parent communications

--- a/src/ECER.Resources.Accounts/Communications/CommunicationRepositoryMapper.cs
+++ b/src/ECER.Resources.Accounts/Communications/CommunicationRepositoryMapper.cs
@@ -15,12 +15,14 @@ internal class CommunicationRepositoryMapper : Profile
      .ForMember(d => d.Id, opts => opts.MapFrom(s => s.ecer_CommunicationId))
      .ForMember(d => d.Body, opts => opts.MapFrom(s => htmlSanitizer.Sanitize(s.ecer_Message, "", null)))
      .ForMember(d => d.Subject, opts => opts.MapFrom(s => s.ecer_Name))
+     .ForMember(d => d.From, opts => opts.MapFrom(s => s.ecer_initiatedfromName))
      .ForMember(d => d.Acknowledged, opts => opts.MapFrom(s => s.ecer_Acknowledged))
      .ForMember(d => d.NotifiedOn, opts => opts.MapFrom(s => s.ecer_DateNotified))
      .ForMember(d => d.Status, opts => opts.MapFrom(s => s.StatusCode));
 
     CreateMap<Communication, ecer_Communication>(MemberList.Source)
      .ForSourceMember(s => s.Subject, opts => opts.DoNotValidate())
+     .ForSourceMember(s => s.From, opts => opts.DoNotValidate())
      .ForSourceMember(s => s.NotifiedOn, opts => opts.DoNotValidate())
      .ForSourceMember(s => s.Acknowledged, opts => opts.DoNotValidate())
      .ForSourceMember(s => s.Status, opts => opts.DoNotValidate())

--- a/src/ECER.Resources.Accounts/Communications/CommunicationRepositoryMapper.cs
+++ b/src/ECER.Resources.Accounts/Communications/CommunicationRepositoryMapper.cs
@@ -15,7 +15,7 @@ internal class CommunicationRepositoryMapper : Profile
      .ForMember(d => d.Id, opts => opts.MapFrom(s => s.ecer_CommunicationId))
      .ForMember(d => d.Body, opts => opts.MapFrom(s => htmlSanitizer.Sanitize(s.ecer_Message, "", null)))
      .ForMember(d => d.Subject, opts => opts.MapFrom(s => s.ecer_Name))
-     .ForMember(d => d.From, opts => opts.MapFrom(s => s.ecer_initiatedfromName))
+     .ForMember(d => d.From, opts => opts.MapFrom(s => s.ecer_InitiatedFrom))
      .ForMember(d => d.Acknowledged, opts => opts.MapFrom(s => s.ecer_Acknowledged))
      .ForMember(d => d.NotifiedOn, opts => opts.MapFrom(s => s.ecer_DateNotified))
      .ForMember(d => d.Status, opts => opts.MapFrom(s => s.StatusCode));
@@ -30,6 +30,9 @@ internal class CommunicationRepositoryMapper : Profile
      .ForMember(d => d.ecer_Message, opts => opts.MapFrom(s => htmlSanitizer.Sanitize(s.Body, "", null)));
 
     CreateMap<ecer_Communication_StatusCode, CommunicationStatus>()
+      .ConvertUsingEnumMapping(opts => opts.MapByName(true));
+
+    CreateMap<ecer_ParallelProcessCommunication_ecer_InitiatedFrom, InitiatedFrom>()
       .ConvertUsingEnumMapping(opts => opts.MapByName(true));
   }
 }

--- a/src/ECER.Resources.Accounts/Communications/ICommunicationRepository.cs
+++ b/src/ECER.Resources.Accounts/Communications/ICommunicationRepository.cs
@@ -30,7 +30,7 @@ public record Communication(string? Id)
 {
   public string Subject { get; set; } = string.Empty;
   public string Body { get; set; } = string.Empty;
-  public string From { get; set; } = string.Empty;
+  public InitiatedFrom From { get; set; }
   public DateTime NotifiedOn { get; set; }
   public bool Acknowledged { get; set; }
   public CommunicationStatus Status { get; set; }
@@ -42,6 +42,13 @@ public enum CommunicationStatus
   NotifiedRecipient,
   Acknowledged,
   Inactive
+}
+
+public enum InitiatedFrom
+{
+  Investigation,
+  Registrant,
+  Registry,
 }
 
 public record CommunicationsStatus

--- a/src/ECER.Resources.Accounts/Communications/ICommunicationRepository.cs
+++ b/src/ECER.Resources.Accounts/Communications/ICommunicationRepository.cs
@@ -21,6 +21,7 @@ public record UserCommunicationQuery
   public string? ById { get; set; }
   public IEnumerable<CommunicationStatus>? ByStatus { get; set; }
   public string? ByRegistrantId { get; set; }
+  public string? ByParentId { get; set; }
   public int PageNumber { get; set; }
   public int PageSize { get; set; }
 }

--- a/src/ECER.Resources.Accounts/Communications/ICommunicationRepository.cs
+++ b/src/ECER.Resources.Accounts/Communications/ICommunicationRepository.cs
@@ -30,6 +30,7 @@ public record Communication(string? Id)
 {
   public string Subject { get; set; } = string.Empty;
   public string Body { get; set; } = string.Empty;
+  public string From { get; set; } = string.Empty;
   public DateTime NotifiedOn { get; set; }
   public bool Acknowledged { get; set; }
   public CommunicationStatus Status { get; set; }

--- a/src/ECER.Tests/Integration/RegistryApi/CommunicationTests.cs
+++ b/src/ECER.Tests/Integration/RegistryApi/CommunicationTests.cs
@@ -14,12 +14,26 @@ public class CommunicationsTests : RegistryPortalWebAppScenarioBase
   }
 
   [Fact]
-  public async Task GetCommunications_ReturnsCommunications()
+  public async Task GetCommunications_ReturnsParentCommunications_byPage()
   {
     var communicationsResponse = await Host.Scenario(_ =>
     {
       _.WithExistingUser(this.Fixture.AuthenticatedBcscUserIdentity, this.Fixture.AuthenticatedBcscUserId);
       _.Get.Url("/api/messages?page=2&&pageSize=20");
+      _.StatusCodeShouldBeOk();
+    });
+
+    var communications = await communicationsResponse.ReadAsJsonAsync<Clients.RegistryPortal.Server.Communications.Communication[]>();
+    communications.ShouldNotBeNull();
+  }
+
+  [Fact]
+  public async Task GetCommunications_ReturnsChildCommunications_byPage()
+  {
+    var communicationsResponse = await Host.Scenario(_ =>
+    {
+      _.WithExistingUser(this.Fixture.AuthenticatedBcscUserIdentity, this.Fixture.AuthenticatedBcscUserId);
+      _.Get.Url($"/api/messages/{this.Fixture.communicationOneId}?page=2&&pageSize=20");
       _.StatusCodeShouldBeOk();
     });
 

--- a/src/ECER.Tests/Integration/RegistryPortalWebAppScenarioBase.cs
+++ b/src/ECER.Tests/Integration/RegistryPortalWebAppScenarioBase.cs
@@ -128,7 +128,7 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
     testCommunication1 = GetOrAddCommunication(context, inProgressTestApplication, "comm1", null);
     testCommunication2 = GetOrAddCommunication(context, inProgressTestApplication, "comm2", null);
     testCommunication3 = GetOrAddCommunication(context, inProgressTestApplication, "comm3", null);
-    testCommunication4 = GetOrAddCommunication(context, inProgressTestApplication, "comm4", testCommunication1.Id);
+    testCommunication4 = GetOrAddCommunication(context, inProgressTestApplication, "comm4", null);
 
     testPortalInvitationOne = GetOrAddPortalInvitation_CharacterReference(context, authenticatedBcscUser, "name1");
     testPortalInvitationCharacterReferenceSubmit = GetOrAddPortalInvitation_CharacterReference(context, authenticatedBcscUser, "name2");

--- a/src/ECER.Tests/Integration/RegistryPortalWebAppScenarioBase.cs
+++ b/src/ECER.Tests/Integration/RegistryPortalWebAppScenarioBase.cs
@@ -128,7 +128,7 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
     testCommunication1 = GetOrAddCommunication(context, inProgressTestApplication, "comm1", null);
     testCommunication2 = GetOrAddCommunication(context, inProgressTestApplication, "comm2", null);
     testCommunication3 = GetOrAddCommunication(context, inProgressTestApplication, "comm3", null);
-    testCommunication4 = GetOrAddCommunication(context, inProgressTestApplication, "comm4", null);
+    testCommunication4 = GetOrAddCommunication(context, inProgressTestApplication, "comm4", testCommunication1.Id);
 
     testPortalInvitationOne = GetOrAddPortalInvitation_CharacterReference(context, authenticatedBcscUser, "name1");
     testPortalInvitationCharacterReferenceSubmit = GetOrAddPortalInvitation_CharacterReference(context, authenticatedBcscUser, "name2");


### PR DESCRIPTION
---
name: Backend piece for communication
---

## Title
ECER-1254: Add from field to GET child and parent message endpoints
ECER-2316: Create endpoint to get child communication(s) by ecer_parentcommunicationid
ECER-2317: Update messages endpoint to return only parent-level communication records
## Description

- Messages endpoint modified to support both parent and child messages
- From field added to communication mapper
- etc.

## Related Jira Issue(s)

- ECER-1254
- ECER-2316
- ECER-2317
- etc.

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.