### PR TITLE
Stories/ecer 1791

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/appsettings.json
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/appsettings.json
@@ -15,10 +15,7 @@
         }
       }
     ],
-    "Enrich": [
-      "FromLogContext",
-      "WithMachineName"
-    ]
+    "Enrich": ["FromLogContext", "WithMachineName"]
   },
   "Pagination": {
     "DefaultPageSize": 10,
@@ -37,7 +34,7 @@
   "ContentSecurityPolicy": {
     "BaseUri": "'self'",
     "DefaultSource": "'self'",
-    "ScriptSource": "'self' 'unsafe-inline' 'unsafe-eval'",
+    "ScriptSource": "'self' 'unsafe-inline' 'unsafe-eval' https://www.recaptcha.net;",
     "ConnectSource": "'self' https://loginproxy.gov.bc.ca/ https://id.gov.bc.ca/",
     "ImageSource": "'self' data:",
     "StyleSource": "'self' 'unsafe-inline'",
@@ -55,9 +52,7 @@
     "Schemes": {
       "kc": {
         "Authority": "https://loginproxy.gov.bc.ca/auth/realms/childcare-applications",
-        "ValidAudiences": [
-          "childcare-ecer"
-        ],
+        "ValidAudiences": ["childcare-ecer"],
         "ValidIssuers": [
           "https://loginproxy.gov.bc.ca/auth/realms/childcare-applications"
         ]

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/appsettings.json
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/appsettings.json
@@ -34,7 +34,7 @@
   "ContentSecurityPolicy": {
     "BaseUri": "'self'",
     "DefaultSource": "'self'",
-    "ScriptSource": "'self' 'unsafe-inline' 'unsafe-eval' https://www.recaptcha.net;",
+    "ScriptSource": "'self' 'unsafe-inline' 'unsafe-eval' https://www.recaptcha.net/",
     "ConnectSource": "'self' https://loginproxy.gov.bc.ca/ https://id.gov.bc.ca/",
     "ImageSource": "'self' data:",
     "StyleSource": "'self' 'unsafe-inline'",

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCertificationTypePreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCertificationTypePreview.vue
@@ -1,5 +1,5 @@
 <template>
-  <PreviewCard :is-valid="wizardStore.validationState.CertificationType" title="Certification Selection" portal-stage="CertificationType">
+  <PreviewCard title="Certification Selection" portal-stage="CertificationType">
     <template #content>
       <v-row>
         <v-col cols="4">

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReference.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReference.vue
@@ -131,15 +131,6 @@ export default defineComponent({
       Rules,
     };
   },
-  methods: {
-    isNumber,
-    async updateCharacterReference() {
-      this.$emit("update:model-value", [
-        { firstName: this.firstName, lastName: this.lastName, emailAddress: this.emailAddress, phoneNumber: this.phoneNumber },
-      ] as Components.Schemas.CharacterReference);
-    },
-    isNotSpecialCharacterName,
-  },
   computed: {
     hasDuplicateReferences() {
       if (Object.values(this.wizardStore.wizardData.referenceList).length === 0 || this.wizardStore.wizardData.characterReferences.length === 0) {
@@ -160,6 +151,15 @@ export default defineComponent({
 
       return false;
     },
+  },
+  methods: {
+    isNumber,
+    async updateCharacterReference() {
+      this.$emit("update:model-value", [
+        { firstName: this.firstName, lastName: this.lastName, emailAddress: this.emailAddress, phoneNumber: this.phoneNumber },
+      ] as Components.Schemas.CharacterReference);
+    },
+    isNotSpecialCharacterName,
   },
 });
 </script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReferencePreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReferencePreview.vue
@@ -1,5 +1,5 @@
 <template>
-  <PreviewCard :is-valid="wizardStore.validationState.CharacterReferences" title="Character Reference" portal-stage="CharacterReferences">
+  <PreviewCard title="Character Reference" portal-stage="CharacterReferences">
     <template #content>
       <v-row>
         <v-col cols="4">

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceContactInformationPreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceContactInformationPreview.vue
@@ -1,5 +1,5 @@
 <template>
-  <PreviewCard :is-valid="wizardStore.validationState.ContactInformation" title="Contact Information" portal-stage="ContactInformation">
+  <PreviewCard title="Contact Information" portal-stage="ContactInformation">
     <template #content>
       <v-row>
         <v-col cols="4">

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
@@ -92,6 +92,17 @@
           <v-btn prepend-icon="mdi-plus" rounded="lg" color="alternate" @click="handleAddEducation">Add Education</v-btn>
         </v-row>
       </v-col>
+      <v-col>
+        <!-- this prevents form from proceeding if rules are not met -->
+        <v-input
+          :model-value="modelValue"
+          :rules="[
+            (v) => Object.keys(v).length > 0 || 'education required',
+            (v) => Object.keys(v).length >= numOfEducationRequired || `at least ${numOfEducationRequired} transcripts required`,
+          ]"
+          auto-hide="auto"
+        ></v-input>
+      </v-col>
     </div>
   </v-row>
 </template>
@@ -178,6 +189,18 @@ export default defineComponent({
       } else {
         return "Course";
       }
+    },
+    numOfEducationRequired() {
+      let numOfEducationRequired = 1;
+
+      this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id]?.includes(
+        CertificationType.SNE,
+      ) && numOfEducationRequired++;
+      this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id]?.includes(
+        CertificationType.ITE,
+      ) && numOfEducationRequired++;
+
+      return numOfEducationRequired;
     },
   },
 

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducationPreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducationPreview.vue
@@ -1,5 +1,5 @@
 <template>
-  <PreviewCard :is-valid="wizardStore.validationState.Education" title="Education" portal-stage="Education">
+  <PreviewCard title="Education" portal-stage="Education">
     <template #content>
       <div v-for="(education, id, index) in educations" :key="id">
         <v-divider v-if="index !== 0" :thickness="2" color="grey-lightest" class="border-opacity-100 my-6" />

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceWorkExperienceReferencePreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceWorkExperienceReferencePreview.vue
@@ -1,5 +1,5 @@
 <template>
-  <PreviewCard :is-valid="wizardStore.validationState.WorkReferences" title="Work Experience References" portal-stage="WorkReferences">
+  <PreviewCard title="Work Experience References" portal-stage="WorkReferences">
     <template #content>
       <div v-for="(experience, id, index) in references" :key="id">
         <v-divider v-if="index !== 0" :thickness="2" color="grey-lightest" class="border-opacity-100 my-6" />

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceWorkExperienceReferences.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceWorkExperienceReferences.vue
@@ -116,7 +116,7 @@
           <p class="small">You must enter 500 hours of work experience to submit your application.</p>
         </Alert>
       </v-col>
-      <v-col v-if="applicationStore.hasDuplicateReferences" sm="12" md="10" lg="8" xl="6">
+      <v-col v-if="hasDuplicateReferences" sm="12" md="10" lg="8" xl="6">
         <Alert type="error">
           <p class="small">Your work experience reference(s) cannot be the same as your character reference</p>
         </Alert>
@@ -134,6 +134,7 @@
       </v-col>
     </div>
   </v-row>
+  <v-input auto-hide="auto" :model-value="modelValue" :rules="[!hasDuplicateReferences, totalHours >= 500 || count >= 6]"></v-input>
 </template>
 
 <script lang="ts">
@@ -207,12 +208,50 @@ export default defineComponent({
     newClientId() {
       return Object.keys(this.modelValue).length + 1;
     },
+    hasDuplicateReferences() {
+      if (Object.values(this.wizardStore.wizardData.referenceList).length === 0 || this.wizardStore.wizardData.characterReferences.length === 0) {
+        return false;
+      }
+
+      const refSet = new Set<string>();
+
+      for (const ref of this.wizardStore.wizardData.characterReferences) {
+        refSet.add(`${ref.firstName} ${ref.lastName}`);
+      }
+
+      for (const ref of Object.values(this.wizardStore.wizardData.referenceList) as [Components.Schemas.WorkExperienceReference]) {
+        if (refSet.has(`${ref.firstName} ${ref.lastName}`)) {
+          return true;
+        }
+      }
+
+      return false;
+    },
   },
   mounted() {
     this.mode = "list";
   },
   methods: {
     isNumber,
+    // hasDuplicateReferences() {
+    //   if (Object.values(this.wizardStore.wizardData.referenceList).length === 0 || this.wizardStore.wizardData.characterReferences.length === 0) {
+    //     return false;
+    //   }
+
+    //   const refSet = new Set<string>();
+
+    //   for (const ref of this.wizardStore.wizardData.characterReferences) {
+    //     refSet.add(`${ref.firstName} ${ref.lastName}`);
+    //   }
+
+    //   for (const ref of Object.values(this.wizardStore.wizardData.referenceList) as [Components.Schemas.WorkExperienceReference]) {
+    //     if (refSet.has(`${ref.firstName} ${ref.lastName}`)) {
+    //       return true;
+    //     }
+    //   }
+
+    //   return false;
+    // },
     async handleSubmit() {
       // Validate the form
       const { valid } = await (this.$refs.addWorkExperienceReferenceForm as any).validate();

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceWorkExperienceReferences.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceWorkExperienceReferences.vue
@@ -233,25 +233,6 @@ export default defineComponent({
   },
   methods: {
     isNumber,
-    // hasDuplicateReferences() {
-    //   if (Object.values(this.wizardStore.wizardData.referenceList).length === 0 || this.wizardStore.wizardData.characterReferences.length === 0) {
-    //     return false;
-    //   }
-
-    //   const refSet = new Set<string>();
-
-    //   for (const ref of this.wizardStore.wizardData.characterReferences) {
-    //     refSet.add(`${ref.firstName} ${ref.lastName}`);
-    //   }
-
-    //   for (const ref of Object.values(this.wizardStore.wizardData.referenceList) as [Components.Schemas.WorkExperienceReference]) {
-    //     if (refSet.has(`${ref.firstName} ${ref.lastName}`)) {
-    //       return true;
-    //     }
-    //   }
-
-    //   return false;
-    // },
     async handleSubmit() {
       // Validate the form
       const { valid } = await (this.$refs.addWorkExperienceReferenceForm as any).validate();

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Application.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Application.vue
@@ -6,49 +6,16 @@
     <template #stepperHeader>
       <v-stepper-header>
         <template v-for="(step, index) in Object.values(wizardStore.steps)" :key="step.stage">
-          <v-stepper-item
-            color="primary"
-            :step="wizardStore.step"
-            :value="index + 1"
-            :title="step.title"
-            :rules="wizardStore.step <= index + 1 ? [] : [() => wizardStore.validationState[step.stage as Components.Schemas.PortalStage]]"
-          ></v-stepper-item>
+          <v-stepper-item color="primary" :step="wizardStore.step" :value="index + 1" :title="step.title"></v-stepper-item>
           <v-divider v-if="index !== Object.values(wizardStore.steps).length - 1" :key="`divider-${index}`" />
         </template>
       </v-stepper-header>
     </template>
     <template #PrintPreview>
-      <v-btn rounded="lg" variant="text" @click="wizardStore.allStageValidations ? printPage() : (showPrintDialog = true)">
+      <v-btn rounded="lg" variant="text" @click="printPage()">
         <v-icon color="secondary" icon="mdi-printer-outline" class="mr-2"></v-icon>
         <a class="small">Print Preview</a>
       </v-btn>
-
-      <ConfirmationDialog
-        :cancel-button-text="'Cancel'"
-        :accept-button-text="'Yes'"
-        :title="'Print Confirmation'"
-        :custom-button-variant="'text'"
-        :show="showPrintDialog"
-        :disabled="wizardStore.allStageValidations"
-        @cancel="showPrintDialog = false"
-        @accept="handleAcceptPrint"
-      >
-        <template #activator>
-          <span @click="wizardStore.allStageValidations ? printPage() : {}">
-            <v-icon color="secondary" icon="mdi-printer-outline" class="mr-2"></v-icon>
-            <a class="small">Print Preview</a>
-          </span>
-        </template>
-        <template #confirmation-text>
-          <p>
-            Your Application contains missing data and/or invalid data.
-            <br />
-            The printed preview will show which sections are incomplete
-          </p>
-          <br />
-          <p><b>Are you sure you want to proceed?</b></p>
-        </template>
-      </ConfirmationDialog>
     </template>
     <template #actions>
       <v-container class="mb-8">
@@ -118,11 +85,6 @@ export default defineComponent({
 
     return { applicationWizard, applicationStore, wizardStore, alertStore, userStore, certificationTypeStore, loadingStore };
   },
-  data() {
-    return {
-      showPrintDialog: false,
-    };
-  },
   computed: {
     showSaveButtons() {
       return (
@@ -137,14 +99,10 @@ export default defineComponent({
   },
   methods: {
     async handleSubmit() {
-      if (!this.wizardStore.allStageValidations) {
-        this.alertStore.setFailureAlert("Your application is incomplete. You need to complete it before you can submit.");
-      } else {
-        const submitApplicationResponse = await this.applicationStore.submitApplication();
+      const submitApplicationResponse = await this.applicationStore.submitApplication();
 
-        if (submitApplicationResponse?.applicationId) {
-          this.$router.push({ name: "submitted", params: { applicationId: submitApplicationResponse.applicationId } });
-        }
+      if (submitApplicationResponse?.applicationId) {
+        this.$router.push({ name: "submitted", params: { applicationId: submitApplicationResponse.applicationId } });
       }
     },
     async handleSaveAndContinue() {
@@ -245,11 +203,6 @@ export default defineComponent({
           dateOfBirth: this.wizardStore.wizardData[applicationWizard.steps.profile.form.inputs.dateOfBirth.id],
         });
       }
-    },
-    handleAcceptPrint() {
-      this.showPrintDialog = false;
-      /* creating a delay before printing - helps prevent warning dialog overlay in print preview */
-      setTimeout(this.printPage, 500);
     },
     printPage() {
       window.print();

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Application.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Application.vue
@@ -49,7 +49,6 @@
 import { defineComponent } from "vue";
 
 import { getProfile, putProfile } from "@/api/profile";
-import ConfirmationDialog from "@/components/ConfirmationDialog.vue";
 import Wizard from "@/components/Wizard.vue";
 import WizardHeader from "@/components/WizardHeader.vue";
 import applicationWizard from "@/config/application-wizard";
@@ -64,7 +63,7 @@ import { AddressType } from "@/utils/constant";
 
 export default defineComponent({
   name: "Application",
-  components: { Wizard, WizardHeader, ConfirmationDialog },
+  components: { Wizard, WizardHeader },
   setup: async () => {
     const wizardStore = useWizardStore();
     const userStore = useUserStore();

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/application.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/application.ts
@@ -50,23 +50,6 @@ export const useApplicationStore = defineStore("application", {
         }, 0) ?? 0
       );
     },
-    hasDuplicateReferences(state): boolean {
-      if (!state.draftApplication.characterReferences || !state.draftApplication.workExperienceReferences) return false;
-
-      const refSet = new Set<string>();
-
-      for (const ref of state.draftApplication.characterReferences) {
-        refSet.add(`${ref.firstName} ${ref.lastName}`);
-      }
-
-      for (const ref of state.draftApplication.workExperienceReferences) {
-        if (refSet.has(`${ref.firstName} ${ref.lastName}`)) {
-          return true;
-        }
-      }
-
-      return false;
-    },
   },
   actions: {
     async fetchApplications() {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/wizard.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/wizard.ts
@@ -3,9 +3,7 @@ import { defineStore } from "pinia";
 import type { Components } from "@/types/openapi";
 import type { ReferenceStage, Step, Wizard } from "@/types/wizard";
 import { AddressType } from "@/utils/constant";
-import { CertificationType } from "@/utils/constant";
 
-import { useApplicationStore } from "./application";
 import { useOidcStore } from "./oidc";
 import { useUserStore } from "./user";
 

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/wizard.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/wizard.ts
@@ -45,35 +45,6 @@ export const useWizardStore = defineStore("wizard", {
     currentStepStage(state): Components.Schemas.PortalStage | ReferenceStage {
       return this.steps[state.step - 1].stage;
     },
-    validationState(state): PortalStageValidation {
-      const applicationStore = useApplicationStore();
-
-      let numOfEducationRequired = 1;
-      state.wizardData[this.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id]?.includes(CertificationType.SNE) &&
-        numOfEducationRequired++;
-      state.wizardData[this.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id]?.includes(CertificationType.ITE) &&
-        numOfEducationRequired++;
-
-      return {
-        CertificationType: (state.wizardData[this.wizardConfig.steps.certificationType.form.inputs.certificationSelection.id].length || []) > 0,
-        Declaration:
-          state.wizardData[this.wizardConfig.steps.declaration.form.inputs.signedDate.id] !== null &&
-          state.wizardData[this.wizardConfig.steps.declaration.form.inputs.consentCheckbox.id] === true,
-        ContactInformation: true,
-        Education: Object.values(state.wizardData[this.wizardConfig.steps.education.form.inputs.educationList.id]).length >= numOfEducationRequired,
-        CharacterReferences:
-          (state.wizardData[this.wizardConfig.steps.characterReferences.form.inputs.characterReferences.id].length || []) > 0 &&
-          !applicationStore.hasDuplicateReferences,
-        WorkReferences:
-          Object.values(state.wizardData[this.wizardConfig.steps.workReference.form.inputs.referenceList.id]).length > 0 &&
-          applicationStore.totalWorkExperienceHours >= 500 &&
-          !applicationStore.hasDuplicateReferences,
-        Review: true,
-      };
-    },
-    allStageValidations() {
-      return !(Object.values(this.validationState).indexOf(false) > -1);
-    },
   },
   actions: {
     async initializeWizard(wizard: Wizard, draftApplication: Components.Schemas.DraftApplication): Promise<void> {


### PR DESCRIPTION
ECER-1791: Update validation in application wizard to always validate on save and continue

## Description

- Moved validation to occur on each step including education + work experience. 
- Note with education added in feedback for number of education based on program requirement. 
- Work experience, user must enter at least 500 hours or 6 work experiences. 
- Removed validation checks in preview cards since user should never be in an error state here. 
- Removed validation state + all stage validation from wizard.ts. 
- HasDuplicates check moved back to the character + work experience components. 
- Application.vue - removed check that information is in a valid state. User should always be in a valid state at this point.

## Random bug fix
- Added security content policy for recaptcha to load recaptcha script. 

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Duplicates check (will disappear when user changes the input)
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/6a44757e-8679-4089-89d8-7d5f63aabf5d)
Extra input check for education
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/389a2107-1468-453c-8ecc-bb9df9341f5f)


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.