### PR TITLE
adding in frame source for recaptcha

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/appsettings.json
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/appsettings.json
@@ -34,11 +34,12 @@
   "ContentSecurityPolicy": {
     "BaseUri": "'self'",
     "DefaultSource": "'self'",
-    "ScriptSource": "'self' 'unsafe-inline' 'unsafe-eval' https://www.recaptcha.net/",
+    "ScriptSource": "'self' 'unsafe-inline' 'unsafe-eval' https://www.recaptcha.net/recaptcha/ https://www.gstatic.com/recaptcha/",
     "ConnectSource": "'self' https://loginproxy.gov.bc.ca/ https://id.gov.bc.ca/",
     "ImageSource": "'self' data:",
     "StyleSource": "'self' 'unsafe-inline'",
     "FrameAncestors": "'self'",
+    "FrameSource": "'self' https://www.recaptcha.net/recaptcha/ https://www.gstatic.com/recaptcha/",
     "FormAction": "'self'"
   },
   "clientAuthenticationMethods": {

--- a/src/ECER.Utilities.Hosting/SecurityExtensions.cs
+++ b/src/ECER.Utilities.Hosting/SecurityExtensions.cs
@@ -76,6 +76,7 @@ public record CspSettings : IOptions<CspSettings>
   public string FontSource { get; set; } = string.Empty;
   public string FrameAncestors { get; set; } = string.Empty;
   public string FormAction { get; set; } = string.Empty;
+  public string FrameSource { get; set; } = string.Empty;
 
   public CspSettings Value => this;
 
@@ -88,7 +89,8 @@ public record CspSettings : IOptions<CspSettings>
     (string.IsNullOrWhiteSpace(StyleSource) ? "" : $"style-src {StyleSource};") +
     (string.IsNullOrWhiteSpace(FontSource) ? "" : $"font-src {this.FontSource};") +
     (string.IsNullOrWhiteSpace(FrameAncestors) ? "" : $"frame-ancestors {this.FrameAncestors};") +
-    (string.IsNullOrWhiteSpace(FormAction) ? "" : $"form-action {this.FormAction};")
+    (string.IsNullOrWhiteSpace(FormAction) ? "" : $"form-action {this.FormAction};") +
+    (string.IsNullOrWhiteSpace(FrameSource) ? "" : $"frame-src {this.FrameSource};")
   ;
 }
 


### PR DESCRIPTION
## Title
ECER-1596: This should remove the error when loading the iframe for recaptcha on the website. 

## Description

- Adding in FrameSource to CspSettings.

## Checklist
- [ ] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

Unable to test until this is deployed.
Error message in console.
![image](https://github.com/bcgov/ECC-ECER/assets/74216496/7c9a96ba-5df1-4c6d-aa44-55072cf24942)
