### PR TITLE
ECER-2387: Upload file to BE endpoint object storage upload

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Communications/CommunicationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Communications/CommunicationsEndpoints.cs
@@ -29,7 +29,6 @@ public class CommunicationsEndpoints : IRegisterEndpoints
         PageSize = pageSize
       };
       var results = await messageBus.Send<CommunicationsQueryResults>(query);
-
       return TypedResults.Ok(mapper.Map<IEnumerable<Communication>>(results.Items));
     })
      .WithOpenApi("Handles messages queries", string.Empty, "message_get")

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Files/FilesEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Files/FilesEndpoints.cs
@@ -1,0 +1,46 @@
+﻿using AutoMapper;
+using ECER.Managers.Admin.Contract.Files;
+using ECER.Utilities.Hosting;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using System.ComponentModel.DataAnnotations;
+
+namespace ECER.Clients.RegistryPortal.Server.Files;
+
+public class FilesEndpoints : IRegisterEndpoints
+{
+  public void Register(IEndpointRouteBuilder endpointRouteBuilder)
+  {
+    endpointRouteBuilder.MapPost("/api/files/{fileId}", async Task<Results<Ok<UploadFileResponse>, BadRequest<ProblemDetails>, NotFound>> (string fileId,
+        [FromHeader(Name = "file-classification")][Required] string classification,
+        [FromHeader(Name = "file-tag")] string? tags,
+        [FromForm(Name = "file")] IFormFile file, HttpContext httpContext, CancellationToken ct, IMediator messageBus, IMapper mapper) =>
+    {
+      if (!Guid.TryParse(fileId, out _))
+      {
+        return TypedResults.BadRequest(new ProblemDetails { Title = "Invalid GUID" });
+      }
+
+      if (file == null || file.Length == 0)
+      {
+        return TypedResults.BadRequest(new ProblemDetails { Title = "No file uploaded or file is empty" });
+      }
+      var fileProperties = new FileProperties() { Classification = classification, Tags = tags };
+      var folder = "tempfolder";
+      var files = httpContext.Request.Form.Files.Select(file => new FileData(new FileLocation(fileId, folder ?? string.Empty), fileProperties, file.FileName, file.ContentType, file.OpenReadStream())).ToList();
+      if (files.Count == 0) return TypedResults.BadRequest(new ProblemDetails { Title = "No files were uploaded" });
+      await messageBus.Send(new SaveFileCommand(files), ct);
+      return TypedResults.Ok(new UploadFileResponse(string.Empty));
+    })
+      .WithOpenApi("Handles upload file request", string.Empty, "upload_file")
+      .RequireAuthorization()
+      .DisableAntiforgery();
+  }
+}
+
+/// <summary>
+/// upload file Response
+/// </summary>
+/// <param name="fileId"></param>
+public record UploadFileResponse(string fileId);

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Files/FilesEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Files/FilesEndpoints.cs
@@ -4,6 +4,7 @@ using ECER.Utilities.Hosting;
 using MediatR;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using System.ComponentModel.DataAnnotations;
 
 namespace ECER.Clients.RegistryPortal.Server.Files;
@@ -15,7 +16,7 @@ public class FilesEndpoints : IRegisterEndpoints
     endpointRouteBuilder.MapPost("/api/files/{fileId}", async Task<Results<Ok<UploadFileResponse>, BadRequest<ProblemDetails>, NotFound>> (string fileId,
         [FromHeader(Name = "file-classification")][Required] string classification,
         [FromHeader(Name = "file-tag")] string? tags,
-        [FromForm(Name = "file")] IFormFile file, HttpContext httpContext, CancellationToken ct, IMediator messageBus, IMapper mapper) =>
+        [FromForm(Name = "file")] IFormFile file, HttpContext httpContext, CancellationToken ct, IMediator messageBus, IMapper mapper, IOptions<UploaderSettings> uploaderOptions) =>
     {
       if (!Guid.TryParse(fileId, out _))
       {
@@ -27,11 +28,11 @@ public class FilesEndpoints : IRegisterEndpoints
         return TypedResults.BadRequest(new ProblemDetails { Title = "No file uploaded or file is empty" });
       }
       var fileProperties = new FileProperties() { Classification = classification, Tags = tags };
-      var folder = "tempfolder";
-      var files = httpContext.Request.Form.Files.Select(file => new FileData(new FileLocation(fileId, folder ?? string.Empty), fileProperties, file.FileName, file.ContentType, file.OpenReadStream())).ToList();
+
+      var files = httpContext.Request.Form.Files.Select(file => new FileData(new FileLocation(fileId, uploaderOptions.Value.TempFolderName ?? string.Empty), fileProperties, file.FileName, file.ContentType, file.OpenReadStream())).ToList();
       if (files.Count == 0) return TypedResults.BadRequest(new ProblemDetails { Title = "No files were uploaded" });
       await messageBus.Send(new SaveFileCommand(files), ct);
-      return TypedResults.Ok(new UploadFileResponse(string.Empty));
+      return TypedResults.Ok(new UploadFileResponse(fileId));
     })
       .WithOpenApi("Handles upload file request", string.Empty, "upload_file")
       .RequireAuthorization()

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Program.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Program.cs
@@ -46,6 +46,7 @@ public class Program
       builder.Services.Configure<JsonOptions>(opts => opts.SerializerOptions.Converters.Add(new JsonStringEnumConverter()));
       builder.Services.Configure<Microsoft.AspNetCore.Mvc.JsonOptions>(opts => opts.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
       builder.Services.Configure<PaginationSettings>(builder.Configuration.GetSection("Pagination"));
+      builder.Services.Configure<UploaderSettings>(builder.Configuration.GetSection("Uploader"));
       builder.Services.Configure<RecaptchaSettings>(builder.Configuration.GetSection("Recaptcha"));
       builder.Services.AddProblemDetails();
 
@@ -141,6 +142,11 @@ public class PaginationSettings
   public int DefaultPageNumber { get; set; }
   public string PageProperty { get; set; } = string.Empty;
   public string PageSizeProperty { get; set; } = string.Empty;
+}
+
+public class UploaderSettings
+{
+  public string TempFolderName { get; set; } = string.Empty;
 }
 
 public class RecaptchaSettings

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/appsettings.json
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/appsettings.json
@@ -26,6 +26,9 @@
     "PageProperty": "page",
     "PageSizeProperty": "pageSize"
   },
+  "Uploader": {
+    "TempFolderName": "tempfolder"
+  },
   "AllowedHosts": "*",
   "DisabledHttpVerbs": "TRACE, OPTIONS",
   "Dataverse": {

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/appsettings.json
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/appsettings.json
@@ -67,6 +67,6 @@
   "Recaptcha": {
     "Url": "https://www.google.com/recaptcha/api/siteverify",
     "Secret": "[recaptcha secret]",
-    "SiteKey":  "[site key]"
+    "SiteKey": "[site key]"
   }
 }

--- a/src/ECER.Managers.Registry/ECER.Managers.Registry.csproj
+++ b/src/ECER.Managers.Registry/ECER.Managers.Registry.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\ECER.Managers.Registry.Contract\ECER.Managers.Registry.Contract.csproj" />
     <ProjectReference Include="..\ECER.Resources.Accounts\ECER.Resources.Accounts.csproj" />
     <ProjectReference Include="..\ECER.Resources.Documents\ECER.Resources.Documents.csproj" />
+    <ProjectReference Include="..\ECER.Utilities.ObjectStorage\ECER.Utilities.ObjectStorage.csproj" />
     <ProjectReference Include="..\ECER.Utilities.Security\ECER.Utilities.Security.csproj" />
   </ItemGroup>
 </Project>

--- a/src/ECER.Tests/Integration/RegistryApi/FileTests.cs
+++ b/src/ECER.Tests/Integration/RegistryApi/FileTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Net.Http.Headers;
 using Alba;
 using Bogus;
-using Shouldly;
 using Xunit.Abstractions;
 using Xunit.Categories;
 
@@ -41,24 +40,5 @@ public class FileTests : RegistryPortalWebAppScenarioBase
       _.Post.MultipartFormData(formData).ToUrl($"/api/files/{testFileId}");
       _.StatusCodeShouldBeOk();
     });
-
-    var response = await Host.Scenario(_ =>
-    {
-      _.WithRequestHeader("file-folder", testFolder);
-      _.Get.Url($"/api/files/{testFileId}");
-      _.StatusCodeShouldBeOk();
-    });
-
-    response.Context.Response.Headers["Content-Type"].ToString().ShouldBe(testFile.ContentType);
-    response.Context.Response.Headers["Content-Disposition"].ToString().Split(';').Select(s => s.Trim()).ShouldContain($"filename={testFile.FileName}");
-    response.Context.Response.Headers["file-folder"].ToString().ShouldBe(testFolder);
-    response.Context.Response.Headers["file-tag"].ToString().ShouldBe(testTags);
-    response.Context.Response.Headers["file-classification"].ToString().ShouldBe(testClassification);
-
-    var returnedFile = await response.ReadAsTextAsync();
-    returnedFile.Length.ShouldBe(fileLength);
-    testFile.Content.Position = 0;
-    using var sw = new StreamReader(testFile.Content);
-    returnedFile.ShouldBe(await sw.ReadToEndAsync());
   }
 }

--- a/src/ECER.Tests/Integration/RegistryApi/FileTests.cs
+++ b/src/ECER.Tests/Integration/RegistryApi/FileTests.cs
@@ -1,0 +1,64 @@
+﻿using System.Net.Http.Headers;
+using Alba;
+using Bogus;
+using Shouldly;
+using Xunit.Abstractions;
+using Xunit.Categories;
+
+namespace ECER.Tests.Integration.RegistryApi;
+
+public class FileTests : RegistryPortalWebAppScenarioBase
+{
+  private readonly Faker faker = new Faker("en_CA");
+
+  public FileTests(ITestOutputHelper output, RegistryPortalWebAppFixture fixture) : base(output, fixture)
+  { }
+
+  [Fact]
+  [Category("VPN")]
+  public async Task CanUploadFile()
+  {
+    var fileLength = 1041;
+    var testFile = await faker.GenerateTestFile(fileLength);
+    var testFileId = Guid.NewGuid().ToString();
+    var testFolder = "integrationtests";
+    var testTags = "tag1=1,tag2=2";
+    var testClassification = "test-classification";
+    using var content = new StreamContent(testFile.Content);
+    content.Headers.ContentType = new MediaTypeHeaderValue(testFile.ContentType);
+
+    using var formData = new MultipartFormDataContent
+        {
+          { content, "file", testFile.FileName }
+        };
+
+    await Host.Scenario(_ =>
+    {
+      _.WithExistingUser(this.Fixture.AuthenticatedBcscUserIdentity, this.Fixture.AuthenticatedBcscUserId);
+      _.WithRequestHeader("file-classification", testClassification);
+      _.WithRequestHeader("file-tag", testTags);
+      _.WithRequestHeader("file-folder", testFolder);
+      _.Post.MultipartFormData(formData).ToUrl($"/api/files/{testFileId}");
+      _.StatusCodeShouldBeOk();
+    });
+
+    var response = await Host.Scenario(_ =>
+    {
+      _.WithRequestHeader("file-folder", testFolder);
+      _.Get.Url($"/api/files/{testFileId}");
+      _.StatusCodeShouldBeOk();
+    });
+
+    response.Context.Response.Headers["Content-Type"].ToString().ShouldBe(testFile.ContentType);
+    response.Context.Response.Headers["Content-Disposition"].ToString().Split(';').Select(s => s.Trim()).ShouldContain($"filename={testFile.FileName}");
+    response.Context.Response.Headers["file-folder"].ToString().ShouldBe(testFolder);
+    response.Context.Response.Headers["file-tag"].ToString().ShouldBe(testTags);
+    response.Context.Response.Headers["file-classification"].ToString().ShouldBe(testClassification);
+
+    var returnedFile = await response.ReadAsTextAsync();
+    returnedFile.Length.ShouldBe(fileLength);
+    testFile.Content.Position = 0;
+    using var sw = new StreamReader(testFile.Content);
+    returnedFile.ShouldBe(await sw.ReadToEndAsync());
+  }
+}


### PR DESCRIPTION
## Title
ECER-2328: support file upload backend with automated test

## Description

- Upload file endpoint added to registry project
- Uploader with multipart file handler added
- Automated test added for file upload endpoint

VPN Required to run automated test and upload file to S3

## Related Jira Issue(s)

- ECER-2328
- ECER-2386

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.