### PR TITLE
ECER-1305: Suppress error toast for getReference call (REWORK)

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/api/application.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/api/application.ts
@@ -7,7 +7,7 @@ const apiResultHandler = new ApiResultHandler();
 const getApplications = async (): Promise<ApiResponse<Components.Schemas.Application[] | null | undefined>> => {
   const client = await getClient();
 
-  return apiResultHandler.execute<Components.Schemas.Application[] | null | undefined>(client.application_get({ id: "" }));
+  return apiResultHandler.execute<Components.Schemas.Application[] | null | undefined>({ request: client.application_get({ id: "" }) });
 };
 
 const createOrUpdateDraftApplication = async (
@@ -21,7 +21,9 @@ const createOrUpdateDraftApplication = async (
     id: application.id || "",
   };
 
-  return apiResultHandler.execute<Components.Schemas.DraftApplicationResponse | null | undefined>(client.draftapplication_put(pathParameters, body));
+  return apiResultHandler.execute<Components.Schemas.DraftApplicationResponse | null | undefined>({
+    request: client.draftapplication_put(pathParameters, body),
+  });
 };
 
 const submitDraftApplication = async (applicationId: string): Promise<ApiResponse<Components.Schemas.SubmitApplicationResponse | null | undefined>> => {
@@ -30,7 +32,10 @@ const submitDraftApplication = async (applicationId: string): Promise<ApiRespons
     id: applicationId,
   };
 
-  return apiResultHandler.execute<Components.Schemas.SubmitApplicationResponse | null | undefined>(client.application_post(null, body), "application_post");
+  return apiResultHandler.execute<Components.Schemas.SubmitApplicationResponse | null | undefined>({
+    request: client.application_post(null, body),
+    key: "application_post",
+  });
 };
 
 const cancelDraftApplication = async (applicationId: string): Promise<ApiResponse<Components.Schemas.SubmitApplicationResponse | null | undefined>> => {
@@ -39,7 +44,9 @@ const cancelDraftApplication = async (applicationId: string): Promise<ApiRespons
     id: applicationId,
   };
 
-  return await apiResultHandler.execute<Components.Schemas.SubmitApplicationResponse | null | undefined>(client.draftapplication_delete(pathParameters));
+  return await apiResultHandler.execute<Components.Schemas.SubmitApplicationResponse | null | undefined>({
+    request: client.draftapplication_delete(pathParameters),
+  });
 };
 
 const getApplicationStatus = async (applicationId: string): Promise<ApiResponse<Components.Schemas.SubmittedApplicationStatus | null | undefined>> => {
@@ -48,7 +55,9 @@ const getApplicationStatus = async (applicationId: string): Promise<ApiResponse<
     id: applicationId,
   };
 
-  return await apiResultHandler.execute<Components.Schemas.SubmittedApplicationStatus | null | undefined>(client.application_status_get(pathParameters));
+  return await apiResultHandler.execute<Components.Schemas.SubmittedApplicationStatus | null | undefined>({
+    request: client.application_status_get(pathParameters),
+  });
 };
 
 export { cancelDraftApplication, createOrUpdateDraftApplication, getApplications, getApplicationStatus, submitDraftApplication };

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/api/message.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/api/message.ts
@@ -6,18 +6,18 @@ const apiResultHandler = new ApiResultHandler();
 
 const getMessagesStatus = async (): Promise<ApiResponse<Components.Schemas.CommunicationsStatusResults | null>> => {
   const client = await getClient();
-  return apiResultHandler.execute<Components.Schemas.CommunicationsStatusResults>(client.message_status_get());
+  return apiResultHandler.execute<Components.Schemas.CommunicationsStatusResults>({ request: client.message_status_get() });
 };
 
 const getMessages = async (): Promise<ApiResponse<Components.Schemas.Communication[] | null | undefined>> => {
   const client = await getClient();
-  return apiResultHandler.execute<Components.Schemas.Communication[]>(client.message_get());
+  return apiResultHandler.execute<Components.Schemas.Communication[]>({ request: client.message_get() });
 };
 
 const markMessageAsRead = async (messageId: string): Promise<ApiResponse<Components.Schemas.CommunicationResponse>> => {
   const client = await getClient();
-  return apiResultHandler.execute<Components.Schemas.CommunicationResponse>(
-    client.communication_put(
+  return apiResultHandler.execute<Components.Schemas.CommunicationResponse>({
+    request: client.communication_put(
       {
         id: messageId,
       },
@@ -25,12 +25,12 @@ const markMessageAsRead = async (messageId: string): Promise<ApiResponse<Compone
         communicationId: messageId,
       },
     ),
-  );
+  });
 };
 
 const sendMessage = async (sendMessageRequest: Components.Schemas.SendMessageRequest): Promise<ApiResponse<Components.Schemas.SendMessageResponse>> => {
   const client = await getClient();
-  return apiResultHandler.execute<Components.Schemas.SendMessageResponse>(client.message_post(null, sendMessageRequest), "message_post");
+  return apiResultHandler.execute<Components.Schemas.SendMessageResponse>({ request: client.message_post(null, sendMessageRequest), key: "message_post" });
 };
 
 export { getMessages, getMessagesStatus, markMessageAsRead, sendMessage };

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/api/reference.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/api/reference.ts
@@ -11,7 +11,10 @@ const getReference = async (token: string): Promise<ApiResponse<Components.Schem
     token: token,
   };
 
-  return apiResultHandler.execute<Components.Schemas.PortalInvitationQueryResult | null | undefined>(client.references_get(pathParameters));
+  return apiResultHandler.execute<Components.Schemas.PortalInvitationQueryResult | null | undefined>({
+    request: client.references_get(pathParameters),
+    suppressErrorToast: true,
+  });
 };
 
 const optOutReference = async (
@@ -25,32 +28,41 @@ const optOutReference = async (
     unabletoProvideReferenceReasons: optOutReason,
     recaptchaToken: recaptchaToken,
   };
-  return apiResultHandler.execute(client.reference_optout(null, body), "reference_optout");
+  return apiResultHandler.execute({
+    request: client.reference_optout(null, body),
+    key: "reference_optout",
+  });
 };
 
 const postCharacterReference = async (characterReferenceSubmission: Components.Schemas.CharacterReferenceSubmissionRequest): Promise<ApiResponse<any>> => {
   const client = await getClient();
-  return apiResultHandler.execute(client.character_reference_post(null, characterReferenceSubmission), "character_reference_post");
+  return apiResultHandler.execute({ request: client.character_reference_post(null, characterReferenceSubmission), key: "character_reference_post" });
 };
 
 const postWorkExperienceReference = async (
   workExperienceReferenceSubmission: Components.Schemas.WorkExperienceReferenceSubmissionRequest,
 ): Promise<ApiResponse<any>> => {
   const client = await getClient();
-  return apiResultHandler.execute(client.workExperience_reference_post(null, workExperienceReferenceSubmission), "workExperience_reference_post");
+  return apiResultHandler.execute({
+    request: client.workExperience_reference_post(null, workExperienceReferenceSubmission),
+    key: "workExperience_reference_post",
+  });
 };
 
 const resendCharacterReference = async (params: Paths.ApplicationCharacterReferenceResendInvitePost.PathParameters): Promise<ApiResponse<any>> => {
   const client = await getClient();
-  return apiResultHandler.execute(client.application_character_reference_resend_invite_post(params), "application_character_reference_resend_invite_post");
+  return apiResultHandler.execute({
+    request: client.application_character_reference_resend_invite_post(params),
+    key: "application_character_reference_resend_invite_post",
+  });
 };
 
 const resendWorkExperienceReference = async (params: Paths.ApplicationCharacterReferenceResendInvitePost.PathParameters): Promise<ApiResponse<any>> => {
   const client = await getClient();
-  return apiResultHandler.execute(
-    client.application_work_experience_reference_resend_invite_post(params),
-    "application_work_experience_reference_resend_invite_post",
-  );
+  return apiResultHandler.execute({
+    request: client.application_work_experience_reference_resend_invite_post(params),
+    key: "application_work_experience_reference_resend_invite_post",
+  });
 };
 
 const upsertWorkExperienceReference = async (
@@ -58,7 +70,10 @@ const upsertWorkExperienceReference = async (
   body: Paths.ApplicationWorkexperiencereferenceUpdatePost.RequestBody,
 ): Promise<ApiResponse<any>> => {
   const client = await getClient();
-  return apiResultHandler.execute(client.application_workexperiencereference_update_post(params, body), "application_workexperiencereference_update_post");
+  return apiResultHandler.execute({
+    request: client.application_workexperiencereference_update_post(params, body),
+    key: "application_workexperiencereference_update_post",
+  });
 };
 
 const upsertCharacterReference = async (
@@ -66,7 +81,10 @@ const upsertCharacterReference = async (
   body: Paths.ApplicationCharacterreferenceUpdatePost.RequestBody,
 ): Promise<ApiResponse<any>> => {
   const client = await getClient();
-  return apiResultHandler.execute(client.application_characterreference_update_post(params, body), "application_characterreference_update_post");
+  return apiResultHandler.execute({
+    request: client.application_characterreference_update_post(params, body),
+    key: "application_characterreference_update_post",
+  });
 };
 
 export {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/apiResultHandler.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/apiResultHandler.ts
@@ -10,18 +10,24 @@ export interface ApiResponse<T> {
   error?: any;
 }
 
+export interface ExecuteOptions<T> {
+  request: Promise<AxiosResponse<T>>;
+  key?: LoadingOperation;
+  suppressErrorToast?: boolean;
+}
+
 class ApiResultHandler {
   // Inject the alert store
 
   // Generic method to execute an API request and handle the response
-  public async execute<T>(request: Promise<AxiosResponse<T>>, key?: LoadingOperation): Promise<ApiResponse<T>> {
+  public async execute<T>({ request, key, suppressErrorToast = false }: ExecuteOptions<T>): Promise<ApiResponse<T>> {
     try {
       if (key) this.setLoadingState(key, true);
 
       const response = await request;
       return { data: response.data };
     } catch (error: any) {
-      this.handleError(error);
+      this.handleError(error, suppressErrorToast);
       return { error: error.response ? error.response.data : "An unknown error occurred" };
     } finally {
       if (key) this.setLoadingState(key, false);
@@ -29,34 +35,35 @@ class ApiResultHandler {
   }
 
   // Method to handle API errors
-  private handleError(error: any) {
+  private handleError(error: any, suppressErrorToast: boolean) {
     if (error.response) {
       const status = error.response.status;
       if (status === 400) {
         console.log(error.response.data);
         // Extract error message from server's response
         const errorMessage = error.response.data.message || error.response.data.detail || "Bad request. Please check your input.";
-        this.showErrorMessage(errorMessage);
+        this.showErrorMessage(errorMessage, suppressErrorToast);
       } else if (status === 404) {
         // Handle 404 Not Found
-        this.showErrorMessage("Requested resource not found.");
+        this.showErrorMessage("Requested resource not found.", suppressErrorToast);
       } else if (status === 500) {
         // Handle 500 Internal Server Error
-        this.showErrorMessage("Server error. Please try again later.");
+        this.showErrorMessage("Server error. Please try again later.", suppressErrorToast);
       }
     } else if (error.request) {
       // The request was made but no response was received
-      this.showErrorMessage("No response from server. Please check your network.");
+      this.showErrorMessage("No response from server. Please check your network.", suppressErrorToast);
     } else {
       // Something happened in setting up the request that triggered an Error
-      this.showErrorMessage("Error in request: " + error.message);
+      this.showErrorMessage("Error in request: " + error.message, suppressErrorToast);
     }
   }
 
   // Method to show error messages
-  private showErrorMessage(message: any) {
+  private showErrorMessage(message: any, suppressErrorToast: boolean) {
     const alertStore = useAlertStore();
-    alertStore.setFailureAlert(message);
+    console.log(suppressErrorToast);
+    if (!suppressErrorToast) alertStore.setFailureAlert(message);
   }
 
   private setLoadingState(key: LoadingOperation, loading: boolean) {


### PR DESCRIPTION
## Description

- Refactor api handler `execute` function for optional named parameters
- Suppress error for `getReference` api call

## Related Jira Issue(s)

- [ECER-1305](https://eccbc.atlassian.net/browse/ECER-1305)

## Checklist
- [X] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.