### PR TITLE
Tasks/ecer 1785

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/api/application.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/api/application.ts
@@ -23,6 +23,7 @@ const createOrUpdateDraftApplication = async (
 
   return apiResultHandler.execute<Components.Schemas.DraftApplicationResponse | null | undefined>({
     request: client.draftapplication_put(pathParameters, body),
+    key: "draftapplication_put",
   });
 };
 

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ConfirmationDialog.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ConfirmationDialog.vue
@@ -22,8 +22,8 @@
           <v-card-actions>
             <v-row>
               <v-col class="text-right d-flex flex-row justify-end flex-wrap">
-                <v-btn class="ma-0" color="primary" variant="outlined" @click="accept">{{ acceptButtonText }}</v-btn>
-                <v-btn color="primary" variant="flat" @click="cancel">{{ cancelButtonText }}</v-btn>
+                <v-btn class="ma-0" variant="outlined" @click="cancel">{{ cancelButtonText }}</v-btn>
+                <v-btn color="primary" variant="flat" @click="accept">{{ acceptButtonText }}</v-btn>
               </v-col>
             </v-row>
           </v-card-actions>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Wizard.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Wizard.vue
@@ -1,10 +1,10 @@
 <template>
   <slot name="header"></slot>
-  <v-stepper v-model="wizardStore.step" min-height="100dvh" :alt-labels="true" :mobile="$vuetify.display.mobile">
-    <slot name="stepperHeader">
+  <v-stepper v-model="wizardStore.step" min-height="100dvh" :alt-labels="true" :non-linear="true" :elevation="0">
+    <slot v-if="!$vuetify.display.mobile" name="stepperHeader">
       <v-stepper-header v-if="showSteps">
         <template v-for="(step, index) in Object.values(wizard.steps)" :key="step.stage">
-          <v-stepper-item color="primary" :step="wizardStore.step" :value="index + 1" :title="step.title"></v-stepper-item>
+          <v-stepper-item color="primary" :step="wizardStore.step" :value="index + 1" :title="step.title" :editable="true"></v-stepper-item>
           <v-divider v-if="index !== Object.values(wizard.steps).length - 1" :key="`divider-${index}`" />
         </template>
       </v-stepper-header>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Wizard.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Wizard.vue
@@ -1,6 +1,6 @@
 <template>
   <slot name="header"></slot>
-  <v-stepper v-model="wizardStore.step" min-height="100dvh" :alt-labels="true" :non-linear="true" :elevation="0">
+  <v-stepper v-model="wizardStore.step" min-height="100dvh" :alt-labels="true" :elevation="0">
     <slot v-if="!$vuetify.display.mobile" name="stepperHeader">
       <v-stepper-header v-if="showSteps">
         <template v-for="(step, index) in Object.values(wizard.steps)" :key="step.stage">

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/WizardHeader.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/WizardHeader.vue
@@ -1,20 +1,33 @@
 <template>
-  <v-container fluid class="bg-white">
-    <v-row>
-      <v-col cols="12">
-        <v-breadcrumbs :items="items" color="primary">
-          <template #divider>/</template>
-        </v-breadcrumbs>
-      </v-col>
-    </v-row>
-    <v-row justify="space-between" class="pb-6">
-      <v-col offset-md="1" cols="12" sm="8">
-        <ApplicationCertificationTypeHeader :certification-types="applicationStore.draftApplication.certificationTypes ?? []" />
-      </v-col>
-      <v-col v-if="false" cols="auto" offset="1">
-        <v-btn class="mr-2" rounded="lg" variant="outlined" color="primary">Cancel Application</v-btn>
-      </v-col>
-    </v-row>
+  <v-container fluid class="bg-primary">
+    <v-container>
+      <v-row>
+        <v-col class="d-flex justify-space-between">
+          <div>
+            <ApplicationCertificationTypeHeader :certification-types="applicationStore.draftApplication.certificationTypes ?? []" />
+            <a href="#" class="text-white" @click.prevent="toggleChangeCertificationConfirmation">Click to change certification</a>
+          </div>
+          <div>
+            <v-btn v-if="showSaveButton" variant="outlined" @click="saveAndExit">Save and exit</v-btn>
+          </div>
+        </v-col>
+      </v-row>
+    </v-container>
+    <ConfirmationDialog
+      @accept="changeCertification"
+      @cancel="toggleChangeCertificationConfirmation"
+      :show="showConfirmation"
+      title="Are you sure you want to change the type?"
+      accept-button-text="Change type"
+    >
+      <template #confirmation-text>
+        <div class="pb-3">When you change the type of certification you're applying for</div>
+        <ul class="ml-10">
+          <li>It will save the data you've entered</li>
+          <li>It may change the type and amount of information you need to provide</li>
+        </ul>
+      </template>
+    </ConfirmationDialog>
   </v-container>
 </template>
 
@@ -22,18 +35,29 @@
 import { defineComponent } from "vue";
 
 import { useApplicationStore } from "@/store/application";
+import ConfirmationDialog from "./ConfirmationDialog.vue";
 
 import ApplicationCertificationTypeHeader from "./ApplicationCertificationTypeHeader.vue";
 
 export default defineComponent({
   name: "WizardHeader",
-  components: { ApplicationCertificationTypeHeader },
+  components: { ApplicationCertificationTypeHeader, ConfirmationDialog },
   setup() {
     const applicationStore = useApplicationStore();
 
     return {
       applicationStore,
     };
+  },
+  props: {
+    handleSaveDraft: {
+      type: Function,
+      required: true,
+    },
+    showSaveButton: {
+      type: Boolean,
+      required: true,
+    },
   },
   data: () => ({
     items: [
@@ -49,6 +73,20 @@ export default defineComponent({
         href: "application",
       },
     ],
+    showConfirmation: false,
   }),
+  methods: {
+    toggleChangeCertificationConfirmation() {
+      this.showConfirmation = !this.showConfirmation;
+    },
+    saveAndExit() {
+      this.handleSaveDraft();
+      this.$router.push({ name: "dashboard" });
+    },
+    changeCertification() {
+      this.showConfirmation = false;
+      this.$router.push({ name: "application-certification" });
+    },
+  },
 });
 </script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/WizardHeader.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/WizardHeader.vue
@@ -8,17 +8,17 @@
             <a href="#" class="text-white" @click.prevent="toggleChangeCertificationConfirmation">Click to change certification</a>
           </div>
           <div>
-            <v-btn v-if="showSaveButton" variant="outlined" @click="saveAndExit">Save and exit</v-btn>
+            <v-btn v-if="showSaveButton" variant="outlined" :loading="loadingStore.isLoading('draftapplication_put')" @click="saveAndExit">Save and exit</v-btn>
           </div>
         </v-col>
       </v-row>
     </v-container>
     <ConfirmationDialog
-      @accept="changeCertification"
-      @cancel="toggleChangeCertificationConfirmation"
       :show="showConfirmation"
       title="Are you sure you want to change the type?"
       accept-button-text="Change type"
+      @accept="changeCertification"
+      @cancel="toggleChangeCertificationConfirmation"
     >
       <template #confirmation-text>
         <div class="pb-3">When you change the type of certification you're applying for</div>
@@ -35,20 +35,14 @@
 import { defineComponent } from "vue";
 
 import { useApplicationStore } from "@/store/application";
-import ConfirmationDialog from "./ConfirmationDialog.vue";
+import { useLoadingStore } from "@/store/loading";
 
 import ApplicationCertificationTypeHeader from "./ApplicationCertificationTypeHeader.vue";
+import ConfirmationDialog from "./ConfirmationDialog.vue";
 
 export default defineComponent({
   name: "WizardHeader",
   components: { ApplicationCertificationTypeHeader, ConfirmationDialog },
-  setup() {
-    const applicationStore = useApplicationStore();
-
-    return {
-      applicationStore,
-    };
-  },
   props: {
     handleSaveDraft: {
       type: Function,
@@ -58,6 +52,15 @@ export default defineComponent({
       type: Boolean,
       required: true,
     },
+  },
+  setup() {
+    const applicationStore = useApplicationStore();
+    const loadingStore = useLoadingStore();
+
+    return {
+      applicationStore,
+      loadingStore,
+    };
   },
   data: () => ({
     items: [
@@ -79,11 +82,11 @@ export default defineComponent({
     toggleChangeCertificationConfirmation() {
       this.showConfirmation = !this.showConfirmation;
     },
-    saveAndExit() {
-      this.handleSaveDraft();
+    async saveAndExit() {
+      await this.handleSaveDraft();
       this.$router.push({ name: "dashboard" });
     },
-    changeCertification() {
+    async changeCertification() {
       this.showConfirmation = false;
       this.$router.push({ name: "application-certification" });
     },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Application.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Application.vue
@@ -6,15 +6,24 @@
     "
   >
     <template #header>
-      <WizardHeader class="mb-6" :handleSaveDraft="handleSaveAsDraft" :showSaveButton="showSaveButtons" />
+      <WizardHeader class="mb-6" :handle-save-draft="handleSaveAsDraft" :show-save-button="showSaveButtons" />
     </template>
     <template #stepperHeader>
-      <v-stepper-header class="elevation-0">
-        <template v-for="(step, index) in Object.values(wizardStore.steps)" :key="step.stage">
-          <v-stepper-item color="primary" :step="wizardStore.step" :value="index + 1" :title="step.title"></v-stepper-item>
-          <v-divider v-if="index !== Object.values(wizardStore.steps).length - 1" :key="`divider-${index}`" />
-        </template>
-      </v-stepper-header>
+      <v-container>
+        <v-stepper-header class="elevation-0">
+          <template v-for="(step, index) in Object.values(wizardStore.steps)" :key="step.stage">
+            <v-stepper-item
+              color="primary"
+              :step="wizardStore.step"
+              :value="index + 1"
+              :title="step.title"
+              :editable="index + 1 < wizardStore.step && wizardStore.listComponentMode !== 'add'"
+              :complete="index + 1 < wizardStore.step"
+            ></v-stepper-item>
+            <v-divider v-if="index !== Object.values(wizardStore.steps).length - 1" :key="`divider-${index}`" />
+          </template>
+        </v-stepper-header>
+      </v-container>
     </template>
     <template #PrintPreview>
       <v-btn rounded="lg" variant="text" @click="printPage()">
@@ -23,7 +32,18 @@
       </v-btn>
     </template>
     <template #actions>
-      <v-container class="mb-8">
+      <v-container>
+        <v-btn
+          v-if="$vuetify.display.mobile"
+          :disabled="wizardStore.step === 1"
+          rounded="lg"
+          variant="outlined"
+          color="primary"
+          class="mr-3"
+          @click="handleBack"
+        >
+          Back
+        </v-btn>
         <v-btn v-if="showSaveButtons" rounded="lg" color="primary" @click="handleSaveAndContinue">Save and Continue</v-btn>
         <v-btn v-if="showSubmitApplication" rounded="lg" color="primary" :loading="loadingStore.isLoading('application_post')" @click="handleSubmit">
           Submit Application
@@ -153,13 +173,13 @@ export default defineComponent({
         this.alertStore.setSuccessAlert("Your responses have been saved. You may resume this application from your dashboard.");
       }
     },
-    handleSaveAsDraft(): void {
+    async handleSaveAsDraft() {
       switch (this.wizardStore.currentStepStage) {
         case "ContactInformation":
-          this.saveProfile();
+          await this.saveProfile();
           break;
         default:
-          this.saveDraftAndAlertSuccess();
+          await this.saveDraftAndAlertSuccess();
           break;
       }
     },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Application.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Application.vue
@@ -6,10 +6,10 @@
     "
   >
     <template #header>
-      <WizardHeader class="mb-6" />
+      <WizardHeader class="mb-6" :handleSaveDraft="handleSaveAsDraft" :showSaveButton="showSaveButtons" />
     </template>
     <template #stepperHeader>
-      <v-stepper-header>
+      <v-stepper-header class="elevation-0">
         <template v-for="(step, index) in Object.values(wizardStore.steps)" :key="step.stage">
           <v-stepper-item color="primary" :step="wizardStore.step" :value="index + 1" :title="step.title"></v-stepper-item>
           <v-divider v-if="index !== Object.values(wizardStore.steps).length - 1" :key="`divider-${index}`" />
@@ -24,18 +24,10 @@
     </template>
     <template #actions>
       <v-container class="mb-8">
-        <v-row class="justify-space-between ga-4" no-gutters>
-          <v-col cols="auto" class="mr-auto">
-            <v-btn :disabled="wizardStore.step === 1" rounded="lg" variant="outlined" color="primary" aut @click="handleBack">Back</v-btn>
-          </v-col>
-          <v-col cols="auto">
-            <v-btn v-if="showSaveButtons" rounded="lg" variant="outlined" color="primary" class="mr-4" primary @click="handleSaveAsDraft">Save as Draft</v-btn>
-            <v-btn v-if="showSaveButtons" rounded="lg" color="primary" @click="handleSaveAndContinue">Save and Continue</v-btn>
-            <v-btn v-if="showSubmitApplication" rounded="lg" color="primary" :loading="loadingStore.isLoading('application_post')" @click="handleSubmit">
-              Submit Application
-            </v-btn>
-          </v-col>
-        </v-row>
+        <v-btn v-if="showSaveButtons" rounded="lg" color="primary" @click="handleSaveAndContinue">Save and Continue</v-btn>
+        <v-btn v-if="showSubmitApplication" rounded="lg" color="primary" :loading="loadingStore.isLoading('application_post')" @click="handleSubmit">
+          Submit Application
+        </v-btn>
       </v-container>
     </template>
   </Wizard>
@@ -161,7 +153,7 @@ export default defineComponent({
         this.alertStore.setSuccessAlert("Your responses have been saved. You may resume this application from your dashboard.");
       }
     },
-    async handleSaveAsDraft() {
+    handleSaveAsDraft(): void {
       switch (this.wizardStore.currentStepStage) {
         case "ContactInformation":
           this.saveProfile();

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-assistant-and-one-year.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-assistant-and-one-year.ts
@@ -2,7 +2,7 @@ import type { Wizard } from "@/types/wizard";
 
 import characterReferencesForm from "./character-references-form";
 import educationForm from "./education-form";
-import previewForm from "./preview-form-assistant-and-one-year";
+import previewFormAssistantAndOneYear from "./preview-form-assistant-and-one-year";
 import profileInformationForm from "./profile-information-form";
 
 const applicationWizard: Wizard = {
@@ -29,7 +29,7 @@ const applicationWizard: Wizard = {
     review: {
       stage: "Review",
       title: "Preview & Submit",
-      form: previewForm,
+      form: previewFormAssistantAndOneYear,
       key: "item.4",
     },
   },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-assistant-and-one-year.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-assistant-and-one-year.ts
@@ -10,7 +10,7 @@ const applicationWizard: Wizard = {
   steps: {
     profile: {
       stage: "ContactInformation",
-      title: "Contact Information",
+      title: "Contact information",
       form: profileInformationForm,
       key: "item.1",
     },
@@ -22,13 +22,13 @@ const applicationWizard: Wizard = {
     },
     characterReferences: {
       stage: "CharacterReferences",
-      title: "Character Reference",
+      title: "Character references",
       form: characterReferencesForm,
       key: "item.3",
     },
     review: {
       stage: "Review",
-      title: "Preview & Submit",
+      title: "Preview and Submit",
       form: previewFormAssistantAndOneYear,
       key: "item.4",
     },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-assistant-and-one-year.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-assistant-and-one-year.ts
@@ -28,7 +28,7 @@ const applicationWizard: Wizard = {
     },
     review: {
       stage: "Review",
-      title: "Preview and Submit",
+      title: "Review and Submit",
       form: previewFormAssistantAndOneYear,
       key: "item.4",
     },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-five-year.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-five-year.ts
@@ -11,7 +11,7 @@ const applicationWizard: Wizard = {
   steps: {
     profile: {
       stage: "ContactInformation",
-      title: "Contact Information",
+      title: "Contact information",
       form: profileInformationForm,
       key: "item.1",
     },
@@ -23,19 +23,19 @@ const applicationWizard: Wizard = {
     },
     characterReferences: {
       stage: "CharacterReferences",
-      title: "Character Reference",
+      title: "Character references",
       form: characterReferencesForm,
       key: "item.3",
     },
     workReference: {
       stage: "WorkReferences",
-      title: "Work Experience References",
+      title: "Work experience references",
       form: referencesForm,
       key: "item.4",
     },
     review: {
       stage: "Review",
-      title: "Preview & Submit",
+      title: "Preview and submit",
       form: previewFormFiveYear,
       key: "item.5",
     },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-five-year.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-five-year.ts
@@ -35,7 +35,7 @@ const applicationWizard: Wizard = {
     },
     review: {
       stage: "Review",
-      title: "Preview and submit",
+      title: "Review and submit",
       form: previewFormFiveYear,
       key: "item.5",
     },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-five-year.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-five-year.ts
@@ -2,7 +2,7 @@ import type { Wizard } from "@/types/wizard";
 
 import characterReferencesForm from "./character-references-form";
 import educationForm from "./education-form";
-import previewForm from "./preview-form-assistant-and-one-year";
+import previewFormFiveYear from "./preview-form-five-year";
 import profileInformationForm from "./profile-information-form";
 import referencesForm from "./references-form";
 
@@ -36,7 +36,7 @@ const applicationWizard: Wizard = {
     review: {
       stage: "Review",
       title: "Preview & Submit",
-      form: previewForm,
+      form: previewFormFiveYear,
       key: "item.5",
     },
   },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/main.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/main.ts
@@ -29,6 +29,9 @@ const vuetify = createVuetify({
       mdi,
     },
   },
+  display: {
+    mobileBreakpoint: "sm",
+  },
   components,
   directives,
 });


### PR DESCRIPTION
## Title
ECER-1785, 

## Description
ECER-1785
- Changed title to sentence casing for the wizard
- Added link to change certification type
- Clicking link will show dialog for user to confirm. 

ECER-1795
- Made it so user can click on "button" to steps.  for previous steps. 
- changed text from Preview to Review

ECER-1801
- Removed stepper from mobile. 

BugFixes: 
- Swapped ordering of buttons for confirmation dialog
- 5 yr cert now shows work references in review screen

## Checklist
- [ ] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.
New header for stepper with Save and Exit Buttons + Click to change certification link
![image](https://github.com/user-attachments/assets/b446a492-277a-454c-8f3e-d6ef07e46135)

Confirmation dialog for changing certification
![image](https://github.com/user-attachments/assets/91f9eb7b-930e-4b7c-96d0-0763e8a3cd30)

Able to click back to previous steps in stepper 
![image](https://github.com/user-attachments/assets/f6712073-c77c-45dd-8b6d-cbfd290ac368)

Buttons on the bottom are left aligned and renamed to Save and Continue
![image](https://github.com/user-attachments/assets/c6088393-72e5-4c67-b741-996c78eafe69)

For mobile we hide stepper and show back button 
![image](https://github.com/user-attachments/assets/2d500c42-fc46-4950-b435-c42bc68dacf0)

