### PR TITLE
ECER-2406: Allow for cancelled certifications to be renewed (REWORK)

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Dashboard.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Dashboard.vue
@@ -42,7 +42,7 @@
     </v-row>
 
     <!-- Options -->
-    <v-row v-if="certificationStore.hasCertifications && certificationStore.latestNotCancelled" justify="center" class="mt-6">
+    <v-row v-if="certificationStore.hasCertifications" justify="center" class="mt-6">
       <v-col>
         <v-row>
           <v-col cols="12">

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Dashboard.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Dashboard.vue
@@ -29,10 +29,12 @@
           <v-col cols="12">
             <ECEHeader title="Your ECE certifications" />
             <div v-if="certifications && certificationStore.hasCertifications">
-              <p class="mt-4">
-                ECE registration number
-                {{ certificationStore.latestCertification?.number }}
-              </p>
+              <div class="d-flex flex-row justify-start ga-3 flex-wrap mt-4">
+                <p>ECE registration number</p>
+                <p>
+                  {{ certificationStore.latestCertification?.number }}
+                </p>
+              </div>
               <CertificationCard :class="smAndDown ? 'mx-n6 mt-4' : 'mt-4'" :is-rounded="false" />
             </div>
             <p v-else class="small mt-4">You do not have an ECE certificate in your My ECE Registry account.</p>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/certification.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/certification.ts
@@ -32,10 +32,6 @@ export const useCertificationStore = defineStore("certification", {
     latestCertificationExpiryDate(state): string | null | undefined {
       return state.latestCertification?.expiryDate;
     },
-    latestNotCancelled(state): boolean {
-      if (!state.latestCertification) return false;
-      return state.latestCertification.statusCode !== "Cancelled";
-    },
     latestIsEceAssistant(state): boolean {
       if (!state.latestCertification) return false;
       return state.latestCertification.levels?.some((level) => level.type === "Assistant") ?? false;


### PR DESCRIPTION
## Description

- Adjust renewal logic to allow for cancelled certificates to be renewed
- Styling for ECER-2676

## Related Jira Issue(s)

- [ECER-2405](https://eccbc.atlassian.net/browse/ECER-2405)
- [ECER-2406](https://eccbc.atlassian.net/browse/ECER-2406)
- [ECER-2407](https://eccbc.atlassian.net/browse/ECER-2407)
- [ECER-2408](https://eccbc.atlassian.net/browse/ECER-2408)
- [ECER-2409](https://eccbc.atlassian.net/browse/ECER-2409)
- [ECER-2410](https://eccbc.atlassian.net/browse/ECER-2410)

## Checklist
- [X] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.