### PR TITLE
ECER-2507: Receive Previous Name Record from Portal Submission

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Users/ProfileEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Users/ProfileEndpoints.cs
@@ -35,7 +35,8 @@ public class ProfileEndpoints : IRegisterEndpoints
 /// <summary>
 /// User profile information
 /// </summary>
-public record UserProfile {
+public record UserProfile
+{
   public string? FirstName { get; set; }
   public string? LastName { get; set; }
   public string? MiddleName { get; set; }
@@ -52,12 +53,13 @@ public record UserProfile {
 /// <summary>
 /// Previous Name
 /// </summary>
-public record PreviousName ([Required] string FirstName, [Required] string LastName)
+public record PreviousName([Required] string FirstName, [Required] string LastName)
 {
   public string? Id { get; set; }
   public string? MiddleName { get; set; }
   public string? PreferredName { get; set; }
   public PreviousNameStage? Status { get; set; }
+  public PreviousNameSources? Source { get; set; }
 }
 
 public enum PreviousNameStage
@@ -66,6 +68,13 @@ public enum PreviousNameStage
   ReadyforVerification,
   Verified,
   Archived,
+}
+
+public enum PreviousNameSources
+{
+  NameLog,
+  Profile,
+  Transcript,
 }
 
 /// <summary>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/AddPreviousName.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/AddPreviousName.vue
@@ -99,6 +99,7 @@ export default {
         firstName: this.formStore.formData[previousNameForm.inputs.firstName.id],
         middleName: this.formStore.formData[previousNameForm.inputs.middleName.id] ?? null,
         lastName: this.formStore.formData[previousNameForm.inputs.lastName.id],
+        source: "Profile",
       };
     },
     duplicatePreviousName() {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
@@ -817,9 +817,7 @@ declare namespace Paths {
     export interface PathParameters {
       fileId: Parameters.FileId;
     }
-    export interface RequestBody {
-      file: string; // binary
-    }
+    export type RequestBody = string; // binary
     namespace Responses {
       export type $200 = /* file Response */ Components.Schemas.FileResponse;
       export type $400 = Components.Schemas.ProblemDetails | Components.Schemas.HttpValidationProblemDetails;

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
@@ -310,7 +310,9 @@ declare namespace Components {
       middleName?: string | null;
       preferredName?: string | null;
       status?: PreviousNameStage;
+      source?: PreviousNameSources;
     }
+    export type PreviousNameSources = "NameLog" | "Profile" | "Transcript";
     export type PreviousNameStage = "Unverified" | "ReadyforVerification" | "Verified" | "Archived";
     export interface ProblemDetails {
       [name: string]: any;
@@ -815,7 +817,9 @@ declare namespace Paths {
     export interface PathParameters {
       fileId: Parameters.FileId;
     }
-    export type RequestBody = string; // binary
+    export interface RequestBody {
+      file: string; // binary
+    }
     namespace Responses {
       export type $200 = /* file Response */ Components.Schemas.FileResponse;
       export type $400 = Components.Schemas.ProblemDetails | Components.Schemas.HttpValidationProblemDetails;

--- a/src/ECER.Managers.Registry.Contract/Registrants/Contract.cs
+++ b/src/ECER.Managers.Registry.Contract/Registrants/Contract.cs
@@ -29,7 +29,8 @@ public record RegistrantQueryResults(IEnumerable<Registrant> Items);
 
 public record Registrant(string UserId, UserProfile Profile);
 
-public record UserProfile {
+public record UserProfile
+{
   public string? FirstName { get; set; }
   public string? LastName { get; set; }
   public string? MiddleName { get; set; }
@@ -43,12 +44,13 @@ public record UserProfile {
   public IEnumerable<PreviousName> PreviousNames { get; set; } = Array.Empty<PreviousName>();
 };
 
-public record PreviousName (string FirstName, string LastName)
+public record PreviousName(string FirstName, string LastName)
 {
   public string? Id { get; set; }
   public string? MiddleName { get; set; }
   public string? PreferredName { get; set; }
   public PreviousNameStage? Status { get; set; }
+  public PreviousNameSources? Source { get; set; }
 }
 
 public enum PreviousNameStage
@@ -57,6 +59,13 @@ public enum PreviousNameStage
   ReadyforVerification,
   Verified,
   Archived,
+}
+
+public enum PreviousNameSources
+{
+  NameLog,
+  Profile,
+  Transcript,
 }
 
 public record Address(

--- a/src/ECER.Resources.Accounts/Registrants/IRegistrantRepository.cs
+++ b/src/ECER.Resources.Accounts/Registrants/IRegistrantRepository.cs
@@ -37,7 +37,8 @@ public record Registrant
   public UserProfile Profile { get; set; } = null!;
 }
 
-public record UserProfile {
+public record UserProfile
+{
   public string? FirstName { get; set; }
   public string? LastName { get; set; }
   public string? MiddleName { get; set; }
@@ -51,12 +52,13 @@ public record UserProfile {
   public IEnumerable<PreviousName> PreviousNames { get; set; } = Array.Empty<PreviousName>();
 };
 
-public record PreviousName (string FirstName, string LastName)
+public record PreviousName(string FirstName, string LastName)
 {
   public string? Id { get; set; }
   public string? MiddleName { get; set; }
   public string? PreferredName { get; set; }
   public PreviousNameStage? Status { get; set; }
+  public PreviousNameSources? Source { get; set; }
 }
 
 public enum PreviousNameStage
@@ -65,6 +67,13 @@ public enum PreviousNameStage
   ReadyforVerification,
   Verified,
   Archived,
+}
+
+public enum PreviousNameSources
+{
+  NameLog,
+  Profile,
+  Transcript,
 }
 
 public record Address(

--- a/src/ECER.Resources.Accounts/Registrants/RegistrantRepositoryMapper.cs
+++ b/src/ECER.Resources.Accounts/Registrants/RegistrantRepositoryMapper.cs
@@ -21,7 +21,8 @@ internal sealed class RegistrantRepositoryMapper : Profile
       .ForMember(d => d.ecer_LastName, opts => opts.MapFrom(s => s.LastName))
       .ForMember(d => d.ecer_PreferredName, opts => opts.MapFrom(s => s.PreferredName))
       .ForMember(d => d.ecer_MiddleName, opts => opts.MapFrom(s => s.MiddleName))
-      .ForMember(d => d.StatusCode, opts => opts.MapFrom(s => s.Status));
+      .ForMember(d => d.StatusCode, opts => opts.MapFrom(s => s.Status))
+      .ForMember(d => d.ecer_Source, opts => opts.MapFrom(s => s.Source));
 
     CreateMap<ecer_PreviousName, PreviousName>(MemberList.Source)
       .ForCtorParam(nameof(PreviousName.FirstName), opts => opts.MapFrom(s => s.ecer_FirstName))
@@ -30,6 +31,7 @@ internal sealed class RegistrantRepositoryMapper : Profile
       .ForMember(d => d.MiddleName, opts => opts.MapFrom(s => s.ecer_MiddleName))
       .ForMember(d => d.Status, opts => opts.MapFrom(s => s.StatusCode))
       .ForMember(d => d.Id, opts => opts.MapFrom(s => s.ecer_PreviousNameId))
+      .ForMember(d => d.Source, opts => opts.MapFrom(s => s.ecer_Source))
       .ValidateMemberList(MemberList.Destination);
 
     CreateMap<ecer_Authentication, UserIdentity>()
@@ -74,6 +76,10 @@ internal sealed class RegistrantRepositoryMapper : Profile
         ;
 
     CreateMap<ecer_PreviousName_StatusCode, PreviousNameStage>()
+      .ConvertUsingEnumMapping(opts => opts.MapByName(true))
+      .ReverseMap();
+
+    CreateMap<ecer_PreviousNameSources, PreviousNameSources>()
       .ConvertUsingEnumMapping(opts => opts.MapByName(true))
       .ReverseMap();
   }


### PR DESCRIPTION

## Title
ECER-2507: Receive Previous Name Record from Portal Submission

## Description

- Added and mapped ecer_Source choice field(enum) for Previous Name record in all the layers of B.E
- Setting ecer_Source = "Profile" when adding previous name from  "My profile" section 

## Related Jira Issue(s)

- ECER-2507

## Checklist
- [x] I have tested these changes locally.
- [x] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.
