### PR TITLE
rework allow user to delete and upload the same file twice

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/FileUploader.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/FileUploader.vue
@@ -171,6 +171,8 @@ export default defineComponent({
         this.showErrorBanner = false;
         (this.$refs.fileInput as HTMLInputElement).click();
       }
+      //fix to allow uploading the same file twice
+      (this.$refs.fileInput as HTMLInputElement).value = "";
     },
     updateEmit() {
       this.$emit("update:files", this.selectedFiles);


### PR DESCRIPTION
## Title
ECER-2378: Allow user to upload the same file twice

## Description

- Issue was that the value of the v-file-input component was not clearing the value between uploads. When it sees the same value for the next upload it doesn't register. 

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.