### PR TITLE
Stories/ecer 2887

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
@@ -54,7 +54,13 @@
           <v-col>
             <v-text-field
               v-model="startYear"
-              :rules="[Rules.required('Enter the start date of your program or course')]"
+              :rules="[
+                Rules.required('Enter the start date of your program or course'),
+                Rules.conditionalWrapper(
+                  isDraftApplicationAssistantRenewal,
+                  Rules.dateRuleRange(applicationStore.draftApplication.createdOn!, 5, 'The start date of your course should be within the last 5 years'),
+                ),
+              ]"
               label="Start date of program or course"
               type="date"
               variant="outlined"
@@ -67,7 +73,12 @@
           <v-col>
             <v-text-field
               v-model="endYear"
-              :rules="[Rules.required('Enter the end date of your program or course')]"
+              :rules="[
+                Rules.required('Enter the end date of your program or course'),
+                isDraftApplicationAssistantRenewal
+                  ? Rules.dateRuleRange(applicationStore.draftApplication.createdOn!, 5, 'The end date of your course should be within the last 5 years')
+                  : true,
+              ]"
               label="End date of program or course"
               type="date"
               variant="outlined"
@@ -85,7 +96,7 @@
           <v-col>
             <v-text-field
               v-model="school"
-              :rules="[Rules.required('Enter the full name of your educational institution')]"
+              :rules="[Rules.required('Enter the name of the educational institution where you took your program or course')]"
               label="Full name of educational institution"
               variant="outlined"
               color="primary"
@@ -95,7 +106,7 @@
         </v-row>
         <v-row>
           <v-col>
-            <v-text-field v-model="campusLocation" label="Campus Location (Optional)" variant="outlined" color="primary" maxlength="50"></v-text-field>
+            <v-text-field v-model="campusLocation" label="Campus Location (Optional)" variant="outlined" color="primary" maxlength="200"></v-text-field>
           </v-col>
         </v-row>
         <v-row>
@@ -125,7 +136,11 @@
         <br />
         <p>What name is shown on your transcript?</p>
         <br />
-        <v-radio-group v-model="previousNameRadio" :rules="[Rules.requiredRadio('Select an option')]" @update:model-value="previousNameRadioChanged">
+        <v-radio-group
+          v-model="previousNameRadio"
+          :rules="[Rules.requiredRadio('Select an option to specify what name has been shown on your transcript')]"
+          @update:model-value="previousNameRadioChanged"
+        >
           <v-radio v-for="(step, index) in previousNameRadioOptions" :key="index" :label="step.label" :value="step.value"></v-radio>
         </v-radio-group>
         <div v-if="previousNameRadio === 'other'">
@@ -177,7 +192,7 @@
       </v-col>
       <v-col cols="12" class="mt-6">
         <v-row justify="start" class="ml-1">
-          <v-btn prepend-icon="mdi-plus" rounded="lg" color="alternate" @click="handleAddEducation">Add Education</v-btn>
+          <v-btn v-if="showAddEducationButton" prepend-icon="mdi-plus" rounded="lg" color="alternate" @click="handleAddEducation">Add Education</v-btn>
         </v-row>
       </v-col>
       <v-col>
@@ -309,6 +324,13 @@ export default defineComponent({
 
       radioOptions.push({ label: "Other name", value: "other" });
       return radioOptions;
+    },
+    isDraftApplicationAssistantRenewal(): boolean {
+      return this.applicationStore.isDraftApplicationRenewal && this.applicationStore.isDraftCertificateTypeEceAssistant;
+    },
+    showAddEducationButton(): boolean {
+      //covers case where user has assistant renewal and can only add 1 education. Otherwise allow user to upload as many as needed.
+      return this.isDraftApplicationAssistantRenewal ? Object.keys(this.modelValue).length < 1 : true;
     },
   },
   mounted() {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Dashboard.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Dashboard.vue
@@ -44,7 +44,7 @@
     </v-row>
 
     <!-- Options -->
-    <v-row v-if="certificationStore.hasCertifications" justify="center" class="mt-6">
+    <v-row v-if="certificationStore.hasCertifications && !applicationStore.hasDraftApplication" justify="center" class="mt-6">
       <v-col>
         <v-row>
           <v-col cols="12">
@@ -160,16 +160,19 @@ export default defineComponent({
   }),
   computed: {
     showApplicationCard(): boolean {
+      if (this.certificationStore.hasCertifications && !this.applicationStore.hasDraftApplication) {
+        return false;
+      }
+
       return (
-        (this.applicationStore.applicationStatus === undefined ||
-          this.applicationStore.applicationStatus === "Draft" ||
-          this.applicationStore.applicationStatus === "Submitted" ||
-          this.applicationStore.applicationStatus === "Ready" ||
-          this.applicationStore.applicationStatus === "InProgress" ||
-          this.applicationStore.applicationStatus === "PendingQueue" ||
-          this.applicationStore.applicationStatus === "Pending" ||
-          this.applicationStore.applicationStatus === "Escalated") &&
-        !this.certificationStore.hasCertifications //if user has certifications we should not show applications card until designs are confirmed
+        this.applicationStore.applicationStatus === undefined ||
+        this.applicationStore.applicationStatus === "Draft" ||
+        this.applicationStore.applicationStatus === "Submitted" ||
+        this.applicationStore.applicationStatus === "Ready" ||
+        this.applicationStore.applicationStatus === "InProgress" ||
+        this.applicationStore.applicationStatus === "PendingQueue" ||
+        this.applicationStore.applicationStatus === "Pending" ||
+        this.applicationStore.applicationStatus === "Escalated"
       );
     },
   },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formRules.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formRules.ts
@@ -115,6 +115,26 @@ const atLeastOneOptionRequired = (message = "Please select at least one option")
   return (v: any[]) => v.length > 0 || message;
 };
 /**
+ * Checks whether input is x years from a specific date
+ * Date format should be 2022-12-10 YYYY-MM-DD.
+ * @param {String} targetDate
+ * @param {Number} years
+ * @returns {String|Boolean}
+ */
+const dateRuleRange = (targetDate: string, years: number, message = `Date should be within ${years} years`) => {
+  return (v: string) => {
+    if (v && targetDate) {
+      const input = DateTime.fromISO(v);
+      const target = DateTime.fromISO(targetDate);
+      const differenceInYears = Math.abs(input.diff(target, "years").years);
+
+      return differenceInYears < years || message;
+    }
+
+    return true;
+  };
+};
+/**
  * Custom endDate Rule! Checks that we have start date and that end date
  * happens after start date. Date format should be 2022-12-10 YYYY-MM-DD.
  * @param {String} effectiveDate
@@ -133,6 +153,22 @@ const endDateRule = (effectiveDate: string, expiryDate: string, message = "End d
 };
 
 /**
+ * conditional wrapper for form rules. If condition is met then return rule function
+ * otherwise ignore by returning true
+ * @param {boolean} condition
+ * @param {Function} rule
+ * @returns {Boolean|ValidationRule$1}
+ */
+const conditionalWrapper = (condition: boolean, rule: any) => {
+  return condition ? rule : true;
+  if (condition) {
+    return rule;
+  } else {
+    return true;
+  }
+};
+
+/**
  * Rule for website url
  * @param {String} message
  * @returns Function
@@ -143,6 +179,8 @@ const website = (message = "Website must be valid and secure (i.e., https)") => 
 
 export {
   atLeastOneOptionRequired,
+  conditionalWrapper,
+  dateRuleRange,
   email,
   endDateRule,
   hasCheckbox,


### PR DESCRIPTION
ECER-2887: updates to education component to handle ECE Assistant renewals

Added a conditional wrapper for rules. So they only apply for certain applications. 

## Description

- https://eccbc.atlassian.net/browse/ECER-2887 updates to education component to handle ECE Assistant Renewals
- https://eccbc.atlassian.net/browse/ECER-2297 fix to continue application from draft even in a renewal situation
- https://eccbc.atlassian.net/browse/ECER-2842 hiding options when user has a draft application

## Related Jira Issue(s)

- ECER-2889 (still in grooming getting ahead of it)
- ECER-2297 continuing application from draft

## Checklist
- [ ] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
When a user is doing an Assistant Renewal their education must be within the last 5 years. Otherwise we do not check. 
![image](https://github.com/user-attachments/assets/4684bfc4-bd7e-49f7-aa5d-902408914fed)

After adding 1 education (for Assistant renewal) add button disappears
![image](https://github.com/user-attachments/assets/77327229-2912-407a-9c9b-31961591c868)

Title reflects ECE Assistant Renewal 
![image](https://github.com/user-attachments/assets/24a9f9e0-f734-49af-97ab-11c0d63c6825)

When user has draft application in progress they see the option to continue 
![image](https://github.com/user-attachments/assets/e8c70561-339e-4d9c-970c-965e2857f764)

When user has a certification but no draft application they do not get to start a brand new application. They must choose an "option" 
![image](https://github.com/user-attachments/assets/3d303edc-58a3-47d1-97f6-cfa43bc2966a)


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.