### PR TITLE
ECER-2245: Upload ID for previous name

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Users/ProfileEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Users/ProfileEndpoints.cs
@@ -60,6 +60,7 @@ public record PreviousName([Required] string FirstName, [Required] string LastNa
   public string? PreferredName { get; set; }
   public PreviousNameStage? Status { get; set; }
   public PreviousNameSources? Source { get; set; }
+  public IEnumerable<IdentityDocument> Documents { get; set; } = Array.Empty<IdentityDocument>();
 }
 
 public enum PreviousNameStage
@@ -75,6 +76,14 @@ public enum PreviousNameSources
   NameLog,
   Profile,
   Transcript,
+}
+
+public record IdentityDocument(string Id)
+{
+  public string Url { get; set; } = null!;
+  public string Extention { get; set; } = null!;
+  public string Name { get; set; } = null!;
+  public string Size { get; set; } = null!;
 }
 
 /// <summary>

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Users/UserMapper.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Users/UserMapper.cs
@@ -40,7 +40,10 @@ internal sealed class UserMapper : AutoMapper.Profile
         opts => opts.MapFrom(src => string.IsNullOrEmpty(src.Id) ? null : src.Id))
       .ReverseMap();
 
-    
+
+    CreateMap<Managers.Registry.Contract.Registrants.IdentityDocument, IdentityDocument>().ReverseMap();
+
+
     CreateMap<UserProfile, Managers.Registry.Contract.Registrants.UserProfile>()
       .ForMember(d => d.PreviousNames, opts => opts.MapFrom(s => s.PreviousNames))
       .ReverseMap()

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
@@ -245,6 +245,7 @@ declare namespace Components {
        *
        */
       fileId?: string | null;
+      url?: string | null;
     }
     export interface GetMessagesResponse {
       communications?: Communication[] | null;
@@ -260,6 +261,13 @@ declare namespace Components {
       errors?: {
         [name: string]: string[];
       } | null;
+    }
+    export interface IdentityDocument {
+      id?: string | null;
+      url?: string | null;
+      extention?: string | null;
+      name?: string | null;
+      size?: string | null;
     }
     export type InitiatedFrom = "Investigation" | "PortalUser" | "Registry";
     export type InviteType = "CharacterReference" | "WorkExperienceReference";
@@ -311,6 +319,7 @@ declare namespace Components {
       preferredName?: string | null;
       status?: PreviousNameStage;
       source?: PreviousNameSources;
+      documents?: IdentityDocument[] | null;
     }
     export type PreviousNameSources = "NameLog" | "Profile" | "Transcript";
     export type PreviousNameStage = "Unverified" | "ReadyforVerification" | "Verified" | "Archived";

--- a/src/ECER.Managers.Registry.Contract/Registrants/Contract.cs
+++ b/src/ECER.Managers.Registry.Contract/Registrants/Contract.cs
@@ -51,6 +51,7 @@ public record PreviousName(string FirstName, string LastName)
   public string? PreferredName { get; set; }
   public PreviousNameStage? Status { get; set; }
   public PreviousNameSources? Source { get; set; }
+  public IEnumerable<IdentityDocument> Documents { get; set; } = Array.Empty<IdentityDocument>();
 }
 
 public enum PreviousNameStage
@@ -66,6 +67,14 @@ public enum PreviousNameSources
   NameLog,
   Profile,
   Transcript,
+}
+
+public record IdentityDocument(string Id)
+{
+  public string Url { get; set; } = null!;
+  public string Extention { get; set; } = null!;
+  public string Name { get; set; } = null!;
+  public string Size { get; set; } = null!;
 }
 
 public record Address(

--- a/src/ECER.Managers.Registry/RegistrantMapper.cs
+++ b/src/ECER.Managers.Registry/RegistrantMapper.cs
@@ -20,25 +20,27 @@ internal sealed class RegistrantMapper : AutoMapper.Profile
       .ForCtorParam(nameof(Contract.Registrants.Registrant.UserId), opts => opts.MapFrom(s => s.Id))
       .ForCtorParam(nameof(Contract.Registrants.Registrant.Profile), opts => opts.MapFrom(s => s.Profile))
       ;
-    
+
     CreateMap<Contract.Registrants.UserProfile, Resources.Accounts.Registrants.UserProfile>()
-      .ForMember(d=> d.FirstName, opts => opts.MapFrom(s=>s.FirstName))
-      .ForMember(d=> d.LastName, opts => opts.MapFrom(s=>s.LastName))
-      .ForMember(d=> d.MiddleName, opts => opts.MapFrom(s=>s.MiddleName))
-      .ForMember(d=> d.PreferredName, opts => opts.MapFrom(s=>s.PreferredName))
-      .ForMember(d=> d.AlternateContactPhone, opts => opts.MapFrom(s=>s.AlternateContactPhone))
-      .ForMember(d=> d.Email, opts => opts.MapFrom(s=>s.Email))
-      .ForMember(d=> d.DateOfBirth, opts => opts.MapFrom(s=>s.DateOfBirth))
-      .ForMember(d=> d.Phone, opts => opts.MapFrom(s=>s.Phone))
-      .ForMember(d=> d.ResidentialAddress, opts => opts.MapFrom(s=>s.ResidentialAddress))
-      .ForMember(d=> d.MailingAddress, opts => opts.MapFrom(s=>s.MailingAddress))
-      .ForMember(d=> d.PreviousNames, opts => opts.MapFrom(s=>s.PreviousNames))
+      .ForMember(d => d.FirstName, opts => opts.MapFrom(s => s.FirstName))
+      .ForMember(d => d.LastName, opts => opts.MapFrom(s => s.LastName))
+      .ForMember(d => d.MiddleName, opts => opts.MapFrom(s => s.MiddleName))
+      .ForMember(d => d.PreferredName, opts => opts.MapFrom(s => s.PreferredName))
+      .ForMember(d => d.AlternateContactPhone, opts => opts.MapFrom(s => s.AlternateContactPhone))
+      .ForMember(d => d.Email, opts => opts.MapFrom(s => s.Email))
+      .ForMember(d => d.DateOfBirth, opts => opts.MapFrom(s => s.DateOfBirth))
+      .ForMember(d => d.Phone, opts => opts.MapFrom(s => s.Phone))
+      .ForMember(d => d.ResidentialAddress, opts => opts.MapFrom(s => s.ResidentialAddress))
+      .ForMember(d => d.MailingAddress, opts => opts.MapFrom(s => s.MailingAddress))
+      .ForMember(d => d.PreviousNames, opts => opts.MapFrom(s => s.PreviousNames))
       .ReverseMap()
         .ValidateMemberList(MemberList.Destination)
         ;
 
     CreateMap<Contract.Registrants.PreviousName, PreviousName>().ReverseMap();
-    
+
+    CreateMap<Contract.Registrants.IdentityDocument, IdentityDocument>().ReverseMap();
+
     CreateMap<Contract.Registrants.Address, Resources.Accounts.Registrants.Address>()
         .ReverseMap()
         .ValidateMemberList(MemberList.Destination)

--- a/src/ECER.Resources.Accounts/Registrants/IRegistrantRepository.cs
+++ b/src/ECER.Resources.Accounts/Registrants/IRegistrantRepository.cs
@@ -59,6 +59,7 @@ public record PreviousName(string FirstName, string LastName)
   public string? PreferredName { get; set; }
   public PreviousNameStage? Status { get; set; }
   public PreviousNameSources? Source { get; set; }
+  public IEnumerable<IdentityDocument> Documents { get; set; } = Array.Empty<IdentityDocument>();
 }
 
 public enum PreviousNameStage
@@ -74,6 +75,14 @@ public enum PreviousNameSources
   NameLog,
   Profile,
   Transcript,
+}
+
+public record IdentityDocument(string Id)
+{
+  public string Url { get; set; } = null!;
+  public string Extention { get; set; } = null!;
+  public string Name { get; set; } = null!;
+  public string Size { get; set; } = null!;
 }
 
 public record Address(

--- a/src/ECER.Resources.Accounts/Registrants/RegistrantRepositoryMapper.cs
+++ b/src/ECER.Resources.Accounts/Registrants/RegistrantRepositoryMapper.cs
@@ -22,7 +22,8 @@ internal sealed class RegistrantRepositoryMapper : Profile
       .ForMember(d => d.ecer_PreferredName, opts => opts.MapFrom(s => s.PreferredName))
       .ForMember(d => d.ecer_MiddleName, opts => opts.MapFrom(s => s.MiddleName))
       .ForMember(d => d.StatusCode, opts => opts.MapFrom(s => s.Status))
-      .ForMember(d => d.ecer_Source, opts => opts.MapFrom(s => s.Source));
+      .ForMember(d => d.ecer_Source, opts => opts.MapFrom(s => s.Source))
+      .ForMember(d => d.ecer_documenturl_PreviousNameId, opts => { opts.Condition(s => s.Documents.Any()); opts.MapFrom(s => s.Documents); });
 
     CreateMap<ecer_PreviousName, PreviousName>(MemberList.Source)
       .ForCtorParam(nameof(PreviousName.FirstName), opts => opts.MapFrom(s => s.ecer_FirstName))
@@ -32,7 +33,15 @@ internal sealed class RegistrantRepositoryMapper : Profile
       .ForMember(d => d.Status, opts => opts.MapFrom(s => s.StatusCode))
       .ForMember(d => d.Id, opts => opts.MapFrom(s => s.ecer_PreviousNameId))
       .ForMember(d => d.Source, opts => opts.MapFrom(s => s.ecer_Source))
+      .ForMember(d => d.Documents, opts => opts.Ignore())
       .ValidateMemberList(MemberList.Destination);
+
+    CreateMap<IdentityDocument, bcgov_DocumentUrl>(MemberList.Source)
+      .ForMember(d => d.bcgov_DocumentUrlId, opts => opts.MapFrom(s => s.Id))
+      .ForMember(d => d.bcgov_FileName, opts => opts.MapFrom(s => s.Name))
+      .ForMember(d => d.bcgov_FileSize, opts => opts.MapFrom(s => s.Size))
+      .ForMember(d => d.bcgov_Url, opts => opts.MapFrom(s => s.Url))
+      .ForMember(d => d.bcgov_FileExtension, opts => opts.MapFrom(s => s.Extention));
 
     CreateMap<ecer_Authentication, UserIdentity>()
         .ForCtorParam(nameof(UserIdentity.UserId), opts => opts.MapFrom(s => s.ecer_ExternalID))


### PR DESCRIPTION
## Title
ECER-2245: Upload ID for previous name

## Description

- B.E piece for file upload and move to permanent location.
- B.E changes to add uploaded files to bcgov_DocumentUrl dynamics entity and associate with previous name record 
- Updating existing previous name record and setting StatusCode = ecer_PreviousName_StatusCode.ReadyforVerification
- F.E changes for the verify previous name page
- Implemented uploaded file validations

## Related Jira Issue(s)

- ECER-2468
- ECER-2469
- ECER-2470
- ECER-2245

## Checklist
- [x] I have tested these changes locally.
- [x] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/5ed1892f-b018-4ae7-b858-ca30b440294f)

![image](https://github.com/user-attachments/assets/8bcf3bdb-b514-40a6-8498-7128231edc2d)

No file added:

![image](https://github.com/user-attachments/assets/f948edf8-81d8-4d20-9652-59c253716c1f)

