### PR TITLE
Stories/ecer 1932

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCertificationTypePreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCertificationTypePreview.vue
@@ -1,5 +1,5 @@
 <template>
-  <PreviewCard title="Application type" portal-stage="CertificationType" :editable="false">
+  <PreviewCard :title="generateTitle" portal-stage="CertificationType" :editable="false">
     <template #content>
       <v-row>
         <v-col cols="4">
@@ -42,9 +42,9 @@ export default defineComponent({
       if (this.applicationStore.isDraftCertificateTypeEceAssistant) {
         certificationType = "ECE Assistant";
       } else if (this.applicationStore.isDraftCertificateTypeOneYear) {
-        certificationType = "One Year";
+        certificationType = "ECE One Year";
       } else if (this.applicationStore.isDraftCertificateTypeFiveYears) {
-        certificationType = "Five Year";
+        certificationType = "ECE Five Year";
 
         if (this.applicationStore.isDraftCertificateTypeSne) {
           certificationType += " and Special Needs Educator (SNE)";
@@ -54,6 +54,13 @@ export default defineComponent({
         }
       }
       return certificationType;
+    },
+    generateTitle() {
+      if (this.applicationStore.isDraftApplicationRenewal) {
+        return "Certification renewal";
+      } else {
+        return "Application type";
+      }
     },
   },
 });

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceOneYearRenewalExplanationPreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceOneYearRenewalExplanationPreview.vue
@@ -1,0 +1,63 @@
+<template>
+  <PreviewCard title="Renewal Information" portal-stage="ExplanationLetter">
+    <template #content>
+      <v-row>
+        <v-col cols="4">
+          <p class="small">Why do you need to renew your ECE One Year certification</p>
+        </v-col>
+        <v-col>
+          <p class="small font-weight-bold">
+            {{ generateReasonToRenew }}
+          </p>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="4">
+          <p class="small">Other reason</p>
+        </v-col>
+        <v-col>
+          <p class="small font-weight-bold">
+            {{ wizardStore.wizardData[wizardStore.wizardConfig.steps.oneYearRenewalExplanation.form.inputs.explanationLetter.id] ?? "—" }}
+          </p>
+        </v-col>
+      </v-row>
+    </template>
+  </PreviewCard>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+import PreviewCard from "@/components/PreviewCard.vue";
+import { useWizardStore } from "@/store/wizard";
+import type { EcePreviewProps } from "@/types/input";
+import { renewalInformationRadio } from "@/utils/constant";
+export default defineComponent({
+  name: "EceOneYearRenewalExplanationPreview",
+  components: {
+    PreviewCard,
+  },
+  props: {
+    props: {
+      type: Object as () => EcePreviewProps,
+      required: true,
+    },
+  },
+  setup: () => {
+    const wizardStore = useWizardStore();
+    return {
+      wizardStore,
+    };
+  },
+  computed: {
+    generateReasonToRenew() {
+      const renewalReason = renewalInformationRadio.find(
+        (reason) =>
+          reason.value === this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.oneYearRenewalExplanation.form.inputs.oneYearRenewalExplanation.id],
+      )?.label;
+
+      return renewalReason ?? "-";
+    },
+  },
+});
+</script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceOneYearRenewalExplanationPreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceOneYearRenewalExplanationPreview.vue
@@ -17,7 +17,7 @@
         </v-col>
         <v-col>
           <p class="small font-weight-bold">
-            {{ wizardStore.wizardData[wizardStore.wizardConfig.steps.oneYearRenewalExplanation.form.inputs.explanationLetter.id] ?? "—" }}
+            {{ wizardStore.wizardData[wizardStore.wizardConfig.steps.oneYearRenewalExplanation.form.inputs.explanationLetter.id] || "—" }}
           </p>
         </v-col>
       </v-row>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceProfessionalDevelopment.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceProfessionalDevelopment.vue
@@ -113,11 +113,6 @@
             :rules="[
               Rules.required('Enter the end date of your course or workshop'),
               Rules.dateBeforeRule(startDate || ''),
-              Rules.dateBetweenRule(
-                certificationStore?.latestCertification?.effectiveDate || '',
-                certificationStore?.latestCertification?.expiryDate || '',
-                'The end date of your course or workshop must be within the term of your current certificate',
-              ),
               Rules.conditionalWrapper(
                 certificationStore.latestCertificateStatus === 'Active',
                 Rules.dateBetweenRule(

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceProfessionalDevelopmentPreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceProfessionalDevelopmentPreview.vue
@@ -1,0 +1,118 @@
+<template>
+  <PreviewCard title="Professional development" portal-stage="ProfessionalDevelopment">
+    <template #content>
+      <div v-for="(professionalDevelopment, index) in professionalDevelopments" :key="professionalDevelopment.id!">
+        <v-divider v-if="index !== 0" :thickness="2" color="grey-lightest" class="border-opacity-100 my-6" />
+        <v-row>
+          <v-col>
+            <h4 class="text-black">Name of course or workshop</h4>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col cols="4">
+            <p class="small">How many hours was it</p>
+          </v-col>
+          <v-col>
+            <p class="small font-weight-bold">{{ `${professionalDevelopment.numberOfHours} hours` }}</p>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col cols="4">
+            <p class="small">Name of place that hosted the course or workshop</p>
+          </v-col>
+          <v-col>
+            <p class="small font-weight-bold">{{ professionalDevelopment.organizationName }}</p>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col cols="4">
+            <p class="small">Website with description of course or workshop (optional)</p>
+          </v-col>
+          <v-col>
+            <p class="small font-weight-bold">{{ professionalDevelopment.courseorWorkshopLink || "-" }}</p>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col cols="4">
+            <p class="small">When did you take it?</p>
+          </v-col>
+          <v-col>
+            <p class="small font-weight-bold">
+              {{
+                `${formatDate(professionalDevelopment.startDate || "", "LLLL d, yyyy")} to ${formatDate(professionalDevelopment.endDate || "", "LLLL d, yyyy")}`
+              }}
+            </p>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col cols="4">
+            <p class="small">Instructor name</p>
+          </v-col>
+          <v-col>
+            <p class="small font-weight-bold">
+              {{ professionalDevelopment.instructorName || "-" }}
+            </p>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col cols="4">
+            <p class="small">Phone number</p>
+          </v-col>
+          <v-col>
+            <p class="small font-weight-bold">
+              {{ professionalDevelopment.organizationContactInformation || "-" }}
+            </p>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col cols="4">
+            <p class="small">Certificate of document that shows you completed the course</p>
+          </v-col>
+          <v-col>
+            <v-row no-gutters>
+              <v-col v-for="(file, childIndex) in professionalDevelopment.files" :key="childIndex" cols="12" class="small font-weight-bold">
+                {{ file.name }}
+              </v-col>
+            </v-row>
+          </v-col>
+        </v-row>
+      </div>
+    </template>
+  </PreviewCard>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+import PreviewCard from "@/components/PreviewCard.vue";
+import { useWizardStore } from "@/store/wizard";
+import type { EcePreviewProps } from "@/types/input";
+import type { Components } from "@/types/openapi";
+import { formatDate } from "@/utils/format";
+
+export default defineComponent({
+  name: "EceProfessionalDevelopmentPreview",
+  components: {
+    PreviewCard,
+  },
+  props: {
+    props: {
+      type: Object as () => EcePreviewProps,
+      required: true,
+    },
+  },
+  setup: () => {
+    const wizardStore = useWizardStore();
+
+    return {
+      wizardStore,
+      formatDate,
+    };
+  },
+  computed: {
+    professionalDevelopments(): Components.Schemas.ProfessionalDevelopment[] {
+      return this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.professionalDevelopments.form.inputs.professionalDevelopments.id];
+    },
+  },
+});
+</script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceProfessionalDevelopmentPreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceProfessionalDevelopmentPreview.vue
@@ -29,7 +29,7 @@
             <p class="small">Website with description of course or workshop (optional)</p>
           </v-col>
           <v-col>
-            <p class="small font-weight-bold">{{ professionalDevelopment.courseorWorkshopLink || "-" }}</p>
+            <p class="small font-weight-bold">{{ professionalDevelopment.courseorWorkshopLink || "—" }}</p>
           </v-col>
         </v-row>
         <v-row>
@@ -50,7 +50,7 @@
           </v-col>
           <v-col>
             <p class="small font-weight-bold">
-              {{ professionalDevelopment.instructorName || "-" }}
+              {{ professionalDevelopment.instructorName || "—" }}
             </p>
           </v-col>
         </v-row>
@@ -60,7 +60,7 @@
           </v-col>
           <v-col>
             <p class="small font-weight-bold">
-              {{ professionalDevelopment.organizationContactInformation || "-" }}
+              {{ professionalDevelopment.organizationContactInformation || "—" }}
             </p>
           </v-col>
         </v-row>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Application.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Application.vue
@@ -81,6 +81,7 @@ import type { ApplicationStage, Wizard as WizardType } from "@/types/wizard";
 import { AddressType } from "@/utils/constant";
 
 import type { ProfessionalDevelopmentExtended } from "../inputs/EceProfessionalDevelopment.vue";
+import { formatDate } from "@/utils/format";
 
 export default defineComponent({
   name: "Application",
@@ -109,7 +110,7 @@ export default defineComponent({
       return differenceInYears > 5;
     };
 
-    const draftApplicationCreatedOn = applicationStore.draftApplication.createdOn!;
+    const draftApplicationCreatedOn = applicationStore.draftApplication.createdOn || formatDate(DateTime.now().toString());
 
     if (applicationStore.isDraftApplicationRenewal) {
       if (applicationStore.isDraftCertificateTypeEceAssistant) {
@@ -120,7 +121,7 @@ export default defineComponent({
           if (!latestCertificateIsExpired(draftApplicationCreatedOn)) {
             await wizardStore.initializeWizard(applicationWizardRenewOneYearActive, applicationStore.draftApplication);
             wizardConfigSetup = applicationWizardRenewOneYearActive;
-          } else if (!latestCertificateExpiredMoreThan5Years(applicationStore.draftApplication.createdOn!)) {
+          } else if (!latestCertificateExpiredMoreThan5Years(draftApplicationCreatedOn)) {
             await wizardStore.initializeWizard(applicationWizardRenewOneYearExpired, applicationStore.draftApplication);
             wizardConfigSetup = applicationWizardRenewOneYearExpired;
           }

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Application.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Application.vue
@@ -79,9 +79,9 @@ import { useUserStore } from "@/store/user";
 import { useWizardStore } from "@/store/wizard";
 import type { ApplicationStage, Wizard as WizardType } from "@/types/wizard";
 import { AddressType } from "@/utils/constant";
+import { formatDate } from "@/utils/format";
 
 import type { ProfessionalDevelopmentExtended } from "../inputs/EceProfessionalDevelopment.vue";
-import { formatDate } from "@/utils/format";
 
 export default defineComponent({
   name: "Application",

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-renew-five-year-expired-less-than-five-years.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-renew-five-year-expired-less-than-five-years.ts
@@ -22,7 +22,7 @@ const applicationWizard: Wizard = {
       form: explanationLetterForm,
       key: "item.2",
     },
-    education: {
+    professionalDevelopments: {
       stage: "ProfessionalDevelopment",
       title: "Professional development",
       form: professionalDevelopmentForm,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-renew-five-year-expired-more-than-five-years.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-renew-five-year-expired-more-than-five-years.ts
@@ -15,7 +15,7 @@ const applicationWizard: Wizard = {
       form: profileInformationForm,
       key: "item.1",
     },
-    education: {
+    professionalDevelopments: {
       stage: "ProfessionalDevelopment",
       title: "Professional development",
       form: professionalDevelopmentForm,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-renew-one-year-active-review-form.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-renew-one-year-active-review-form.ts
@@ -1,0 +1,54 @@
+import EceCertificationTypePreview from "@/components/inputs/EceCertificationTypePreview.vue";
+import EceCharacterReferencePreview from "@/components/inputs/EceCharacterReferencePreview.vue";
+import EceContactInformationPreview from "@/components/inputs/EceContactInformationPreview.vue";
+import EceOneYearRenewalExplanationPreview from "@/components/inputs/EceOneYearRenewalExplanationPreview.vue";
+import type { Form } from "@/types/form";
+
+const renewOneYearActiveReviewForm: Form = {
+  id: "previewForm",
+  title: "Review and submit",
+  inputs: {
+    certificationSelectionPreview: {
+      id: "certificationSelectionPreview",
+      component: EceCertificationTypePreview,
+      props: {},
+      cols: {
+        md: 12,
+        lg: 12,
+        xl: 12,
+      },
+    },
+    contactInformationPreview: {
+      id: "contactInformationPreview",
+      component: EceContactInformationPreview,
+      props: {},
+      cols: {
+        md: 12,
+        lg: 12,
+        xl: 12,
+      },
+    },
+    oneYearRenewalExplanationPreview: {
+      id: "oneYearRenewalExplanationPreview",
+      component: EceOneYearRenewalExplanationPreview,
+      props: {},
+      cols: {
+        md: 12,
+        lg: 12,
+        xl: 12,
+      },
+    },
+    characterReferencePreview: {
+      id: "characterReferencePreview",
+      component: EceCharacterReferencePreview,
+      props: {},
+      cols: {
+        md: 12,
+        lg: 12,
+        xl: 12,
+      },
+    },
+  },
+};
+
+export default renewOneYearActiveReviewForm;

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-renew-one-year-active.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-renew-one-year-active.ts
@@ -1,9 +1,9 @@
 import type { Wizard } from "@/types/wizard";
 
+import renewOneYearActiveReviewForm from "./application-wizard-renew-one-year-active-review-form";
 import characterReferencesForm from "./character-references-form";
 import oneYearRenewalExplanationForm from "./one-year-renewal-explanation-letter-form";
 import profileInformationForm from "./profile-information-form";
-import reviewAndSubmitForm from "./review-submit-form";
 
 const applicationWizard: Wizard = {
   id: "form-1",
@@ -14,7 +14,7 @@ const applicationWizard: Wizard = {
       form: profileInformationForm,
       key: "item.1",
     },
-    oneYearRenewalExplanationLetter: {
+    oneYearRenewalExplanation: {
       stage: "ExplanationLetter",
       title: "Renewal information",
       form: oneYearRenewalExplanationForm,
@@ -29,7 +29,7 @@ const applicationWizard: Wizard = {
     review: {
       stage: "Review",
       title: "Review and submit",
-      form: reviewAndSubmitForm,
+      form: renewOneYearActiveReviewForm,
       key: "item.4",
     },
   },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-renew-one-year-expired-review-form.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-renew-one-year-expired-review-form.ts
@@ -1,0 +1,76 @@
+import EceCertificationTypePreview from "@/components/inputs/EceCertificationTypePreview.vue";
+import EceCharacterReferencePreview from "@/components/inputs/EceCharacterReferencePreview.vue";
+import EceContactInformationPreview from "@/components/inputs/EceContactInformationPreview.vue";
+import EceOneYearRenewalExplanationPreview from "@/components/inputs/EceOneYearRenewalExplanationPreview.vue";
+import EceProfessionalDevelopmentPreview from "@/components/inputs/EceProfessionalDevelopmentPreview.vue";
+import EceWorkExperienceReferencePreview from "@/components/inputs/EceWorkExperienceReferencePreview.vue";
+import type { Form } from "@/types/form";
+
+const renewOneYearExpiredReviewForm: Form = {
+  id: "previewForm",
+  title: "Review and submit",
+  inputs: {
+    certificationSelectionPreview: {
+      id: "certificationSelectionPreview",
+      component: EceCertificationTypePreview,
+      props: {},
+      cols: {
+        md: 12,
+        lg: 12,
+        xl: 12,
+      },
+    },
+    contactInformationPreview: {
+      id: "contactInformationPreview",
+      component: EceContactInformationPreview,
+      props: {},
+      cols: {
+        md: 12,
+        lg: 12,
+        xl: 12,
+      },
+    },
+    oneYearRenewalExplanationPreview: {
+      id: "oneYearRenewalExplanationPreview",
+      component: EceOneYearRenewalExplanationPreview,
+      props: {},
+      cols: {
+        md: 12,
+        lg: 12,
+        xl: 12,
+      },
+    },
+    professionalDevelopmentPreview: {
+      id: "professionalDevelopmentPreview",
+      component: EceProfessionalDevelopmentPreview,
+      props: {},
+      cols: {
+        md: 12,
+        lg: 12,
+        xl: 12,
+      },
+    },
+    characterReferencePreview: {
+      id: "characterReferencePreview",
+      component: EceCharacterReferencePreview,
+      props: {},
+      cols: {
+        md: 12,
+        lg: 12,
+        xl: 12,
+      },
+    },
+    workExperienceReferencePreview: {
+      id: "workExperienceReferencePreview",
+      component: EceWorkExperienceReferencePreview,
+      props: {},
+      cols: {
+        md: 12,
+        lg: 12,
+        xl: 12,
+      },
+    },
+  },
+};
+
+export default renewOneYearExpiredReviewForm;

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-renew-one-year-expired.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/application-wizard-renew-one-year-expired.ts
@@ -1,11 +1,11 @@
 import type { Wizard } from "@/types/wizard";
 
+import renewOneYearExpiredReviewForm from "./application-wizard-renew-one-year-expired-review-form";
 import characterReferencesForm from "./character-references-form";
-import explanationLetterForm from "./explanation-letter-form";
+import oneYearRenewalExplanation from "./one-year-renewal-explanation-letter-form";
 import professionalDevelopmentForm from "./professional-development-form";
 import profileInformationForm from "./profile-information-form";
 import referencesForm from "./references-form";
-import reviewAndSubmitForm from "./review-submit-form";
 
 const applicationWizard: Wizard = {
   id: "form-1",
@@ -16,13 +16,13 @@ const applicationWizard: Wizard = {
       form: profileInformationForm,
       key: "item.1",
     },
-    explanationLetter: {
+    oneYearRenewalExplanation: {
       stage: "ExplanationLetter",
-      title: "Explanation Letter",
-      form: explanationLetterForm,
+      title: "Renewal information",
+      form: oneYearRenewalExplanation,
       key: "item.2",
     },
-    education: {
+    professionalDevelopments: {
       stage: "ProfessionalDevelopment",
       title: "Professional development",
       form: professionalDevelopmentForm,
@@ -43,7 +43,7 @@ const applicationWizard: Wizard = {
     review: {
       stage: "Review",
       title: "Review and submit",
-      form: reviewAndSubmitForm,
+      form: renewOneYearExpiredReviewForm,
       key: "item.6",
     },
   },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/application.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/application.ts
@@ -116,13 +116,13 @@ export const useApplicationStore = defineStore("application", {
 
       // One year renewal explanation letter
       if (
-        wizardStore.wizardConfig.steps?.oneYearRenewalExplanationLetter?.form?.inputs?.oneYearRenewalExplanation?.id &&
-        wizardStore.wizardConfig.steps?.oneYearRenewalExplanationLetter?.form?.inputs?.explanationLetter?.id
+        wizardStore.wizardConfig.steps?.oneYearRenewalExplanation?.form?.inputs?.oneYearRenewalExplanation?.id &&
+        wizardStore.wizardConfig.steps?.oneYearRenewalExplanation?.form?.inputs?.explanationLetter?.id
       ) {
         this.draftApplication.oneYearRenewalexplanation =
-          wizardStore.wizardData[wizardStore.wizardConfig.steps.oneYearRenewalExplanationLetter.form.inputs.oneYearRenewalExplanation.id];
+          wizardStore.wizardData[wizardStore.wizardConfig.steps.oneYearRenewalExplanation.form.inputs.oneYearRenewalExplanation.id];
         this.draftApplication.explanationLetter =
-          wizardStore.wizardData[wizardStore.wizardConfig.steps.oneYearRenewalExplanationLetter.form.inputs.explanationLetter.id];
+          wizardStore.wizardData[wizardStore.wizardConfig.steps.oneYearRenewalExplanation.form.inputs.explanationLetter.id];
       }
 
       // Character References step data

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/wizard.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/wizard.ts
@@ -89,11 +89,11 @@ export const useWizardStore = defineStore("wizard", {
         ...(wizard.steps?.education?.form?.inputs?.educationList?.id && { [wizard.steps?.education?.form?.inputs?.educationList?.id]: transcriptsDict }),
 
         // one year explanation letter
-        ...(wizard.steps?.oneYearRenewalExplanationLetter?.form?.inputs?.oneYearRenewalExplanation?.id && {
-          [wizard.steps?.oneYearRenewalExplanationLetter?.form?.inputs?.oneYearRenewalExplanation?.id]: draftApplication?.oneYearRenewalexplanation || "",
+        ...(wizard.steps?.oneYearRenewalExplanation?.form?.inputs?.oneYearRenewalExplanation?.id && {
+          [wizard.steps?.oneYearRenewalExplanation?.form?.inputs?.oneYearRenewalExplanation?.id]: draftApplication?.oneYearRenewalexplanation || "",
         }),
-        ...(wizard.steps?.oneYearRenewalExplanationLetter?.form?.inputs?.explanationLetter?.id && {
-          [wizard.steps?.oneYearRenewalExplanationLetter?.form?.inputs?.explanationLetter?.id]: draftApplication?.explanationLetter || "",
+        ...(wizard.steps?.oneYearRenewalExplanation?.form?.inputs?.explanationLetter?.id && {
+          [wizard.steps?.oneYearRenewalExplanation?.form?.inputs?.explanationLetter?.id]: draftApplication?.explanationLetter || "",
         }),
 
         // Character References step data

--- a/src/ECER.Engines.Validation/Applications/RenewalValidationConditions/OneYear.cs
+++ b/src/ECER.Engines.Validation/Applications/RenewalValidationConditions/OneYear.cs
@@ -12,8 +12,8 @@ internal sealed partial class ApplicationRenewalValidationEngine
     {
       case CertificateStatus.Active:
 
-        // each application should contain explanation letter
-        if (string.IsNullOrEmpty(application.ExplanationLetter))
+        
+        if (application.OneYearRenewalexplanation == OneYearRenewalexplanations.Other && string.IsNullOrEmpty(application.ExplanationLetter))
         {
           validationErrors.Add("the application does not have explanation letter");
         }
@@ -30,8 +30,9 @@ internal sealed partial class ApplicationRenewalValidationEngine
         {
           validationErrors.Add("the application does not have any professional development");
         }
+        
         // each application should contain explanation letter
-        if (string.IsNullOrEmpty(application.ExplanationLetter))
+        if (application.OneYearRenewalexplanation == OneYearRenewalexplanations.Other && string.IsNullOrEmpty(application.ExplanationLetter))
         {
           validationErrors.Add("the application does not have explanation letter");
         }

--- a/src/ECER.Tests/Unit/ApplicationRenewalValidationEngineTests.cs
+++ b/src/ECER.Tests/Unit/ApplicationRenewalValidationEngineTests.cs
@@ -44,12 +44,13 @@ public class ApplicationRenewalValidationEngineTests
   }
 
   [Fact]
-  public async Task Validate_OneYearRenewalWithActiveCertificateWithoutExplanationLetter_ReturnsExplanationLetterError()
+  public async Task Validate_OneYearRenewalWithActiveCertificateOneYearRenewalOtherWithoutExplanationLetter_ReturnsExplanationLetterError()
   {
     // Arrange
     var application = new Application("id", "registrantId", ApplicationStatus.Draft)
     {
       CertificationTypes = new List<CertificationType> { CertificationType.OneYear },
+      OneYearRenewalexplanation = OneYearRenewalexplanations.Other,
       ExplanationLetter = null, // No explanation letter
       CharacterReferences = new List<CharacterReference> { CreateMockCharacterReference() }
     };


### PR DESCRIPTION
ECER-1932: Completing the flows for one year renewal active + expired in Wizard.  

## Description

- small bug fix for explanation letter not being populated. 
- fixed validation for explanation letter. It should be required only if user selects other.
- review screens completed for both flows. 
- fixed between dates issue for professional development

## Related Jira Issue(s)

- ECER-{###}
- etc.

## Checklist
- [x] I have tested these changes locally.
- [x] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Review page for one year expired application
![localhost_5121_application](https://github.com/user-attachments/assets/e572209e-311d-4af9-bfe2-67722b4a1c1c)

Review page for one year active application
![localhost_5121_application (1)](https://github.com/user-attachments/assets/3d8a9add-e079-4709-a119-fdefe4503262)
