### PR TITLE
ECER-1186: Limit file upload to one file for professional development

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/FileUploader.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/FileUploader.vue
@@ -6,8 +6,8 @@
         Attachments
       </p>
       <p>You can only upload PDF files up to 10MB.</p>
-      <v-btn prepend-icon="mdi-plus" variant="text" color="primary" class="mt-3" @click="triggerFileInput">Add file</v-btn>
-      <v-file-input ref="fileInput" style="display: none" multiple accept="application/pdf" @change="handleFileUpload"></v-file-input>
+      <v-btn v-if="showAddFileButton" prepend-icon="mdi-plus" variant="text" color="primary" class="mt-3" @click="triggerFileInput">Add file</v-btn>
+      <v-file-input ref="fileInput" style="display: none" :multiple="allowMultipleFiles" accept="application/pdf" @change="handleFileUpload"></v-file-input>
       <Alert v-model="showErrorBanner" class="mt-10" type="error">
         <p class="small">{{ errorBannerMessage }}</p>
       </Alert>
@@ -66,6 +66,16 @@ export default defineComponent({
       type: Array as PropType<any[]>,
       required: false,
       default: () => [],
+    },
+    allowMultipleFiles: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
+    showAddFileButton: {
+      type: Boolean,
+      required: false,
+      default: true,
     },
   },
   emits: ["update:files", "delete:file"],

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceProfessionalDevelopment.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceProfessionalDevelopment.vue
@@ -219,6 +219,8 @@
       <v-row v-if="showFileInput">
         <v-col>
           <FileUploader
+            :allow-multiple-files="false"
+            :show-add-file-button="generateUserFileArray.length === 0 && !isFileUploadInProgress"
             :user-files="generateUserFileArray"
             :rules="[Rules.atLeastOneOptionRequired('Upload a certificate or document that shows you completed the course or workshop')]"
             :delete-file-from-temp-when-removed="false"


### PR DESCRIPTION
## Description

- Add optional props with defaults to FileUploader component
- Only allow 1 file uploaded for Professional Development before hiding the "+ Add File" button

## Related Jira Issue(s)

- [ECER-1186](https://eccbc.atlassian.net/browse/ECER-1186)

## Checklist
- [X] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.