### PR TITLE
Filter previous names on portal profile page

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Profile.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Profile.vue
@@ -62,8 +62,8 @@
         <v-col class="mt-6">
           <div class="d-flex flex-column ga-3">
             <p class="font-weight-bold mb-3">Previous names</p>
-            <div v-if="userStore.verifiedPreviousNames.length > 0">
-              <p v-for="(prev, index) in userStore.verifiedPreviousNames" :key="index">
+            <div v-if="verifiedPreviousNamesFiltered.length > 0">
+              <p v-for="(prev, index) in verifiedPreviousNamesFiltered" :key="index">
                 {{ prev.middleName ? `${prev.firstName} ${prev.middleName} ${prev.lastName}` : `${prev.firstName} ${prev.lastName}` }}
               </p>
             </div>
@@ -169,10 +169,10 @@ export default defineComponent({
   setup: async () => {
     const userProfile = await getProfile();
     const userStore = useUserStore();
-
+    const verifiedPreviousNamesFiltered = userStore.verifiedPreviousNames.filter((name) => name.source !== "NameLog");
     userStore.setUserProfile(userProfile);
 
-    return { userProfile, userStore };
+    return { userProfile, userStore, verifiedPreviousNamesFiltered };
   },
   data: () => ({
     items: [

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Profile.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Profile.vue
@@ -62,8 +62,8 @@
         <v-col class="mt-6">
           <div class="d-flex flex-column ga-3">
             <p class="font-weight-bold mb-3">Previous names</p>
-            <div v-if="verifiedPreviousNamesFiltered.length > 0">
-              <p v-for="(prev, index) in verifiedPreviousNamesFiltered" :key="index">
+            <div v-if="userStore.verifiedPreviousNames.length > 0">
+              <p v-for="(prev, index) in userStore.verifiedPreviousNames" :key="index">
                 {{ prev.middleName ? `${prev.firstName} ${prev.middleName} ${prev.lastName}` : `${prev.firstName} ${prev.lastName}` }}
               </p>
             </div>
@@ -169,10 +169,10 @@ export default defineComponent({
   setup: async () => {
     const userProfile = await getProfile();
     const userStore = useUserStore();
-    const verifiedPreviousNamesFiltered = userStore.verifiedPreviousNames.filter((name) => name.source !== "NameLog");
+
     userStore.setUserProfile(userProfile);
 
-    return { userProfile, userStore, verifiedPreviousNamesFiltered };
+    return { userProfile, userStore };
   },
   data: () => ({
     items: [

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
@@ -142,7 +142,7 @@
         <p>What name is shown on your transcript?</p>
         <br />
         <v-radio-group v-model="previousNameRadio" :rules="[Rules.requiredRadio('Select an option')]" @update:model-value="previousNameRadioChanged">
-          <v-radio v-for="(step, index) in previousNameRadioOptions" :key="index" :label="step.label" :value="step.value"></v-radio>
+          <v-radio v-for="(step, index) in ApplicantNameRadioOptions" :key="index" :label="step.label" :value="step.value"></v-radio>
         </v-radio-group>
         <div v-if="previousNameRadio === 'other'">
           <v-row>
@@ -306,6 +306,15 @@ export default defineComponent({
       this.applicationStore.isDraftCertificateTypeIte && numOfEducationRequired++;
 
       return numOfEducationRequired;
+    },
+    ApplicantNameRadioOptions(): RadioOptions[] {
+      let legalNameRadioOptions: RadioOptions[] = [
+        {
+          label: this.userStore.legalName,
+          value: { firstName: this.userStore.firstName, middleName: this.userStore.middleName, lastName: this.userStore.lastName },
+        },
+      ];
+      return [...legalNameRadioOptions, ...this.previousNameRadioOptions];
     },
     previousNameRadioOptions(): RadioOptions[] {
       let radioOptions: RadioOptions[] = this.userStore.verifiedPreviousNames.map((previousName) => {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/user.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/user.ts
@@ -31,9 +31,11 @@ export const useUserStore = defineStore("user", {
       return state.userProfile?.previousNames?.filter((name) => name.status === "ReadyforVerification") ?? [];
     },
     verifiedPreviousNames: (state): Components.Schemas.PreviousName[] => {
-      return state.userProfile?.previousNames?.filter((name) => name.status === "Verified") ?? [];
+      return state.userProfile?.previousNames?.filter((name) => name.status === "Verified" && name.source !== "NameLog") ?? [];
     },
     firstName: (state): string => state.userInfo?.firstName ?? "",
+    middleName: (state): string => state.userInfo?.middleName ?? "",
+    lastName: (state): string => state.userInfo?.lastName ?? "",
     fullName: (state): string => (state.userInfo?.lastName ? `${state.userInfo?.firstName} ${state.userInfo?.lastName}` : `${state.userInfo?.firstName}`),
     email: (state): string => state.userInfo?.email ?? "",
     phoneNumber: (state): string => state.userProfile?.phone ?? "",


### PR DESCRIPTION
## Title
Filter previous names on portal profile page

## Description

- Filter previous names on portal profile page to not include previous names with Source == "NameLog" 


## Related Jira Issue(s)

- ECER-{###}
- etc.

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)

![localhost_5121_profile](https://github.com/user-attachments/assets/809aa833-cc68-49ba-932c-90b11acfb964)

