### PR TITLE
ECER:2849: Add more hours to professional development during assessment - B.E get professional development status and F.E Piece

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationMapper.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationMapper.cs
@@ -76,6 +76,7 @@ public class ApplicationMapper : Profile
       .ForMember(d => d.ReadyForAssessmentDate, opts => opts.Ignore())
       .ForMember(d => d.AddMoreCharacterReference, opts => opts.Ignore())
       .ForMember(d => d.AddMoreWorkExperienceReference, opts => opts.Ignore())
+      .ForMember(d => d.AddMoreProfessionalDevelopment, opts => opts.Ignore())
       .ForMember(d => d.Transcripts, opts => opts.MapFrom(s => s.Transcripts))
       .ForMember(d => d.WorkExperienceReferences, opts => opts.MapFrom(s => s.WorkExperienceReferences))
       .ForMember(d => d.ProfessionalDevelopments, opts => opts.MapFrom(s => s.ProfessionalDevelopments))
@@ -107,8 +108,10 @@ public class ApplicationMapper : Profile
       .ForMember(d => d.TranscriptsStatus, opts => opts.MapFrom(s => s.Transcripts))
       .ForMember(d => d.WorkExperienceReferencesStatus, opts => opts.MapFrom(s => s.WorkExperienceReferences))
       .ForMember(d => d.CharacterReferencesStatus, opts => opts.MapFrom(s => s.CharacterReferences))
+      .ForMember(d => d.ProfessionalDevelopmentsStatus, opts => opts.MapFrom(s => s.ProfessionalDevelopments))
       .ForMember(d => d.AddMoreCharacterReference, opts => opts.MapFrom(s => s.AddMoreCharacterReference))
       .ForMember(d => d.AddMoreWorkExperienceReference, opts => opts.MapFrom(s => s.AddMoreWorkExperienceReference))
+      .ForMember(d => d.AddMoreProfessionalDevelopment, opts => opts.MapFrom(s => s.AddMoreProfessionalDevelopment))
       .ForMember(d => d.ApplicationType, opts => opts.MapFrom(s => s.ApplicationType));
 
     CreateMap<Managers.Registry.Contract.Applications.CharacterReference, CharacterReferenceStatus>()
@@ -150,5 +153,14 @@ public class ApplicationMapper : Profile
         opt => opt.MapFrom(src => src.EducationalInstitutionName))
       .ForCtorParam(nameof(TranscriptStatus.Status),
         opt => opt.MapFrom(src => src.Status));
+
+    CreateMap<Managers.Registry.Contract.Applications.ProfessionalDevelopment, ProfessionalDevelopmentStatus>()
+      .ForCtorParam(nameof(ProfessionalDevelopmentStatus.Id),
+        opt => opt.MapFrom(src => src.Id))
+      .ForCtorParam(nameof(ProfessionalDevelopmentStatus.CourseName),
+        opt => opt.MapFrom(src => src.CourseName))
+      .ForCtorParam(nameof(ProfessionalDevelopmentStatus.NumberOfHours),
+        opt => opt.MapFrom(src => src.NumberOfHours))
+      .ForMember(d => d.Status, opts => opts.MapFrom(s => s.Status));
   }
 }

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
@@ -507,8 +507,10 @@ public record SubmittedApplicationStatus(string Id, DateTime SubmittedOn, Applic
   public IEnumerable<TranscriptStatus> TranscriptsStatus { get; set; } = Array.Empty<TranscriptStatus>();
   public IEnumerable<WorkExperienceReferenceStatus> WorkExperienceReferencesStatus { get; set; } = Array.Empty<WorkExperienceReferenceStatus>();
   public IEnumerable<CharacterReferenceStatus> CharacterReferencesStatus { get; set; } = Array.Empty<CharacterReferenceStatus>();
+  public IEnumerable<ProfessionalDevelopmentStatus> ProfessionalDevelopmentsStatus { get; set; } = Array.Empty<ProfessionalDevelopmentStatus>();
   public bool? AddMoreCharacterReference { get; set; }
   public bool? AddMoreWorkExperienceReference { get; set; }
+  public bool? AddMoreProfessionalDevelopment { get; set; }
   public ApplicationTypes? ApplicationType { get; set; }
 }
 public record FileInfo(string Id)
@@ -534,6 +536,11 @@ public record CharacterReferenceStatus(string Id, CharacterReferenceStage Status
 {
   public string? PhoneNumber { get; set; }
   public bool? WillProvideReference { get; set; }
+}
+
+public record ProfessionalDevelopmentStatus(string Id, string CourseName, int NumberOfHours)
+{
+  public ProfessionalDevelopmentStatusCode? Status { get; set; }
 }
 
 public enum TranscriptStage
@@ -580,8 +587,8 @@ public enum CharacterReferenceStage
 public enum ProfessionalDevelopmentStatusCode
 {
   ApplicationSubmitted,
+  Approved,
   Draft,
-  Inactive,
   InProgress,
   Rejected,
   Submitted,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/api/application.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/api/application.ts
@@ -61,4 +61,15 @@ const getApplicationStatus = async (applicationId: string): Promise<ApiResponse<
   });
 };
 
-export { cancelDraftApplication, createOrUpdateDraftApplication, getApplications, getApplicationStatus, submitDraftApplication };
+const addProfessionalDevelopment = async (
+  params: Paths.ApplicationProfessionaldevelopmentAddPost.PathParameters,
+  body: Paths.ApplicationProfessionaldevelopmentAddPost.RequestBody,
+): Promise<ApiResponse<any>> => {
+  const client = await getClient();
+  return apiResultHandler.execute({
+    request: client.application_professionaldevelopment_add_post(params, body),
+    key: "application_professionaldevelopment_add_post",
+  });
+};
+
+export { addProfessionalDevelopment, cancelDraftApplication, createOrUpdateDraftApplication, getApplications, getApplicationStatus, submitDraftApplication };

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/AddProfessionalDevelopment.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/AddProfessionalDevelopment.vue
@@ -1,0 +1,425 @@
+<template>
+  <v-container>
+    <v-breadcrumbs class="pl-0" :items="items" color="primary">
+      <template #divider>/</template>
+    </v-breadcrumbs>
+    <div class="d-flex flex-column ga-3">
+      <h1 class="mt-5">Professional development</h1>
+      <v-row>
+        <v-col>
+          <h3>Add course or workshop</h3>
+          <br />
+          <p>The course or workshop must:</p>
+          <br />
+          <ul class="ml-10">
+            <li>Be relevant to the field of early childhood education</li>
+            <li v-if="certificationStore.latestCertificateStatus === 'Active'">
+              {{
+                `Have been completed within the term of your current certificate (Between ${formatDate(certificationStore?.latestCertification?.effectiveDate || "", "LLLL d, yyyy")} to ${formatDate(certificationStore?.latestCertification?.expiryDate || "", "LLLL d, yyyy")})`
+              }}
+            </li>
+            <li v-else-if="certificationStore.latestCertificateStatus === 'Expired'">Have been completed within the last 5 years</li>
+          </ul>
+        </v-col>
+      </v-row>
+      <v-form ref="professionalDevelopmentForm">
+        <v-row>
+          <v-col>
+            <h3 class="mt-5">Course or workshop information</h3>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col md="8" lg="6" xl="4">
+            <v-text-field
+              v-model="professionalDevelopment.courseName"
+              variant="outlined"
+              label="Name of course or workshop"
+              maxlength="100"
+              :rules="[Rules.required('Enter your course or workshop name')]"
+            ></v-text-field>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col md="8" lg="6" xl="4">
+            <v-text-field
+              v-model="professionalDevelopment.numberOfHours"
+              variant="outlined"
+              label="How many hours was it?"
+              :rules="[Rules.required('Enter your course of workshop hours')]"
+              @keypress="isNumber($event)"
+            ></v-text-field>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col md="8" lg="6" xl="4">
+            <v-text-field
+              v-model="professionalDevelopment.organizationName"
+              variant="outlined"
+              label="Name of place that hosted the course or workshop"
+              maxlength="300"
+              :rules="[Rules.required('Enter the name of the place that hosted the course or workshop')]"
+            ></v-text-field>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col md="8" lg="6" xl="4">
+            <v-text-field
+              variant="outlined"
+              label="Website with description of course or workshop (optional)"
+              maxlength="500"
+              :rules="[Rules.website()]"
+            ></v-text-field>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col>
+            <h3>When did you take it?</h3>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col sm="6" md="4" lg="2">
+            <v-text-field
+              ref="startDateInput"
+              v-model="professionalDevelopment.startDate"
+              :rules="[
+                Rules.required('Enter the start date of your course or workshop'),
+                Rules.futureDateNotAllowedRule(),
+                Rules.conditionalWrapper(
+                  certificationStore.latestCertificateStatus === 'Active',
+                  Rules.dateBetweenRule(
+                    certificationStore?.latestCertification?.effectiveDate || '',
+                    certificationStore?.latestCertification?.expiryDate || '',
+                    'The start date of your course or workshop must be within the term of your current certificate',
+                  ),
+                ),
+                Rules.conditionalWrapper(
+                  certificationStore.latestCertificateStatus === 'Expired',
+                  Rules.dateRuleRange(
+                    applicationStore.draftApplication.createdOn || '',
+                    5,
+                    'The start date of your course or workshop must be within the last five years',
+                  ),
+                ),
+              ]"
+              label="Start date"
+              type="date"
+              variant="outlined"
+              color="primary"
+              :max="today"
+              @input="validateDates"
+            ></v-text-field>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col sm="6" md="4" lg="2">
+            <v-text-field
+              ref="endDateInput"
+              v-model="professionalDevelopment.endDate"
+              :rules="[
+                Rules.required('Enter the end date of your course or workshop'),
+                Rules.futureDateNotAllowedRule(),
+                Rules.dateBeforeRule(professionalDevelopment.startDate || ''),
+                Rules.conditionalWrapper(
+                  certificationStore.latestCertificateStatus === 'Active',
+                  Rules.dateBetweenRule(
+                    certificationStore?.latestCertification?.effectiveDate || '',
+                    certificationStore?.latestCertification?.expiryDate || '',
+                    'The end date of your course or workshop must be within the term of your current certificate',
+                  ),
+                ),
+                Rules.conditionalWrapper(
+                  certificationStore.latestCertificateStatus === 'Expired',
+                  Rules.dateRuleRange(
+                    applicationStore.draftApplication.createdOn || '',
+                    5,
+                    'The end date of your course or workshop must be within the last five years',
+                  ),
+                ),
+              ]"
+              label="End date"
+              type="date"
+              variant="outlined"
+              color="primary"
+              :max="today"
+              @input="validateDates"
+            ></v-text-field>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col>
+            <h3>Proof of course or workshop</h3>
+            <br />
+            <p>We may need to verify you took this course. You'll need to provide at least one option below</p>
+            <br />
+            <p>What can you provide? Choose all that apply</p>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col>
+            <v-checkbox
+              v-model="professionalDevelopment.selection"
+              label="Phone number for instructor of course or workshop"
+              :hide-details="true"
+              density="compact"
+              value="phone"
+              @input="selectionChanged"
+            ></v-checkbox>
+            <v-checkbox
+              v-model="professionalDevelopment.selection"
+              label="Email address for instructor of course or workshop"
+              :hide-details="true"
+              value="email"
+              density="compact"
+              @input="selectionChanged"
+            ></v-checkbox>
+            <v-checkbox
+              v-model="professionalDevelopment.selection"
+              label="A certificate or document that shows I completed the course"
+              hide-details="auto"
+              value="file"
+              density="compact"
+              :rules="[Rules.atLeastOneOptionRequired()]"
+              @input="selectionChanged"
+            ></v-checkbox>
+          </v-col>
+        </v-row>
+        <v-row v-if="showInstructorNameInput">
+          <v-col cmd="8" lg="6" xl="4">
+            <v-text-field
+              v-model="professionalDevelopment.instructorName"
+              variant="outlined"
+              label="Instructor name"
+              maxlength="100"
+              :rules="[Rules.required('Enter the instructor name of your course or workshop')]"
+            ></v-text-field>
+          </v-col>
+        </v-row>
+        <v-row v-if="showPhoneNumberInput">
+          <v-col md="8" lg="6" xl="4">
+            <v-text-field
+              v-model="professionalDevelopment.organizationContactInformation"
+              label="Phone number"
+              :rules="[
+                Rules.required('Enter the phone number for your course or workshop contact'),
+                Rules.phoneNumber('Enter your reference\'s 10-digit phone number'),
+              ]"
+              variant="outlined"
+              color="primary"
+              maxlength="10"
+              @keypress="isNumber($event)"
+            ></v-text-field>
+          </v-col>
+        </v-row>
+        <v-row v-if="showEmailInput">
+          <v-col md="8" lg="6" xl="4">
+            <v-text-field
+              v-model="professionalDevelopment.organizationEmailAddress"
+              variant="outlined"
+              label="Email address"
+              :rules="[Rules.required('Enter the email address of your course or workshop contact'), Rules.email()]"
+            ></v-text-field>
+          </v-col>
+        </v-row>
+        <v-row v-if="showFileInput">
+          <v-col>
+            <FileUploader
+              :allow-multiple-files="false"
+              :show-add-file-button="!professionalDevelopment.isFileUploadInProgress"
+              @update:files="handleFileUpdate"
+            />
+          </v-col>
+        </v-row>
+      </v-form>
+    </div>
+    <v-row class="mt-6">
+      <v-col class="d-flex flex-row ga-3 flex-wrap">
+        <v-btn
+          size="large"
+          color="primary"
+          :loading="loadingStore.isLoading('application_professionaldevelopment_add_post')"
+          @click="handleAddProfessionalDevelopment"
+        >
+          Save course or workshop
+        </v-btn>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import { DateTime } from "luxon";
+import { defineComponent } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import type { VForm, VInput } from "vuetify/components";
+
+import { getApplicationStatus } from "@/api/application";
+import { addProfessionalDevelopment } from "@/api/application";
+import FileUploader from "@/components/FileUploader.vue";
+import { useAlertStore } from "@/store/alert";
+import { useApplicationStore } from "@/store/application";
+import { useCertificationStore } from "@/store/certification";
+import { useLoadingStore } from "@/store/loading";
+import type { Components } from "@/types/openapi";
+import { formatDate } from "@/utils/format";
+import { isNumber } from "@/utils/formInput";
+import * as Rules from "@/utils/formRules";
+
+import type { FileItem } from "./UploadFileItem.vue";
+
+interface ProfessionalDevelopmentData {
+  selection: ("phone" | "email" | "file")[];
+  areAttachedFilesValid: boolean;
+  isFileUploadInProgress: boolean;
+}
+
+export default defineComponent({
+  name: "AddProfessionalDevelopment",
+  components: { FileUploader },
+  props: {
+    applicationId: {
+      type: String,
+      required: true,
+    },
+  },
+  setup: async () => {
+    const applicationStore = useApplicationStore();
+    const alertStore = useAlertStore();
+
+    const loadingStore = useLoadingStore();
+    const router = useRouter();
+    const route = useRoute();
+    const applicationStatus = (await getApplicationStatus(route.params.applicationId.toString()))?.data;
+    const certificationStore = useCertificationStore();
+
+    return {
+      applicationStore,
+      alertStore,
+      loadingStore,
+      router,
+      applicationStatus,
+      certificationStore,
+      formatDate,
+    };
+  },
+  data() {
+    const items = [
+      {
+        title: "Home",
+        disabled: false,
+        href: "/",
+      },
+      {
+        title: "Application",
+        disabled: false,
+        href: `/manage-application/${this.applicationId}`,
+      },
+      {
+        title: "Professional development",
+        disabled: false,
+        href: `/manage-application/${this.applicationId}/professional-development`,
+      },
+      {
+        title: "Add",
+        disabled: true,
+        href: `/manage-application/${this.applicationId}/professional-development/add`,
+      },
+    ];
+
+    const professionalDevelopment: ProfessionalDevelopmentData & Components.Schemas.ProfessionalDevelopment = {
+      selection: [],
+      areAttachedFilesValid: true,
+      isFileUploadInProgress: false,
+    };
+
+    return { items, professionalDevelopment, Rules };
+  },
+  computed: {
+    applicationType() {
+      return this.applicationStatus?.applicationType!;
+    },
+    today() {
+      return formatDate(DateTime.now().toString());
+    },
+    showInstructorNameInput() {
+      return this.professionalDevelopment.selection.includes("email") || this.professionalDevelopment.selection.includes("phone");
+    },
+    showPhoneNumberInput() {
+      return this.professionalDevelopment.selection.includes("phone");
+    },
+    showEmailInput() {
+      return this.professionalDevelopment.selection.includes("email");
+    },
+    showFileInput() {
+      return this.professionalDevelopment.selection.includes("file");
+    },
+  },
+
+  methods: {
+    async handleAddProfessionalDevelopment() {
+      // Validate the form
+      const { valid } = await (this.$refs.professionalDevelopmentForm as VForm).validate();
+
+      if (valid) {
+        const { error } = await addProfessionalDevelopment({ application_id: this.applicationId }, this.professionalDevelopment);
+        if (error) {
+          this.alertStore.setFailureAlert("Sorry, something went wrong and your changes could not be saved. Try again later.");
+        } else {
+          this.alertStore.setSuccessAlert("Professional development added sucessfully!");
+          this.router.push({ name: "manageProfessionalDevelopment", params: { applicationId: this.applicationId } });
+        }
+      } else {
+        this.alertStore.setFailureAlert("You must enter all required fields in the valid format to continue.");
+      }
+    },
+    isNumber,
+    selectionChanged() {
+      if (!this.professionalDevelopment.selection.includes("phone") && !this.professionalDevelopment.selection.includes("email")) {
+        //no email or phone clear out instructor name
+        this.professionalDevelopment.instructorName = "";
+      }
+
+      if (!this.professionalDevelopment.selection.includes("phone")) {
+        this.professionalDevelopment.organizationContactInformation = "";
+      }
+
+      if (!this.professionalDevelopment.selection.includes("email")) {
+        this.professionalDevelopment.organizationEmailAddress = "";
+      }
+
+      if (!this.professionalDevelopment.selection.includes("file")) {
+        //if user unchecks file we remove all files
+        this.professionalDevelopment.newFiles = [];
+      }
+    },
+    validateDates() {
+      (this.$refs.startDateInput as VInput).validate();
+      (this.$refs.endDateInput as VInput).validate();
+    },
+    handleFileUpdate(filesArray: FileItem[]) {
+      this.professionalDevelopment.areAttachedFilesValid = true;
+      this.professionalDevelopment.isFileUploadInProgress = false;
+      this.professionalDevelopment.newFiles = []; // Reset attachments
+      if (filesArray && filesArray.length > 0) {
+        for (let i = 0; i < filesArray.length; i++) {
+          const file = filesArray[i];
+
+          // Check for file errors
+          if (file.fileErrors && file.fileErrors.length > 0) {
+            this.professionalDevelopment.areAttachedFilesValid = false;
+          }
+
+          // Check if file is still uploading
+          else if (file.progress < 101) {
+            this.professionalDevelopment.isFileUploadInProgress = true;
+          }
+
+          // If file is valid and fully uploaded, add to attachments
+          if (this.professionalDevelopment.areAttachedFilesValid && !this.professionalDevelopment.isFileUploadInProgress) {
+            this.professionalDevelopment.newFiles?.push(file.fileId);
+          }
+        }
+      }
+    },
+  },
+});
+</script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ApplicationSummary.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ApplicationSummary.vue
@@ -154,6 +154,11 @@
         :text="`${totalRequiredWorkExperienceHours} approved hours of work experience with reference`"
         :go-to="() => $router.push({ name: 'manageWorkExperienceReferences', params: { applicationId: $route.params.applicationId } })"
       />
+      <ApplicationSummaryActionListItem
+        v-if="addMoreProfessionalDevelopmentFlag"
+        :text="`${totalRequiredProfessionalDevelopmentHours} hours of professional development`"
+        :go-to="() => $router.push({ name: 'manageProfessionalDevelopment', params: { applicationId: $route.params.applicationId } })"
+      />
     </div>
     <!-- Step 3 End-->
   </v-container>
@@ -292,6 +297,9 @@ export default defineComponent({
     addMoreWorkExperienceReferencesFlag(): boolean {
       return this.applicationStatus?.addMoreWorkExperienceReference ?? false;
     },
+    addMoreProfessionalDevelopmentFlag(): boolean {
+      return this.applicationStatus?.addMoreProfessionalDevelopment ?? false;
+    },
     hasWaitingForDetailsTranscript(): boolean {
       return this.applicationStatus?.transcriptsStatus?.some((transcript) => transcript.status === "WaitingforDetails") || false;
     },
@@ -309,6 +317,7 @@ export default defineComponent({
         !this.hasCharacterReference ||
         this.waitingForResponseCharacterReferences.length > 0 ||
         this.addMoreWorkExperienceReferencesFlag ||
+        this.addMoreProfessionalDevelopmentFlag ||
         this.hasWaitingForDetailsTranscript
       );
     },
@@ -320,6 +329,9 @@ export default defineComponent({
     },
     totalRequiredWorkExperienceHours(): number {
       return this.applicationStatus?.workExperienceReferencesStatus?.every((reference) => reference.type === WorkExperienceType.IS_400_Hours) ? 400 : 500;
+    },
+    totalRequiredProfessionalDevelopmentHours(): number {
+      return 40;
     },
   },
   methods: {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ManageProfessionalDevelopmentList.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ManageProfessionalDevelopmentList.vue
@@ -1,0 +1,143 @@
+<template>
+  <v-container>
+    <v-breadcrumbs class="pl-0" :items="items" color="primary">
+      <template #divider>/</template>
+    </v-breadcrumbs>
+
+    <div class="d-flex flex-column ga-3 mb-10">
+      <h1 class="mt-5">Professional development</h1>
+      <div role="doc-subtitle">
+        <b>
+          {{ totalRequiredProfessionalDevelopmentHours }} hours of professional development relevant to early childhood education is required.
+          <span v-if="totalHours < totalRequiredProfessionalDevelopmentHours">
+            You need to add {{ totalRequiredProfessionalDevelopmentHours - totalHours }} more hours
+          </span>
+        </b>
+      </div>
+      <p>Your hours:</p>
+      <ul class="ml-10">
+        <li v-if="latestCertification?.statusCode === 'Active'">
+          Must have been completed within the term of your current certificate (between the
+          {{ formatDate(latestCertification.effectiveDate!, "LLL d, yyyy") }} and {{ formatDate(latestCertification.expiryDate!, "LLL d, yyyy") }})
+        </li>
+        <li v-if="latestCertification?.statusCode === 'Expired'">Must have been completed within the last 5 years</li>
+        <li>Can be work or volunteer hours</li>
+        <li>Cannot include hours worked as part of your education on your practicum or work placement</li>
+      </ul>
+    </div>
+    <div v-for="(professionalDevelopment, index) in applicationStatus?.professionalDevelopmentsStatus" :key="index">
+      <ManageProfessionalDevelopmentListItem :professional-development="professionalDevelopment" />
+    </div>
+    <v-card elevation="0" rounded="0" class="border-t">
+      <v-card-text>
+        <v-row class="d-flex" :class="[smAndUp ? 'justify-space-between align-center' : 'flex-column']">
+          <v-col cols="4">
+            <div>
+              <p><b>Total hours</b></p>
+            </div>
+          </v-col>
+
+          <v-col cols="12" sm="4" :align="smAndUp ? 'center' : ''">
+            <p>
+              <b>{{ totalHours }} hours</b>
+            </p>
+          </v-col>
+          <v-spacer></v-spacer>
+        </v-row>
+      </v-card-text>
+    </v-card>
+    <div v-if="totalHours < totalRequiredProfessionalDevelopmentHours" class="mt-10">
+      <p>You need {{ totalRequiredProfessionalDevelopmentHours - totalHours }} more hours of professional development.</p>
+      <v-btn
+        prepend-icon="mdi-plus"
+        class="mt-10"
+        color="primary"
+        @click.prevent="$router.push({ name: 'addProfessionalDevelopment', params: { applicationId: applicationId } })"
+      >
+        Add course or workshop
+      </v-btn>
+    </div>
+    <Callout v-if="totalHours >= totalRequiredProfessionalDevelopmentHours" title="Please wait" type="warning" class="mt-10">
+      No additional courses or workshops are needed. You’ve provided the required hours. We will contact you shortly after we've reviewed the new professional
+      development courses or workshops added.
+    </Callout>
+  </v-container>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { useRoute } from "vue-router";
+import { useDisplay } from "vuetify";
+
+import { getApplicationStatus } from "@/api/application";
+import Callout from "@/components/Callout.vue";
+import ManageProfessionalDevelopmentListItem from "@/components/ManageProfessionalDevelopmentListItem.vue";
+import { useCertificationStore } from "@/store/certification";
+import { formatDate } from "@/utils/format";
+
+export default defineComponent({
+  name: "ManageProfessionalDevelopmentList",
+  components: {
+    ManageProfessionalDevelopmentListItem,
+    Callout,
+  },
+  props: {
+    applicationId: {
+      type: String,
+      required: true,
+    },
+  },
+  setup: async () => {
+    const { smAndUp } = useDisplay();
+    const route = useRoute();
+    const certificationStore = useCertificationStore();
+    const applicationStatus = (await getApplicationStatus(route.params.applicationId.toString()))?.data;
+    const latestCertification = certificationStore.latestCertification;
+
+    return {
+      applicationStatus,
+      smAndUp,
+      latestCertification,
+    };
+  },
+  data() {
+    return {
+      items: [
+        {
+          title: "Home",
+          disabled: false,
+          href: "/",
+        },
+        {
+          title: "Application",
+          disabled: false,
+          href: `/manage-application/${this.applicationId}`,
+        },
+        {
+          title: "Professional development",
+          disabled: true,
+          href: `/manage-application/${this.applicationId}/professional-development`,
+        },
+      ],
+    };
+  },
+  computed: {
+    totalHours(): number {
+      return (
+        this.applicationStatus?.professionalDevelopmentsStatus
+          ?.filter((item) => item.status !== "Rejected")
+          .reduce((total, item) => total + (item.numberOfHours || 0), 0) || 0
+      );
+    },
+    totalRequiredProfessionalDevelopmentHours(): number {
+      return 40;
+    },
+    applicationType() {
+      return this.applicationStatus?.applicationType;
+    },
+  },
+  methods: {
+    formatDate,
+  },
+});
+</script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ManageProfessionalDevelopmentListItem.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ManageProfessionalDevelopmentListItem.vue
@@ -1,0 +1,77 @@
+<template>
+  <v-card elevation="0" rounded="0" class="border-t border-b">
+    <v-card-text>
+      <v-row class="d-flex" :class="[smAndUp ? 'justify-space-between align-center' : 'flex-column']">
+        <v-col cols="12" sm="4">
+          <div>
+            <p>{{ CourseName }}</p>
+          </div>
+        </v-col>
+        <v-col cols="12" sm="4" :align="smAndUp ? 'center' : ''">
+          <p>{{ hoursText }}</p>
+        </v-col>
+        <v-col cols="12" sm="4" :align="smAndUp ? 'right' : ''">
+          <v-sheet rounded width="200px" class="py-2 text-center" :class="{ 'mt-2': !smAndUp }" :color="sheetColor">
+            <p>{{ statusText }}</p>
+          </v-sheet>
+        </v-col>
+      </v-row>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script lang="ts">
+import type { PropType } from "vue";
+import { defineComponent } from "vue";
+import { useDisplay } from "vuetify";
+
+import type { Components } from "@/types/openapi";
+
+export default defineComponent({
+  name: "ManageProfessionalDevelopmentListItem",
+  props: {
+    professionalDevelopment: {
+      type: Object as PropType<Components.Schemas.ProfessionalDevelopmentStatus>,
+      required: true,
+    },
+  },
+  setup: async () => {
+    const { smAndUp } = useDisplay();
+    return { smAndUp };
+  },
+  computed: {
+    statusText() {
+      switch (this.professionalDevelopment.status) {
+        case "Approved":
+          return "Approved";
+        case "Rejected":
+          return "Cancelled";
+        case "Submitted":
+          return "Pending review";
+        default:
+          return "Unhandled Status";
+      }
+    },
+    hoursText(): string {
+      switch (this.statusText) {
+        case "Approved":
+        case "Pending review":
+          return `${this.professionalDevelopment.numberOfHours ?? 0} hours`;
+        case "Cancelled":
+          return "—";
+        default:
+          return "0 hours";
+      }
+    },
+    link(): boolean {
+      return this.professionalDevelopment.status === "Submitted";
+    },
+    sheetColor() {
+      return this.link ? "hawkes-blue" : "white-smoke";
+    },
+    CourseName(): string {
+      return `${this.professionalDevelopment.courseName}`;
+    },
+  },
+});
+</script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/router.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/router.ts
@@ -105,9 +105,23 @@ const router = createRouter({
       props: true,
     },
     {
+      path: "/manage-application/:applicationId/professional-development/add",
+      name: "addProfessionalDevelopment",
+      component: () => import("./components/AddProfessionalDevelopment.vue"),
+      meta: { requiresAuth: true, requiresVerification: true },
+      props: true,
+    },
+    {
       path: "/manage-application/:applicationId/work-experience-references",
       name: "manageWorkExperienceReferences",
       component: () => import("./components/ManageWorkExperienceReferenceList.vue"),
+      meta: { requiresAuth: true, requiresVerification: true },
+      props: true,
+    },
+    {
+      path: "/manage-application/:applicationId/professional-development",
+      name: "manageProfessionalDevelopment",
+      component: () => import("./components/ManageProfessionalDevelopmentList.vue"),
       meta: { requiresAuth: true, requiresVerification: true },
       props: true,
     },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
@@ -2,6 +2,9 @@ import type { AxiosRequestConfig, OpenAPIClient, OperationResponse, Parameters, 
 
 declare namespace Components {
   namespace Schemas {
+    export interface AddProfessionalDevelopmentResponse {
+      professionalDevelopmentId?: string | null;
+    }
     /**
      * Address
      */
@@ -363,10 +366,16 @@ declare namespace Components {
       newFiles?: string[] | null;
       files?: FileInfo[] | null;
     }
+    export interface ProfessionalDevelopmentStatus {
+      id?: string | null;
+      courseName?: string | null;
+      numberOfHours?: number; // int32
+      status?: ProfessionalDevelopmentStatusCode;
+    }
     export type ProfessionalDevelopmentStatusCode =
       | "ApplicationSubmitted"
+      | "Approved"
       | "Draft"
-      | "Inactive"
       | "InProgress"
       | "Rejected"
       | "Submitted"
@@ -431,8 +440,10 @@ declare namespace Components {
       transcriptsStatus?: TranscriptStatus[] | null;
       workExperienceReferencesStatus?: WorkExperienceReferenceStatus[] | null;
       characterReferencesStatus?: CharacterReferenceStatus[] | null;
+      professionalDevelopmentsStatus?: ProfessionalDevelopmentStatus[] | null;
       addMoreCharacterReference?: boolean | null;
       addMoreWorkExperienceReference?: boolean | null;
+      addMoreProfessionalDevelopment?: boolean | null;
       applicationType?: ApplicationTypes;
     }
     export interface Transcript {
@@ -628,6 +639,20 @@ declare namespace Paths {
     namespace Responses {
       export type $200 = Components.Schemas.SubmitApplicationResponse;
       export type $400 = Components.Schemas.ProblemDetails | Components.Schemas.HttpValidationProblemDetails;
+      export interface $404 {}
+    }
+  }
+  namespace ApplicationProfessionaldevelopmentAddPost {
+    namespace Parameters {
+      export type ApplicationId = string;
+    }
+    export interface PathParameters {
+      application_id: Parameters.ApplicationId;
+    }
+    export type RequestBody = Components.Schemas.ProfessionalDevelopment;
+    namespace Responses {
+      export type $200 = Components.Schemas.AddProfessionalDevelopmentResponse;
+      export type $400 = Components.Schemas.HttpValidationProblemDetails;
       export interface $404 {}
     }
   }
@@ -1125,6 +1150,14 @@ export interface OperationMethods {
     data?: any,
     config?: AxiosRequestConfig,
   ): OperationResponse<Paths.ApplicationWorkExperienceReferenceResendInvitePost.Responses.$200>;
+  /**
+   * application_professionaldevelopment_add_post - Add Professional Development
+   */
+  "application_professionaldevelopment_add_post"(
+    parameters?: Parameters<Paths.ApplicationProfessionaldevelopmentAddPost.PathParameters> | null,
+    data?: Paths.ApplicationProfessionaldevelopmentAddPost.RequestBody,
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.ApplicationProfessionaldevelopmentAddPost.Responses.$200>;
 }
 
 export interface PathsDictionary {
@@ -1397,6 +1430,16 @@ export interface PathsDictionary {
       data?: any,
       config?: AxiosRequestConfig,
     ): OperationResponse<Paths.ApplicationWorkExperienceReferenceResendInvitePost.Responses.$200>;
+  };
+  ["/api/applications/{application_id}/professionaldevelopment/add"]: {
+    /**
+     * application_professionaldevelopment_add_post - Add Professional Development
+     */
+    "post"(
+      parameters?: Parameters<Paths.ApplicationProfessionaldevelopmentAddPost.PathParameters> | null,
+      data?: Paths.ApplicationProfessionaldevelopmentAddPost.RequestBody,
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.ApplicationProfessionaldevelopmentAddPost.Responses.$200>;
   };
 }
 

--- a/src/ECER.Managers.Registry.Contract/Applications/Contract.cs
+++ b/src/ECER.Managers.Registry.Contract/Applications/Contract.cs
@@ -61,6 +61,7 @@ public record Application(string? Id, string RegistrantId, ApplicationStatus Sta
   public DateTime? ReadyForAssessmentDate { get; set; }
   public bool? AddMoreCharacterReference { get; set; }
   public bool? AddMoreWorkExperienceReference { get; set; }
+  public bool? AddMoreProfessionalDevelopment { get; set; }
   public ApplicationTypes ApplicationType { get; set; }
   public EducationOrigin? EducationOrigin { get; set; }
   public EducationRecognition? EducationRecognition { get; set; }
@@ -117,8 +118,8 @@ public record CharacterReference(string? FirstName, string? LastName, string? Ph
 public enum ProfessionalDevelopmentStatusCode
 {
   ApplicationSubmitted,
+  Approved,
   Draft,
-  Inactive,
   InProgress,
   Rejected,
   Submitted,

--- a/src/ECER.Managers.Registry.Contract/Applications/Contract.cs
+++ b/src/ECER.Managers.Registry.Contract/Applications/Contract.cs
@@ -362,6 +362,15 @@ public class UpdateCharacterReferenceResult
   public static UpdateCharacterReferenceResult Failure(string message) => new UpdateCharacterReferenceResult { IsSuccess = false, ErrorMessage = message };
 }
 
+public record AddProfessionalDevelopmentCommand(ProfessionalDevelopment professionalDevelopment, string applicationId, string userId) : IRequest<AddProfessionalDevelopmentResult>;
+
+public class AddProfessionalDevelopmentResult
+{
+  public string? ProfessionalDevelopmentId { get; set; }
+  public bool IsSuccess { get; set; }
+  public string? ErrorMessage { get; set; }
+}
+
 public enum ReferenceKnownTime
 {
   From1to2years,

--- a/src/ECER.Managers.Registry/ApplicationHandlers.cs
+++ b/src/ECER.Managers.Registry/ApplicationHandlers.cs
@@ -30,7 +30,8 @@ public class ApplicationHandlers(
     IRequestHandler<Contract.Applications.UpdateWorkExperienceReferenceCommand, UpdateWorkExperienceReferenceResult>,
     IRequestHandler<Contract.Applications.UpdateCharacterReferenceCommand, UpdateCharacterReferenceResult>,
     IRequestHandler<ResendCharacterReferenceInviteRequest, string>,
-    IRequestHandler<ResendWorkExperienceReferenceInviteRequest, string>
+    IRequestHandler<ResendWorkExperienceReferenceInviteRequest, string>,
+    IRequestHandler<Contract.Applications.AddProfessionalDevelopmentCommand, AddProfessionalDevelopmentResult>
 {
   /// <summary>
   /// Handles submitting a new application use case
@@ -283,5 +284,13 @@ public class ApplicationHandlers(
 
     var workExperienceReferenceId = await applicationRepository.ResendWorkExperienceReferenceInvite(new ResendReferenceInviteRequest(request.ReferenceId), cancellationToken);
     return workExperienceReferenceId;
+  }
+
+  public async Task<AddProfessionalDevelopmentResult> Handle(AddProfessionalDevelopmentCommand request, CancellationToken cancellationToken)
+  {
+    ArgumentNullException.ThrowIfNull(request);
+    var ProfessionalDevelopment = mapper.Map<Resources.Documents.Applications.ProfessionalDevelopment>(request.professionalDevelopment);
+    var AddedProfessionalDevelopmentId = await applicationRepository.AddProfessionalDevelopmentForSubmittedApplication(ProfessionalDevelopment, request.applicationId, request.userId, cancellationToken);
+    return new AddProfessionalDevelopmentResult() { ProfessionalDevelopmentId = AddedProfessionalDevelopmentId, IsSuccess = true };
   }
 }

--- a/src/ECER.Resources.Documents/Applications/ApplicationChildren/ProfessionalDevelopments.cs
+++ b/src/ECER.Resources.Documents/Applications/ApplicationChildren/ProfessionalDevelopments.cs
@@ -153,13 +153,12 @@ internal sealed partial class ApplicationRepository
   {
     await Task.CompletedTask;
 
-    var ecerApplication = context.ecer_ApplicationSet.FirstOrDefault(d => d.ecer_ApplicationId == Guid.Parse(applicationId) && d.StatusCode == ecer_Application_StatusCode.Submitted && d.ecer_Applicantid.Id == Guid.Parse(userId));
+    var ecerApplication = context.ecer_ApplicationSet.FirstOrDefault(d => d.ecer_ApplicationId == Guid.Parse(applicationId) && d.ecer_Applicantid.Id == Guid.Parse(userId));
 
     if (ecerApplication == null) throw new InvalidOperationException($"Application '{applicationId}' not found");
 
     var ecerProfessionalDevelopment = mapper.Map<ecer_ProfessionalDevelopment>(newProfessionalDevelopment)!;
-    var newId = Guid.NewGuid();
-    ecerProfessionalDevelopment.ecer_ProfessionalDevelopmentId = newId;
+    ecerProfessionalDevelopment.ecer_ProfessionalDevelopmentId = Guid.NewGuid();
     ecerProfessionalDevelopment.StatusCode = ecer_ProfessionalDevelopment_StatusCode.Submitted;
     context.AddObject(ecerProfessionalDevelopment);
     context.AddLink(ecerApplication, ecer_Application.Fields.ecer_ecer_professionaldevelopment_Applicationi, ecerProfessionalDevelopment);
@@ -167,7 +166,7 @@ internal sealed partial class ApplicationRepository
     await AddFilesForProfessionalDevelopment(ecerProfessionalDevelopment, ecerApplication.ecer_Applicantid.Id, (List<string>)newProfessionalDevelopment.NewFiles, cancellationToken);
 
     context.SaveChanges();
-    return newId.ToString();
+    return ecerProfessionalDevelopment.ecer_ProfessionalDevelopmentId.ToString()!;
   }
 
   private static string GetBucketName(IConfiguration configuration) =>

--- a/src/ECER.Resources.Documents/Applications/ApplicationChildren/ProfessionalDevelopments.cs
+++ b/src/ECER.Resources.Documents/Applications/ApplicationChildren/ProfessionalDevelopments.cs
@@ -149,6 +149,27 @@ internal sealed partial class ApplicationRepository
     }
   }
 
+  public async Task<string> AddProfessionalDevelopmentForSubmittedApplication(ProfessionalDevelopment newProfessionalDevelopment, string applicationId, string userId, CancellationToken cancellationToken)
+  {
+    await Task.CompletedTask;
+
+    var ecerApplication = context.ecer_ApplicationSet.FirstOrDefault(d => d.ecer_ApplicationId == Guid.Parse(applicationId) && d.StatusCode == ecer_Application_StatusCode.Submitted && d.ecer_Applicantid.Id == Guid.Parse(userId));
+
+    if (ecerApplication == null) throw new InvalidOperationException($"Application '{applicationId}' not found");
+
+    var ecerProfessionalDevelopment = mapper.Map<ecer_ProfessionalDevelopment>(newProfessionalDevelopment)!;
+    var newId = Guid.NewGuid();
+    ecerProfessionalDevelopment.ecer_ProfessionalDevelopmentId = newId;
+    ecerProfessionalDevelopment.StatusCode = ecer_ProfessionalDevelopment_StatusCode.Submitted;
+    context.AddObject(ecerProfessionalDevelopment);
+    context.AddLink(ecerApplication, ecer_Application.Fields.ecer_ecer_professionaldevelopment_Applicationi, ecerProfessionalDevelopment);
+
+    await AddFilesForProfessionalDevelopment(ecerProfessionalDevelopment, ecerApplication.ecer_Applicantid.Id, (List<string>)newProfessionalDevelopment.NewFiles, cancellationToken);
+
+    context.SaveChanges();
+    return newId.ToString();
+  }
+
   private static string GetBucketName(IConfiguration configuration) =>
   configuration.GetValue<string>("objectStorage:bucketName") ?? throw new InvalidOperationException("objectStorage:bucketName is not set");
 }

--- a/src/ECER.Resources.Documents/Applications/ApplicationRepositoryMapper.cs
+++ b/src/ECER.Resources.Documents/Applications/ApplicationRepositoryMapper.cs
@@ -21,6 +21,7 @@ internal class ApplicationRepositoryMapper : Profile
        .ForSourceMember(s => s.ReadyForAssessmentDate, opts => opts.DoNotValidate())
        .ForSourceMember(s => s.AddMoreCharacterReference, opts => opts.DoNotValidate())
        .ForSourceMember(s => s.AddMoreWorkExperienceReference, opts => opts.DoNotValidate())
+       .ForSourceMember(s => s.AddMoreProfessionalDevelopment, opts => opts.DoNotValidate())
        .ForMember(d => d.ecer_ApplicationId, opts => opts.MapFrom(s => s.Id))
        .ForMember(d => d.StatusCode, opts => opts.MapFrom(s => s.Status))
        .ForMember(d => d.ecer_IsECEAssistant, opts => opts.MapFrom(s => s.CertificationTypes.Contains(CertificationType.EceAssistant)))
@@ -51,7 +52,8 @@ internal class ApplicationRepositoryMapper : Profile
        .ForMember(d => d.CharacterReferences, opts => opts.MapFrom(s => s.ecer_characterreference_Applicationid))
        .ForMember(d => d.ReadyForAssessmentDate, opts => opts.MapFrom(s => s.ecer_ReadyforAssessmentDate))
        .ForMember(d => d.AddMoreCharacterReference, opts => opts.MapFrom(s => s.ecer_AddMoreCharacterReference))
-       .ForMember(d => d.AddMoreWorkExperienceReference, opts => opts.MapFrom(s => s.ecer_AddMoreWorkExperienceReference));
+       .ForMember(d => d.AddMoreWorkExperienceReference, opts => opts.MapFrom(s => s.ecer_AddMoreWorkExperienceReference))
+       .ForMember(d => d.AddMoreProfessionalDevelopment, opts => opts.MapFrom(s => s.ecer_AddMoreProfessionalDevelopment));
 
     CreateMap<ecer_Application, IEnumerable<CertificationType>>()
         .ConstructUsing((s, _) =>

--- a/src/ECER.Resources.Documents/Applications/IApplicationRepository.cs
+++ b/src/ECER.Resources.Documents/Applications/IApplicationRepository.cs
@@ -49,6 +49,7 @@ public record Application(string? Id, string ApplicantId, IEnumerable<Certificat
   public DateTime? ReadyForAssessmentDate { get; set; }
   public bool? AddMoreCharacterReference { get; set; }
   public bool? AddMoreWorkExperienceReference { get; set; }
+  public bool? AddMoreProfessionalDevelopment { get; set; }
   public ApplicationTypes ApplicationType { get; set; }
   public EducationOrigin? EducationOrigin { get; set; }
   public EducationRecognition? EducationRecognition { get; set; }
@@ -292,8 +293,8 @@ public enum WorkExperienceTypes
 public enum ProfessionalDevelopmentStatusCode
 {
   ApplicationSubmitted,
+  Approved,
   Draft,
-  Inactive,
   InProgress,
   Rejected,
   Submitted,

--- a/src/ECER.Resources.Documents/Applications/IApplicationRepository.cs
+++ b/src/ECER.Resources.Documents/Applications/IApplicationRepository.cs
@@ -23,6 +23,8 @@ public interface IApplicationRepository
   Task<string> ResendCharacterReferenceInvite(ResendReferenceInviteRequest request, CancellationToken cancellationToken);
 
   Task<string> ResendWorkExperienceReferenceInvite(ResendReferenceInviteRequest request, CancellationToken cancellationToken);
+
+  Task<string> AddProfessionalDevelopmentForSubmittedApplication(ProfessionalDevelopment newProfessionalDevelopment, string applicationId, string userId, CancellationToken cancellationToken);
 }
 
 public record ApplicationQuery

--- a/src/ECER.Tests/Integration/RegistryApi/ApplicationTests.cs
+++ b/src/ECER.Tests/Integration/RegistryApi/ApplicationTests.cs
@@ -261,7 +261,7 @@ public class ApplicationTests : RegistryPortalWebAppScenarioBase
         .RuleFor(f => f.ProfessionalDevelopments, f => f.Make(f.Random.Number(1, 3), () => CreateProfessionalDevelopment()))
         .Generate();
 
-    application.Id = this.Fixture.draftTestApplicationId;
+    application.Id = this.Fixture.draftTestApplicationId4;
     application.ApplicationType = ApplicationTypes.Renewal;
     return application;
   }
@@ -418,6 +418,91 @@ public class ApplicationTests : RegistryPortalWebAppScenarioBase
       _.Post.Url($"/api/applications/{applicationId}/workExperienceReference/{referenceId}/resendInvite");
       _.StatusCodeShouldBe(HttpStatusCode.InternalServerError);
     });
+  }
+
+  [Fact]
+  public async Task AddProfessionalDevelopmentAndFiles_ToSubmittedApplication()
+  {
+    // Create Renewal Draft Application
+    var application = Create400HoursTypeRenewalDraftApplication();
+
+    // Save Renewal Draft Application
+    var newDraftApplicationResponse = await Host.Scenario(_ =>
+    {
+      _.WithExistingUser(this.Fixture.AuthenticatedBcscUserIdentity, this.Fixture.AuthenticatedBcscUserId);
+      _.Put.Json(new SaveDraftApplicationRequest(application)).ToUrl($"/api/draftapplications/{application.Id}");
+      _.StatusCodeShouldBeOk();
+    });
+
+    var draftApplicationId = (await newDraftApplicationResponse.ReadAsJsonAsync<DraftApplicationResponse>()).ShouldNotBeNull().ApplicationId;
+
+    // Submit Renewal Application
+    var applicationResponse = await Host.Scenario(_ =>
+    {
+      _.WithExistingUser(this.Fixture.AuthenticatedBcscUserIdentity, this.Fixture.AuthenticatedBcscUserId);
+      _.Post.Json(new ApplicationSubmissionRequest(draftApplicationId)).ToUrl($"/api/applications");
+      _.StatusCodeShouldBeOk();
+    });
+
+    var applicationId = (await applicationResponse.ReadAsJsonAsync<SubmitApplicationResponse>()).ShouldNotBeNull().ApplicationId;
+
+    // Add test File
+    var fileLength = 1041;
+    var testFile = await faker.GenerateTestFile(fileLength);
+    var testFileId = Guid.NewGuid().ToString();
+    var testFolder = "tempfolder";
+    var testTags = "tag1=1,tag2=2";
+    var testClassification = "test-classification";
+    using var content = new StreamContent(testFile.Content);
+    content.Headers.ContentType = new MediaTypeHeaderValue(testFile.ContentType);
+
+    using var formData = new MultipartFormDataContent
+        {
+          { content, "file", testFile.FileName }
+        };
+
+    var fileResponse = await Host.Scenario(_ =>
+    {
+      _.WithExistingUser(this.Fixture.AuthenticatedBcscUserIdentity, this.Fixture.AuthenticatedBcscUserId);
+      _.WithRequestHeader("file-classification", testClassification);
+      _.WithRequestHeader("file-tag", testTags);
+      _.WithRequestHeader("file-folder", testFolder);
+      _.Post.MultipartFormData(formData).ToUrl($"/api/files/{testFileId}");
+      _.StatusCodeShouldBeOk();
+    });
+
+    var uploadedFileResponse = (await fileResponse.ReadAsJsonAsync<FileResponse>()).ShouldNotBeNull();
+
+    // Create Professional development
+    var professionalDevelopment = CreateProfessionalDevelopment();
+    professionalDevelopment.NewFiles = [uploadedFileResponse.fileId];
+
+    // Add professional development to submitted Renewal Application
+    var response = await Host.Scenario(_ =>
+    {
+      _.WithExistingUser(this.Fixture.AuthenticatedBcscUserIdentity, this.Fixture.AuthenticatedBcscUserId);
+      _.Post.Json(professionalDevelopment).ToUrl($"/api/applications/{applicationId}/professionaldevelopment/add");
+      _.StatusCodeShouldBeOk();
+    });
+
+    var addedProfessionalDevelopment = (await response.ReadAsJsonAsync<AddProfessionalDevelopmentResponse>()).ShouldNotBeNull();
+    addedProfessionalDevelopment.ProfessionalDevelopmentId.ShouldNotBeEmpty();
+
+    var applicationByIdResponse = await Host.Scenario(_ =>
+    {
+      _.WithExistingUser(this.Fixture.AuthenticatedBcscUserIdentity, this.Fixture.AuthenticatedBcscUserId);
+      _.Get.Url($"/api/applications/{applicationId}");
+      _.StatusCodeShouldBeOk();
+    });
+
+    var applicationsById = await applicationByIdResponse.ReadAsJsonAsync<Application[]>();
+    applicationsById.ShouldHaveSingleItem();
+    var applicationFromServer = applicationsById[0];
+    applicationFromServer.ProfessionalDevelopments.ShouldNotBeEmpty();
+    var professionalDev = applicationFromServer.ProfessionalDevelopments.FirstOrDefault(pd => pd.Id == addedProfessionalDevelopment.ProfessionalDevelopmentId);
+    professionalDev.ShouldNotBeNull();
+    professionalDev.Files.ShouldHaveSingleItem();
+    professionalDev.Files.First().Id!.ShouldContain(uploadedFileResponse.fileId);
   }
 
   private Transcript CreateTranscript()

--- a/src/ECER.Tests/Integration/RegistryPortalWebAppScenarioBase.cs
+++ b/src/ECER.Tests/Integration/RegistryPortalWebAppScenarioBase.cs
@@ -76,6 +76,7 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
   private ecer_Application inProgressTestApplication2 = null!;
   private ecer_Application draftTestApplication2 = null!;
   private ecer_Application draftTestApplication3 = null!;
+  private ecer_Application draftTestApplication4 = null!;
   private ecer_Application submittedTestApplication = null!;
   private ecer_Application submittedTestApplication2 = null!;
   private ecer_Application submittedTestApplication3 = null!;
@@ -86,6 +87,8 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
   public string inprogressTestApplicationId2 => inProgressTestApplication2.Id.ToString();
   public string draftTestApplicationId2 => draftTestApplication2.Id.ToString();
   public string draftTestApplicationId3 => draftTestApplication3.Id.ToString();
+
+  public string draftTestApplicationId4 => draftTestApplication4.Id.ToString();
   public string submittedTestApplicationId => submittedTestApplication.Id.ToString();
   public string submittedTestApplicationId2 => submittedTestApplication2.Id.ToString();
   public string submittedTestApplicationId3 => submittedTestApplication3.Id.ToString();
@@ -129,6 +132,7 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
     draftTestApplication = GetOrAddApplication(context, authenticatedBcscUser, ecer_Application_StatusCode.Draft);
     draftTestApplication2 = GetOrAddApplication(context, authenticatedBcscUser, ecer_Application_StatusCode.Draft);
     draftTestApplication3 = GetOrAddApplication(context, authenticatedBcscUser, ecer_Application_StatusCode.Draft);
+    draftTestApplication4 = GetOrAddApplication(context, authenticatedBcscUser, ecer_Application_StatusCode.Draft);
     submittedTestApplication = GetOrAddApplication(context, authenticatedBcscUser, ecer_Application_StatusCode.Submitted);
     submittedTestApplication2 = GetOrAddApplication(context, authenticatedBcscUser, ecer_Application_StatusCode.Submitted);
     submittedTestApplication3 = GetOrAddApplication(context, authenticatedBcscUser, ecer_Application_StatusCode.Submitted);


### PR DESCRIPTION
## Title
ECER:2849: Add more hours to professional development during assessment - B.E get professional development status and F.E Piece


## Description

- BE: Add professional development to application summary endpoint.
- B.E: Added and mapped required props to get professional development status in application status endpoint
- B.E: Added automated test 
- F.E: Added New Task under "Step 3" to manage professional development
- F.E: added Manage professional developments and add professional development components

## Related Jira Issue(s)

- ECER-2849
- ECER-2850
- ECER-2354

## Checklist
- [x] I have tested these changes locally.
- [x] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)

![localhost_5121_manage-application_68c44c3d-bc4d-4a05-847c-1d7c2cfbcf4d](https://github.com/user-attachments/assets/8d75b70d-b4a5-48c0-9d4b-328843da5f7f)

![localhost_5121_manage-application_68c44c3d-bc4d-4a05-847c-1d7c2cfbcf4d (1)](https://github.com/user-attachments/assets/4d314246-893d-43dd-8d8b-bac37f72898b)

![localhost_5121_manage-application_68c44c3d-bc4d-4a05-847c-1d7c2cfbcf4d (2)](https://github.com/user-attachments/assets/7a72e65e-809e-4739-a44b-08c0033ad1ae)

Validations:
![localhost_5121_manage-application_68c44c3d-bc4d-4a05-847c-1d7c2cfbcf4d (3)](https://github.com/user-attachments/assets/ce5b8b43-97c9-4e14-93fb-247a8de151f5)

![localhost_5121_manage-application_68c44c3d-bc4d-4a05-847c-1d7c2cfbcf4d (4)](https://github.com/user-attachments/assets/b6cf023d-a204-4d2c-920c-2c7d0ee6ec81)


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.