### PR TITLE
ECER-3178: Status Query for communication separated in Repository

### DIFF
--- a/src/ECER.Managers.Registry/CommunicationHandlers.cs
+++ b/src/ECER.Managers.Registry/CommunicationHandlers.cs
@@ -15,20 +15,8 @@ public class CommunicationHandlers(ICommunicationRepository communicationReposit
   public async Task<CommunicationsStatusResults> Handle(UserCommunicationsStatusQuery request, CancellationToken cancellationToken)
   {
     ArgumentNullException.ThrowIfNull(request);
-
-    var statuses = new List<Resources.Accounts.Communications.CommunicationStatus>();
-    statuses.Add(Resources.Accounts.Communications.CommunicationStatus.NotifiedRecipient);
-    statuses.Add(Resources.Accounts.Communications.CommunicationStatus.Acknowledged);
-    var communications = await communicationRepository.Query(new Resources.Accounts.Communications.UserCommunicationQuery
-    {
-      ByRegistrantId = request.ByRegistrantId,
-      ByStatus = statuses,
-    });
-
-    var unreadCount = communications.UnreadMessagesCount;
-    var hasUnread = unreadCount > 0;
-
-    var communicationsStatus = new Contract.Communications.CommunicationsStatus() { HasUnread = hasUnread, Count = unreadCount };
+    var UnreadMessagesCount = await communicationRepository.QueryStatus(request.ByRegistrantId);
+    var communicationsStatus = new Contract.Communications.CommunicationsStatus() { HasUnread = UnreadMessagesCount > 0, Count = UnreadMessagesCount };
     return new CommunicationsStatusResults(communicationsStatus!);
   }
 

--- a/src/ECER.Resources.Accounts/Communications/CommunicationRepository.cs
+++ b/src/ECER.Resources.Accounts/Communications/CommunicationRepository.cs
@@ -31,8 +31,9 @@ internal class CommunicationRepository : ICommunicationRepository
                                                                      item.StatusCode == ecer_Communication_StatusCode.NotifiedRecipient &&
                                                                      item.StateCode == ecer_communication_statecode.Active &&
                                                                      item.ecer_Acknowledged != true
-                                                                     ).Select(item => new { item.Id, item.ecer_IsRoot, item.ecer_ParentCommunicationid }).ToList().
-                                                                     Where(item => item.ecer_IsRoot ?? false || item.ecer_ParentCommunicationid != null).ToList(); // SDK does not support including this condition inside query
+                                                                     ).Select(item => new { item.Id, parent = item.ecer_IsRoot ?? false, child = item.ecer_ParentCommunicationid != null }).ToList();
+
+    unseenCommunications = unseenCommunications.Where(item => item.parent || item.child).ToList(); // SDK does not support including this condition inside query
     return unseenCommunications.Count;
   }
 

--- a/src/ECER.Resources.Accounts/Communications/CommunicationRepository.cs
+++ b/src/ECER.Resources.Accounts/Communications/CommunicationRepository.cs
@@ -23,6 +23,19 @@ internal class CommunicationRepository : ICommunicationRepository
     this.configuration = configuration;
   }
 
+  public async Task<int> QueryStatus(string RegistrantId)
+  {
+    await Task.CompletedTask;
+    var unseenCommunications = context.ecer_CommunicationSet.Where(item => item.ecer_Registrantid.Id == Guid.Parse(RegistrantId) &&
+                                                                     item.ecer_InitiatedFrom == ecer_InitiatedFrom.Registry &&
+                                                                     item.StatusCode == ecer_Communication_StatusCode.NotifiedRecipient &&
+                                                                     item.StateCode == ecer_communication_statecode.Active &&
+                                                                     item.ecer_Acknowledged != true
+                                                                     ).Select(item => new { item.Id, item.ecer_IsRoot, item.ecer_ParentCommunicationid }).ToList().
+                                                                     Where(item => item.ecer_IsRoot ?? false || item.ecer_ParentCommunicationid != null).ToList(); // SDK does not support including this condition inside query
+    return unseenCommunications.Count;
+  }
+
   public async Task<CommunicationResult> Query(UserCommunicationQuery query)
   {
     await Task.CompletedTask;
@@ -37,7 +50,6 @@ internal class CommunicationRepository : ICommunicationRepository
       var statuses = mapper.Map<IEnumerable<ecer_Communication_StatusCode>>(query.ByStatus)!.ToList();
       communications = communications.WhereIn(item => item.StatusCode!.Value, statuses);
     }
-    var UnreadMessagesCount = communications.Where(item => item.ecer_InitiatedFrom == ecer_InitiatedFrom.Registry && item.ecer_Acknowledged != true).Select(item => item.Id).ToList().Count;
 
     // Filtering by ID
     if (query.ById != null) communications = communications.Where(item => item.ecer_CommunicationId == Guid.Parse(query.ById));
@@ -70,7 +82,6 @@ internal class CommunicationRepository : ICommunicationRepository
     {
       Communications = mapper.Map<IEnumerable<Communication>>(finalCommunications),
       TotalMessagesCount = query.PageNumber > 0 ? paginatedTotalCommunicationCount : finalCommunications.Count,
-      UnreadMessagesCount = UnreadMessagesCount
     };
   }
 

--- a/src/ECER.Resources.Accounts/Communications/ICommunicationRepository.cs
+++ b/src/ECER.Resources.Accounts/Communications/ICommunicationRepository.cs
@@ -9,6 +9,8 @@ namespace ECER.Resources.Accounts.Communications;
 
 public interface ICommunicationRepository
 {
+  Task<int> QueryStatus(string RegistrantId);
+
   Task<CommunicationResult> Query(UserCommunicationQuery query);
 
   Task<string> MarkAsSeen(string communicationId, CancellationToken cancellationToken);
@@ -52,7 +54,6 @@ public record CommunicationResult
 {
   public IEnumerable<Communication>? Communications { get; set; }
   public int TotalMessagesCount { get; set; }
-  public int UnreadMessagesCount { get; set; }
 }
 
 public enum CommunicationStatus


### PR DESCRIPTION
## Title
ECER-3178: The number of messages is not match the number of messages shown

## Description

This occurs because Dynamics generates certain messages that are not root messages and do not have a parent communication, so they are not displayed on the messages page. Here are a few examples:

```
{37b1c37e-ce7a-ef11-ac21-000d3a09e82b}
{0c047c81-ce7a-ef11-ac20-6045bdcce125}
{9151bc04-ba7a-ef11-ac21-6045bdcd6cb0}
{6c2f8da5-ec79-ef11-ac20-7c1e5240b0bf}
```

![image](https://github.com/user-attachments/assets/69d928c7-42f5-416b-97dc-1db890393562)




I've separated communication status query function in repository to improve performance as well


## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.