### PR TITLE
quick fix edit education where middle name could be null 

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
@@ -142,7 +142,7 @@
         <p>What name is shown on your transcript?</p>
         <br />
         <v-radio-group v-model="previousNameRadio" :rules="[Rules.requiredRadio('Select an option')]" @update:model-value="previousNameRadioChanged">
-          <v-radio v-for="(step, index) in ApplicantNameRadioOptions" :key="index" :label="step.label" :value="step.value"></v-radio>
+          <v-radio v-for="(step, index) in applicantNameRadioOptions" :key="index" :label="step.label" :value="step.value"></v-radio>
         </v-radio-group>
         <div v-if="previousNameRadio === 'other'">
           <v-row>
@@ -296,11 +296,11 @@ export default defineComponent({
     newClientId() {
       return Object.keys(this.modelValue).length + 1;
     },
-    ApplicantNameRadioOptions(): RadioOptions[] {
+    applicantNameRadioOptions(): RadioOptions[] {
       let legalNameRadioOptions: RadioOptions[] = [
         {
           label: this.userStore.legalName,
-          value: { firstName: this.userStore.firstName, middleName: this.userStore.middleName, lastName: this.userStore.lastName },
+          value: { firstName: this.userStore.firstName || null, middleName: this.userStore.middleName || null, lastName: this.userStore.lastName || null },
         },
       ];
       return [...legalNameRadioOptions, ...this.previousNameRadioOptions];
@@ -413,16 +413,16 @@ export default defineComponent({
       }
       //set the radio button for previous names and field buttons correctly
       if (educationData.education.isNameUnverified) {
-        let index = this.previousNameRadioOptions.findIndex((option) => option.value === "other");
-        this.previousNameRadio = this.previousNameRadioOptions[index].value;
+        let index = this.applicantNameRadioOptions.findIndex((option) => option.value === "other");
+        this.previousNameRadio = this.applicantNameRadioOptions[index].value;
       } else {
-        let index = this.previousNameRadioOptions.findIndex(
+        let index = this.applicantNameRadioOptions.findIndex(
           (option) =>
             option.value?.firstName === educationData.education.studentFirstName &&
             option.value?.lastName === educationData.education.studentLastName &&
             option.value?.middleName === educationData.education.studentMiddleName,
         );
-        this.previousNameRadio = this.previousNameRadioOptions[index].value;
+        this.previousNameRadio = this.applicantNameRadioOptions[index].value;
       }
       // Change mode to add
       this.mode = "add";


### PR DESCRIPTION
but user store stores it as an empty string instead

## Description

- Bug found during smoke testing. 
- Cause was that the legal name for an applicant would be gotten as "", however the education names are stored as null. So for the previous radio option generation, it wouldn't find the exact match for the index. 
- index would be -1 and when we try to access that, it's unhappy

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/c39a69ee-ede1-4868-9db9-8a6d3521b979)
![image](https://github.com/user-attachments/assets/ec8f08e1-53a9-46dd-b1fa-521ed0541a70)
