### PR TITLE
small fix removing + icon on save course or workshop

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducationPreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducationPreview.vue
@@ -5,7 +5,7 @@
         <v-divider v-if="index !== 0" :thickness="2" color="grey-lightest" class="border-opacity-100 my-6" />
         <v-row>
           <v-col>
-            <h4>{{ education.educationalInstitutionName }}</h4>
+            <h4 class="text-black">{{ education.educationalInstitutionName }}</h4>
           </v-col>
         </v-row>
         <v-row>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceProfessionalDevelopment.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceProfessionalDevelopment.vue
@@ -233,10 +233,7 @@
     <v-row class="mt-10">
       <v-col>
         <v-row justify="start" class="ml-1">
-          <v-btn rounded="lg" color="primary" class="mr-2" @click="handleSubmit">
-            <v-icon icon="mdi-plus" />
-            Save course or workshop
-          </v-btn>
+          <v-btn rounded="lg" color="primary" class="mr-2" @click="handleSubmit">Save course or workshop</v-btn>
           <v-btn rounded="lg" variant="outlined" @click="handleCancel">Cancel</v-btn>
         </v-row>
       </v-col>


### PR DESCRIPTION
ECER-1186: Brief description of the changes

## Description

- quick fix for + icon
- black text for education preview

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/aef7ee7b-20ee-421e-a251-701a5734c8ec)

![image](https://github.com/user-attachments/assets/c5538374-722d-470f-aae1-27e77d02c60b)
