### PR TITLE
ECER-3210: Display registrant details with terms and conditions

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/.vscode/extensions.json
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["Vue.volar", "dbaeumer.vscode-eslint"]
+  "recommendations": [
+    "Vue.volar",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode"
+  ]
 }

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/LookupCertification.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/LookupCertification.vue
@@ -13,8 +13,11 @@
         >
           www.gov.bc.ca/earlychildhoodeducators
         </a>
-        to learn more about the ECE Registry, certificate types, or status information. To find an ECE, you can search by name or registration number. The
-        registration number is on an ECE's certificate that's posted on the wall where they work.
+        to learn more about the ECE Registry, certificate types, or status information.
+        <p class="mt-3">
+          To find an ECE, you can search by name or registration number. The registration number is on an ECE's certificate that's posted on the wall where they
+          work.
+        </p>
       </v-col>
     </v-row>
     <v-form ref="lookupForm" class="mt-10">

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/LookupCertificationRecord.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/LookupCertificationRecord.vue
@@ -12,26 +12,22 @@
       <p class="font-weight-bold mt-4">ECE Registration Number</p>
       <span>{{ lookupCertificationStore.certificationRecord?.registrationNumber }}</span>
       <p class="font-weight-bold mt-4">Registration Status</p>
-      <div v-if="mobile" class="mt-2">
-        <v-chip :color="chipColor" variant="flat" size="small">{{ chipText }}</v-chip>
-        <v-spacer class="mb-2"></v-spacer>
-        <v-chip v-if="lookupCertificationStore.certificationRecord?.hasConditions" color="grey-darkest" variant="outlined" size="small">
-          Has Terms and Conditions
-        </v-chip>
-      </div>
-      <span v-else>
-        {{
-          `${lookupCertificationStore.certificationRecord?.statusCode}${
-            lookupCertificationStore.certificationRecord?.hasConditions ? " with Terms and Conditions" : ""
-          }`
-        }}
-      </span>
+      <v-row class="mt-2" no-gutters>
+        <v-col cols="12" md="auto" class="mr-2 mb-2">
+          <v-chip :color="chipColor" variant="flat" size="small">{{ chipText }}</v-chip>
+        </v-col>
+        <v-col cols="12" md="auto">
+          <v-chip v-if="lookupCertificationStore.certificationRecord?.hasConditions" color="grey-darkest" variant="outlined" size="small">
+            Has Terms and Conditions
+          </v-chip>
+        </v-col>
+      </v-row>
       <p class="font-weight-bold mt-4">Certification</p>
       <span>{{ lookupCertificationStore.certificateLevelName }}</span>
       <p class="font-weight-bold mt-4">Certificate expiry date</p>
       <span>{{ formatDate(lookupCertificationStore.certificationRecord?.expiryDate || "", "LLLL d, yyyy") }}</span>
       <div v-if="lookupCertificationStore.certificationRecord?.hasConditions">
-        <p class="font-weight-bold mt-7 mb-2">Terms and Conditions</p>
+        <p class="font-weight-bold mt-7 mb-2">Certificate Terms and Conditions</p>
         <ul class="ml-10">
           <li v-for="(condition, index) in sortedCertificateConditions" :key="index">
             {{ condition.details }}

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/LookupCertificationRecord.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/LookupCertificationRecord.vue
@@ -7,23 +7,96 @@
     <a href="#" @click.prevent="router.push({ name: 'lookup-certification' })">
       <v-icon size='x-large'>mdi-chevron-left</v-icon>Back to search
     </a>
-    <div>TODO ECER-3210</div>
-    {{ lookupCertificationStore.certificationRecord }}
+    <div>
+      <h2 class="mt-7">{{ lookupCertificationStore.certificationRecord?.name }}</h2>
+      <p class="font-weight-bold mt-4">ECE Registration Number</p>
+      <span>{{ lookupCertificationStore.certificationRecord?.registrationNumber }}</span>
+      <p class="font-weight-bold mt-4">Registration Status</p>
+      <div v-if="mobile" class="mt-2">
+        <v-chip :color="chipColor" variant="flat" size="small">{{ chipText }}</v-chip>
+        <v-spacer class="mb-2"></v-spacer>
+        <v-chip v-if="lookupCertificationStore.certificationRecord?.hasConditions" color="grey-darkest" variant="outlined" size="small">
+          Has Terms and Conditions
+        </v-chip>
+      </div>
+      <span v-else>
+        {{
+          `${lookupCertificationStore.certificationRecord?.statusCode}${
+            lookupCertificationStore.certificationRecord?.hasConditions ? " with Terms and Conditions" : ""
+          }`
+        }}
+      </span>
+      <p class="font-weight-bold mt-4">Certification</p>
+      <span>{{ lookupCertificationStore.certificateLevelName }}</span>
+      <p class="font-weight-bold mt-4">Certificate expiry date</p>
+      <span>{{ formatDate(lookupCertificationStore.certificationRecord?.expiryDate || "", "LLLL d, yyyy") }}</span>
+      <div v-if="lookupCertificationStore.certificationRecord?.hasConditions">
+        <p class="font-weight-bold mt-7 mb-2">Terms and Conditions</p>
+        <ul class="ml-10">
+          <li v-for="(condition, index) in sortedCertificateConditions" :key="index">
+            {{ condition.details }}
+          </li>
+        </ul>
+      </div>
+    </div>
   </v-container>
 </template>
 
 <script lang="ts">
-import { defineComponent, type PropType } from "vue";
+import { defineComponent } from "vue";
+import { useDisplay } from "vuetify";
 import { useRouter } from "vue-router";
 
 import { useLookupCertificationStore } from "@/store/lookupCertification";
+import { formatDate } from "@/utils/format";
 
 export default defineComponent({
   name: "LookupCertification",
   setup() {
     const lookupCertificationStore = useLookupCertificationStore();
     const router = useRouter();
-    return { lookupCertificationStore, router };
+    const { mobile } = useDisplay();
+    return { lookupCertificationStore, router, formatDate, mobile };
+  },
+  computed: {
+    sortedCertificateConditions() {
+      // Sort the conditions based on displayOrder
+      return this.lookupCertificationStore.certificationRecord?.certificateConditions?.sort((a, b) => a.displayOrder! - b.displayOrder!) || [];
+    },
+    chipText() {
+      // "Active" | "Cancelled" | "Expired" | "Inactive" | "Reprinted" | "Suspended"
+      switch (this.lookupCertificationStore.certificationRecord?.statusCode) {
+        case "Active":
+        case "Reprinted":
+          return "Active";
+        case "Renewed":
+          return "Renewed";
+        case "Expired":
+        case "Inactive":
+          return "Expired";
+        case "Cancelled":
+          return "Cancelled";
+        case "Suspended":
+          return "Suspended";
+        default:
+          return "Expired";
+      }
+    },
+    chipColor(): string {
+      // "success" | "error" | "warning" | "info"
+      switch (this.chipText) {
+        case "Active":
+        case "Renewed":
+          return "success";
+        case "Expired":
+          return "error";
+        case "Cancelled":
+        case "Suspended":
+          return "grey-darkest";
+        default:
+          return "grey-darkest";
+      }
+    },
   },
   methods: {},
 });

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/lookupCertification.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/lookupCertification.ts
@@ -17,7 +17,37 @@ export const useLookupCertificationStore = defineStore("lookupCertification", {
     lastName: "",
     registrationNumber: "",
   }),
-  getters: {},
+  getters: {
+    certificateLevelName(state): string {
+      const levels = state.certificationRecord?.levels!;
+      if (levels.some((level) => level.type === "ECE 1 YR")) {
+        return "ECE One Year";
+      }
+
+      if (levels.some((level) => level.type === "Assistant")) {
+        return "ECE Assistant";
+      }
+
+      if (levels.some((level) => level.type === "ECE 5 YR") && levels.some((level) => level.type === "ITE") && levels.some((level) => level.type === "SNE")) {
+        return "ECE Five Year with Infant and Toddler Educator (ITE) and Special Needs Educator (SNE)";
+      }
+
+      if (levels.some((level) => level.type === "ECE 5 YR") && levels.some((level) => level.type === "ITE")) {
+        return "ECE Five Year with Infant and Toddler Educator (ITE)";
+      }
+
+      if (levels.some((level) => level.type === "ECE 5 YR") && levels.some((level) => level.type === "ITE")) {
+        return "ECE Five Year with Special Needs Educator (SNE)";
+      }
+
+      if (levels.some((level) => level.type === "ECE 5 YR")) {
+        return "ECE Five Year";
+      }
+
+      console.warn(`generateCertificateLevelName:: unmapped level type:: ${levels}`);
+      return "";
+    },
+  },
   actions: {
     setCertificationSearchResults(data: Components.Schemas.CertificationLookupResponse[] | undefined): void {
       this.certificationSearchResults = data;


### PR DESCRIPTION
## Title
ECER-3210: Display registrant details with terms and conditions

## Description

- Displaying registrant details with terms and conditions
- Displaying list of conditions(ecer_details) in order specified by ecer_displayorder
- Displaying registration status as "status chips"
- Adjusted lookup certification store to get Certificate Level Name from store

 

## Related Jira Issue(s)

- ECER-3210
- ECER-3208

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)

![localhost_5121_lookup_certification_record (1)](https://github.com/user-attachments/assets/21651fd2-c88d-46d6-93ec-443ed7513cfc)


![localhost_5121_lookup_certification_record](https://github.com/user-attachments/assets/ad2dc0f6-b71e-47c4-8d85-0fc8374c8ff4)

**Mobile View:**

![localhost_5121_lookup_certification_record(iPhone 14 Pro Max) (1)](https://github.com/user-attachments/assets/4f8801c2-d5ab-46b5-b685-e58a08ef6c1d)

