### PR TITLE
ECER-3373: Portal certificate download not opening newest certificate file

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Files/FilesEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Files/FilesEndpoints.cs
@@ -37,7 +37,8 @@ public class FilesEndpoints : IRegisterEndpoints
       if (certificateQueryResult.Items == null || !certificateQueryResult.Items.Any()) return TypedResults.NotFound();
 
       var certificate = certificateQueryResult.Items.FirstOrDefault();
-      var certificateFile = certificate?.Files.FirstOrDefault();
+      //Filter Certificate Files to get latest certificate where Tag1 is "Certificate"
+      var certificateFile = certificate?.Files.Where(f => f.Tag1Name == "Certificate").OrderByDescending(f => f.CreatedOn).FirstOrDefault();
       if (certificateFile == null) return TypedResults.NotFound();
 
       var results = await messageBus.Send(new FileQuery([new FileLocation(certificateFile.Id, certificateFile.Url ?? string.Empty)]), ct);

--- a/src/ECER.Managers.Registry.Contract/Certifications/Contract.cs
+++ b/src/ECER.Managers.Registry.Contract/Certifications/Contract.cs
@@ -34,6 +34,8 @@ public record CertificationFile(string Id)
   public string? Extention { get; set; }
   public string? Size { get; set; }
   public string? Name { get; set; }
+  public DateTime? CreatedOn { get; set; }
+  public string? Tag1Name { get; set; }
 }
 
 public enum CertificateStatusCode

--- a/src/ECER.Resources.Documents/Certifications/CertificationRepositoryMapper.cs
+++ b/src/ECER.Resources.Documents/Certifications/CertificationRepositoryMapper.cs
@@ -31,7 +31,9 @@ internal class CertificationRepositoryMapper : Profile
     .ForMember(d => d.Url, opts => opts.MapFrom(s => s.bcgov_Url))
     .ForMember(d => d.Extention, opts => opts.MapFrom(s => s.bcgov_FileExtension))
     .ForMember(d => d.Size, opts => opts.MapFrom(s => s.bcgov_FileSize))
-    .ForMember(d => d.Name, opts => opts.MapFrom(s => s.bcgov_FileName));
+    .ForMember(d => d.Name, opts => opts.MapFrom(s => s.bcgov_FileName))
+    .ForMember(d => d.CreatedOn, opts => opts.MapFrom(s => s.CreatedOn))
+    .ForMember(d => d.Tag1Name, opts => opts.MapFrom(s => s.bcgov_Tag1IdName));
 
     CreateMap<CertificateStatusCode, ecer_Certificate_StatusCode>()
     .ConvertUsingEnumMapping(opts => opts.MapByName(true))

--- a/src/ECER.Resources.Documents/Certifications/ICertificationRepository.cs
+++ b/src/ECER.Resources.Documents/Certifications/ICertificationRepository.cs
@@ -37,6 +37,8 @@ public record CertificationFile(string Id)
   public string? Extention { get; set; }
   public string? Size { get; set; }
   public string? Name { get; set; }
+  public DateTime? CreatedOn { get; set; }
+  public string? Tag1Name { get; set; }
 }
 
 public enum CertificateStatusCode


### PR DESCRIPTION
## Title
ECER-3373: Portal certificate download not opening newest certificate file

## Description

- Fix for Portal certificate download not opening newest certificate file
- BE : Added and Mapped "Tag1Name" and "CreatedOn" props for Certificate Files 
- Filtering Certificate Files to get latest certificate where Tag 1 Name is "Certificate"

## Related Jira Issue(s)

- ECER-3373


## Checklist
- [x] I have tested these changes locally.
- [x] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.
