### PR TITLE
fix recaptcha error when sending public lookup twice

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/LookupCertification.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/LookupCertification.vue
@@ -182,6 +182,12 @@ export default defineComponent({
           });
 
           this.lookupCertificationStore.setCertificationSearchResults(data);
+
+          //reset grecaptcha after success, token cannot be reused
+          this.recaptchaToken = "";
+          window.grecaptcha.reset();
+          await this.$nextTick();
+          (this.$refs.lookupForm as VForm).resetValidation();
         }
       } catch (e) {
         console.error(e);

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/global.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/global.d.ts
@@ -2,7 +2,7 @@ declare global {
   interface Window {
     grecaptcha: {
       getResponse(): string;
-      reset(string): void;
+      reset(string?): void; //if widget id is not provided, will default to first recaptcha instance
       render(string): string;
     };
     recaptchaSuccessCallback: function;


### PR DESCRIPTION
## Title

## Description

- fix bug when sending request twice with same recaptcha token. 
- await nextTick() required so that the validation error goes away when we reset the token. 

## Checklist
- [ ] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/73e55b18-98f7-4b95-9959-e153ce56c0bc)


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.