### PR TITLE
stories/ECER-3497

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Files/FilesEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Files/FilesEndpoints.cs
@@ -118,6 +118,14 @@ public class FilesEndpoints : IRegisterEndpoints
       {
         return TypedResults.BadRequest(new ProblemDetails { Title = "No file uploaded or file is empty" });
       }
+
+      // Check if the file extension is allowed
+      var fileExtension = Path.GetExtension(file.FileName)?.ToLowerInvariant();
+      if (string.IsNullOrEmpty(fileExtension) || !uploaderOptions.Value.AllowedFileTypes.Contains(fileExtension))
+      {
+        return TypedResults.BadRequest(new ProblemDetails { Title = "Unsupported file type", Detail = $"Supported file types: {string.Join(", ", uploaderOptions.Value.AllowedFileTypes)}" });
+      }
+
       var fileProperties = new FileProperties() { Classification = classification, Tags = tags };
       var sanitizedFilename = Encoding.ASCII.GetString(Encoding.ASCII.GetBytes(file.FileName));
 

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Shared/Contract.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Shared/Contract.cs
@@ -11,6 +11,7 @@ public record PaginationSettings
 public record UploaderSettings
 {
   public string TempFolderName { get; set; } = string.Empty;
+  public IEnumerable<string> AllowedFileTypes { get; set; } = Array.Empty<string>();
 }
 
 public record RecaptchaSettings

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/appsettings.json
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/appsettings.json
@@ -16,7 +16,8 @@
     "PageSizeProperty": "pageSize"
   },
   "Uploader": {
-    "TempFolderName": "tempfolder"
+    "TempFolderName": "tempfolder",
+    "AllowedFileTypes": [ ".txt", ".pdf", ".doc", ".docx", ".rtf", ".xls", ".xlsx", ".jpg", ".jpeg", ".gif", ".png", ".bmp", ".tiff", ".x-tiff" ]
   },
   "AllowedHosts": "*",
   "DisabledHttpVerbs": "TRACE, OPTIONS",


### PR DESCRIPTION
ECER-3497: file extension filter for valid file types on the backend

## Checklist
- [ ] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.