### PR TITLE
ECER-3353: Hide option to continue application for manually entered applications

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationMapper.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationMapper.cs
@@ -81,6 +81,7 @@ public class ApplicationMapper : Profile
       .ForMember(d => d.AddMoreCharacterReference, opts => opts.Ignore())
       .ForMember(d => d.AddMoreWorkExperienceReference, opts => opts.Ignore())
       .ForMember(d => d.AddMoreProfessionalDevelopment, opts => opts.Ignore())
+      .ForMember(d => d.Origin, opts => opts.Ignore())
       .ForMember(d => d.Transcripts, opts => opts.MapFrom(s => s.Transcripts))
       .ForMember(d => d.WorkExperienceReferences, opts => opts.MapFrom(s => s.WorkExperienceReferences))
       .ForMember(d => d.ProfessionalDevelopments, opts => opts.MapFrom(s => s.ProfessionalDevelopments))

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
@@ -337,6 +337,7 @@ public record DraftApplication
   public FiveYearRenewalExplanations? FiveYearRenewalExplanationChoice { get; set; }
   public string? RenewalExplanationOther { get; set; }
   public DateTime? CreatedOn { get; set; }
+  public ApplicationOrigin? Origin { get; set; }
 }
 
 public record Application
@@ -358,6 +359,7 @@ public record Application
   public OneYearRenewalexplanations? OneYearRenewalExplanationChoice { get; set; }
   public FiveYearRenewalExplanations? FiveYearRenewalExplanationChoice { get; set; }
   public string? RenewalExplanationOther { get; set; }
+  public ApplicationOrigin? Origin { get; set; }
 }
 public record ProfessionalDevelopment([Required] string CourseName, [Required] string OrganizationName, [Required] DateTime StartDate, [Required] DateTime EndDate, [Required] int NumberOfHours)
 {
@@ -444,6 +446,13 @@ public enum ApplicationStatus
   PendingQueue,
   ReconsiderationDecision,
   AppealDecision
+}
+
+public enum ApplicationOrigin
+{
+  Manual,
+  Oracle,
+  Portal
 }
 
 public enum ApplicationStatusReasonDetail

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ApplicationCard.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ApplicationCard.vue
@@ -6,18 +6,19 @@
         {{ subTitle }}
       </p>
     </v-card-item>
-    <v-card-actions class="ma-4">
+
+    <div class="d-flex flex-row justify-start ga-3 flex-wrap ma-4">
       <!-- Application status Draft -->
-      <div v-if="applicationStore.applicationStatus === 'Draft'" class="d-flex flex-row justify-start ga-3 flex-wrap">
+      <v-card-actions v-if="applicationStore.applicationStatus === 'Draft' && applicationStore.applicationOrigin !== 'Manual'">
         <v-btn size="large" variant="flat" color="warning" @click="router.push('/application')">
           <v-icon size="large" icon="mdi-arrow-right" />
           Open application
         </v-btn>
         <v-btn class="ma-0" size="large" variant="outlined" color="white" @click="$emit('cancel-application')">Cancel application</v-btn>
-      </div>
+      </v-card-actions>
 
       <!-- Application status Submitted, Ready, In Progress, Pending Queue -->
-      <div
+      <v-card-actions
         v-if="
           applicationStore.applicationStatus === 'Submitted' ||
           applicationStore.applicationStatus === 'Ready' ||
@@ -26,22 +27,21 @@
           applicationStore.applicationStatus === 'Pending' ||
           applicationStore.applicationStatus === 'Escalated'
         "
-        class="d-flex flex-row justify-start ga-3 flex-wrap"
       >
         <v-btn variant="flat" size="large" color="warning" @click="handleManageApplication">
           <v-icon size="large" icon="mdi-arrow-right" />
           Manage Application
         </v-btn>
-      </div>
+      </v-card-actions>
 
       <!-- No application found -->
-      <div v-if="applicationStore.applicationStatus === undefined" class="d-flex flex-row justify-start ga-3 flex-wrap">
+      <v-card-actions v-if="applicationStore.applicationStatus === undefined">
         <v-btn variant="flat" size="large" color="warning" @click="handleStartNewApplication">
           <v-icon size="large" icon="mdi-arrow-right" />
           Apply now
         </v-btn>
-      </div>
-    </v-card-actions>
+      </v-card-actions>
+    </div>
   </v-card>
 </template>
 

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/application.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/application.ts
@@ -83,6 +83,9 @@ export const useApplicationStore = defineStore("application", {
     applicationStatus(state): Components.Schemas.ApplicationStatus | undefined {
       return state.application?.status;
     },
+    applicationOrigin(state): Components.Schemas.ApplicationOrigin | undefined {
+      return state.application?.origin;
+    },
     workExperienceReferenceById: (state) => {
       return (referenceId: string) => state.application?.workExperienceReferences?.find((ref) => ref.id === referenceId);
     },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
@@ -40,6 +40,7 @@ declare namespace Components {
             oneYearRenewalExplanationChoice?: OneYearRenewalexplanations;
             fiveYearRenewalExplanationChoice?: FiveYearRenewalExplanations;
             renewalExplanationOther?: string | null;
+            origin?: ApplicationOrigin;
         }
         export interface ApplicationConfiguration {
             clientAuthenticationMethods?: {
@@ -47,6 +48,7 @@ declare namespace Components {
             } | null;
             version?: string | null;
         }
+        export type ApplicationOrigin = "Manual" | "Oracle" | "Portal";
         export type ApplicationStatus = "Draft" | "Submitted" | "Complete" | "Reconsideration" | "Cancelled" | "Escalated" | "Decision" | "Withdrawn" | "Pending" | "Ready" | "InProgress" | "PendingQueue" | "ReconsiderationDecision" | "AppealDecision";
         export type ApplicationStatusReasonDetail = "Actioned" | "BeingAssessed" | "Certified" | "Denied" | "ForReview" | "InvestigationsConsultationNeeded" | "MoreInformationRequired" | "OperationSupervisorManagerofCertificationsConsultationNeeded" | "PendingDocuments" | "ProgramAnalystReview" | "ReadyforAssessment" | "ReceivedPending" | "ReceivePhysicalTranscripts" | "SupervisorConsultationNeeded" | "ValidatingIDs";
         /**
@@ -127,10 +129,10 @@ declare namespace Components {
         }
         export type CertificationType = "EceAssistant" | "OneYear" | "FiveYears" | "Ite" | "Sne";
         export interface CharacterReference {
-            firstName?: string | null;
             lastName?: string | null;
             phoneNumber?: string | null;
             emailAddress?: string | null;
+            firstName?: string | null;
             id?: string | null;
         }
         export interface CharacterReferenceEvaluation {
@@ -362,10 +364,10 @@ declare namespace Components {
         }
         export interface ReferenceContactInformation {
             lastName?: string | null;
-            firstName?: string | null;
             email?: string | null;
             phoneNumber?: string | null;
             certificateProvinceOther?: string | null;
+            firstName?: string | null;
             certificateProvinceId?: string | null;
             certificateNumber?: string | null;
             dateOfBirth?: string | null; // date-time
@@ -451,12 +453,12 @@ declare namespace Components {
             referenceId?: string | null;
         }
         export interface UserInfo {
-            firstName?: string | null;
             lastName?: string | null;
-            givenName?: string | null;
             dateOfBirth?: string; // date
             email?: string | null;
             phone?: string | null;
+            firstName?: string | null;
+            givenName?: string | null;
             middleName?: string | null;
             registrationNumber?: string | null;
             isVerified?: boolean;
@@ -483,10 +485,10 @@ declare namespace Components {
         }
         export type WorkExperienceRefStage = "ApplicationSubmitted" | "Approved" | "Draft" | "InProgress" | "Rejected" | "Submitted" | "UnderReview" | "WaitingforResponse";
         export interface WorkExperienceReference {
-            firstName?: string | null;
             lastName?: string | null;
             emailAddress?: string | null;
             hours?: number; // int32
+            firstName?: string | null;
             id?: string | null;
             phoneNumber?: string | null;
             type?: WorkExperienceTypes;
@@ -1479,6 +1481,7 @@ export type AddProfessionalDevelopmentResponse = Components.Schemas.AddProfessio
 export type Address = Components.Schemas.Address;
 export type Application = Components.Schemas.Application;
 export type ApplicationConfiguration = Components.Schemas.ApplicationConfiguration;
+export type ApplicationOrigin = Components.Schemas.ApplicationOrigin;
 export type ApplicationStatus = Components.Schemas.ApplicationStatus;
 export type ApplicationStatusReasonDetail = Components.Schemas.ApplicationStatusReasonDetail;
 export type ApplicationSubmissionRequest = Components.Schemas.ApplicationSubmissionRequest;

--- a/src/ECER.Managers.Registry.Contract/Applications/Contract.cs
+++ b/src/ECER.Managers.Registry.Contract/Applications/Contract.cs
@@ -68,6 +68,7 @@ public record Application(string? Id, string RegistrantId, ApplicationStatus Sta
   public OneYearRenewalexplanations? OneYearRenewalExplanationChoice { get; set; }
   public FiveYearRenewalExplanations? FiveYearRenewalExplanationChoice { get; set; }
   public string? RenewalExplanationOther { get; set; }
+  public ApplicationOrigin? Origin { get; set; }
 }
 
 public record Transcript(string? Id, string? EducationalInstitutionName, string? ProgramName, string? StudentNumber, DateTime StartDate, DateTime EndDate, bool IsECEAssistant, bool DoesECERegistryHaveTranscript, bool IsOfficialTranscriptRequested, string StudentFirstName, string StudentLastName, bool IsNameUnverified, EducationRecognition EducationRecognition, EducationOrigin EducationOrigin)
@@ -176,6 +177,13 @@ public enum ApplicationStatus
   PendingQueue,
   ReconsiderationDecision,
   AppealDecision
+}
+
+public enum ApplicationOrigin
+{
+  Manual,
+  Oracle,
+  Portal
 }
 
 public enum ApplicationStatusReasonDetail

--- a/src/ECER.Resources.Documents/Applications/ApplicationRepository.cs
+++ b/src/ECER.Resources.Documents/Applications/ApplicationRepository.cs
@@ -87,6 +87,8 @@ internal sealed partial class ApplicationRepository : IApplicationRepository
     await UpdateCharacterReferences(ecerApplication, ecerCharacterReferences);
     await UpdateTranscripts(ecerApplication, ecerTranscripts);
 
+    ecerApplication.ecer_Origin = ecer_Origin.Portal; // Set application origin to "Portal"
+
     context.SaveChanges();
     return ecerApplication.ecer_ApplicationId.Value.ToString();
   }

--- a/src/ECER.Resources.Documents/Applications/ApplicationRepositoryMapper.cs
+++ b/src/ECER.Resources.Documents/Applications/ApplicationRepositoryMapper.cs
@@ -22,6 +22,7 @@ internal class ApplicationRepositoryMapper : Profile
        .ForSourceMember(s => s.AddMoreCharacterReference, opts => opts.DoNotValidate())
        .ForSourceMember(s => s.AddMoreWorkExperienceReference, opts => opts.DoNotValidate())
        .ForSourceMember(s => s.AddMoreProfessionalDevelopment, opts => opts.DoNotValidate())
+       .ForSourceMember(s => s.Origin, opts => opts.DoNotValidate())
        .ForMember(d => d.ecer_ApplicationId, opts => opts.MapFrom(s => s.Id))
        .ForMember(d => d.StatusCode, opts => opts.MapFrom(s => s.Status))
        .ForMember(d => d.ecer_IsECEAssistant, opts => opts.MapFrom(s => s.CertificationTypes.Contains(CertificationType.EceAssistant)))
@@ -53,7 +54,8 @@ internal class ApplicationRepositoryMapper : Profile
        .ForMember(d => d.ReadyForAssessmentDate, opts => opts.MapFrom(s => s.ecer_ReadyforAssessmentDate))
        .ForMember(d => d.AddMoreCharacterReference, opts => opts.MapFrom(s => s.ecer_AddMoreCharacterReference))
        .ForMember(d => d.AddMoreWorkExperienceReference, opts => opts.MapFrom(s => s.ecer_AddMoreWorkExperienceReference))
-       .ForMember(d => d.AddMoreProfessionalDevelopment, opts => opts.MapFrom(s => s.ecer_AddMoreProfessionalDevelopment));
+       .ForMember(d => d.AddMoreProfessionalDevelopment, opts => opts.MapFrom(s => s.ecer_AddMoreProfessionalDevelopment))
+       .ForMember(d => d.Origin, opts => opts.MapFrom(s => s.ecer_Origin));
 
     CreateMap<ecer_Application, IEnumerable<CertificationType>>()
         .ConstructUsing((s, _) =>
@@ -66,6 +68,10 @@ internal class ApplicationRepositoryMapper : Profile
           if (s.ecer_isSNE.GetValueOrDefault()) types.Add(CertificationType.Sne);
           return types;
         });
+
+    CreateMap<ApplicationOrigin, ecer_Origin>()
+        .ConvertUsingEnumMapping(opts => opts.MapByName(true))
+        .ReverseMap();
 
     CreateMap<ApplicationStatus, ecer_Application_StatusCode>()
         .ConvertUsingEnumMapping(opts => opts.MapByName(true))

--- a/src/ECER.Resources.Documents/Applications/IApplicationRepository.cs
+++ b/src/ECER.Resources.Documents/Applications/IApplicationRepository.cs
@@ -54,6 +54,7 @@ public record Application(string? Id, string ApplicantId, IEnumerable<Certificat
   public OneYearRenewalexplanations? OneYearRenewalExplanationChoice { get; set; }
   public FiveYearRenewalExplanations? FiveYearRenewalExplanationChoice { get; set; }
   public string? RenewalExplanationOther { get; set; }
+  public ApplicationOrigin? Origin { get; set; }
 }
 
 public record Transcript(string? Id, string? EducationalInstitutionName, string? ProgramName, string? StudentNumber, DateTime StartDate, DateTime EndDate, bool IsECEAssistant, bool DoesECERegistryHaveTranscript, bool IsOfficialTranscriptRequested, string StudentFirstName, string StudentLastName, bool IsNameUnverified, EducationRecognition EducationRecognition, EducationOrigin EducationOrigin)
@@ -121,6 +122,13 @@ public enum ApplicationStatus
   PendingQueue,
   ReconsiderationDecision,
   AppealDecision
+}
+
+public enum ApplicationOrigin
+{
+  Manual,
+  Oracle,
+  Portal
 }
 
 public enum ApplicationStatusReasonDetail

--- a/src/ECER.Tests/Integration/RegistryApi/ApplicationTests.cs
+++ b/src/ECER.Tests/Integration/RegistryApi/ApplicationTests.cs
@@ -56,6 +56,7 @@ public class ApplicationTests : RegistryPortalWebAppScenarioBase
     var applicationsById = await applicationByIdResponse.ReadAsJsonAsync<DraftApplication[]>();
     var applicationById = applicationsById.ShouldHaveSingleItem();
     applicationById.ApplicationType.ShouldBe(ApplicationTypes.New);
+    applicationById.Origin.ShouldBe(ApplicationOrigin.Portal);
     applicationById.Transcripts.ShouldNotBeEmpty();
     applicationById.CharacterReferences.ShouldNotBeEmpty();
     applicationById.WorkExperienceReferences.ShouldNotBeEmpty();


### PR DESCRIPTION
## Title
ECER-3353: Hide option to continue application for manually entered applications

## Description

- BE: (one way) map application origin from dynamics to portal
- BE: Set default application origin to "Portal" in the application repository
- BE: Update automated tests
- FE: Hide "Open application" and "Cancel application" option for manual applications

## Related Jira Issue(s)

- ECER-3353
- ECER-3435
- ECER-3436
- ECER-3437
- ECER-3438


## Checklist
- [x] I have tested these changes locally.
- [x] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/de8c46ee-f7b3-4c43-a332-53eb3c7dc54a)
