### PR TITLE
quick fix for stepper colors, primary button color fix for education,…

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
@@ -212,7 +212,7 @@
           </v-row>
         </div>
         <v-row justify="start" class="ml-1 mt-3">
-          <v-btn rounded="lg" color="alternate" class="mr-2" @click="handleSubmit">Save Education</v-btn>
+          <v-btn rounded="lg" color="primary" class="mr-2" @click="handleSubmit">Save education</v-btn>
           <v-btn rounded="lg" variant="outlined" @click="handleCancel">Cancel</v-btn>
         </v-row>
       </v-form>
@@ -223,7 +223,7 @@
       </v-col>
       <v-col cols="12" class="mt-6">
         <v-row justify="start" class="ml-1">
-          <v-btn v-if="showAddEducationButton" prepend-icon="mdi-plus" rounded="lg" color="alternate" @click="handleAddEducation">Add education</v-btn>
+          <v-btn v-if="showAddEducationButton" prepend-icon="mdi-plus" rounded="lg" color="primary" @click="handleAddEducation">Add education</v-btn>
         </v-row>
       </v-col>
       <v-col>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceProfessionalDevelopment.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceProfessionalDevelopment.vue
@@ -274,7 +274,7 @@
           No additional professional development may be added. You provided the required 40 hours. After you submit your application, the registry will review
           and verify the professional development added. If needed, the registry will contact you for additional information.
         </p>
-        <v-btn v-else prepend-icon="mdi-plus" rounded="lg" color="alternate" :disabled="isDisabled" @click="handleAddProfessionalDevelopment">
+        <v-btn v-else prepend-icon="mdi-plus" rounded="lg" color="primary" :disabled="isDisabled" @click="handleAddProfessionalDevelopment">
           Add course or workshop
         </v-btn>
       </v-col>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceWorkExperienceReferences.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceWorkExperienceReferences.vue
@@ -100,7 +100,7 @@
             No additional work references may be added. You provided the required hours. After you submit your application, we’ll email the work references to
             complete their reference. If needed, we'll contact you for additional information.
           </p>
-          <v-btn v-else prepend-icon="mdi-plus" rounded="lg" color="alternate" :disabled="isDisabled" @click="handleAddReference">Add reference</v-btn>
+          <v-btn v-else prepend-icon="mdi-plus" rounded="lg" color="primary" :disabled="isDisabled" @click="handleAddReference">Add reference</v-btn>
         </v-col>
       </v-row>
       <!-- this prevents form from proceeding if rules are not met -->

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/styles/_colors.scss
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/styles/_colors.scss
@@ -6,7 +6,7 @@ $grey-dark: "#3B3A39";
 $grey-light: "#A19F9D";
 $grey-lightest: "#D2D0CE";
 $grey-darkest: "#5F6368";
-$grey-stepper: "#605E5C";
+$grey-stepper: "#4F4F4F";
 $ash-grey: "#ADB5BD";
 $white-smoke: "#f8f8f8";
 $background-light: "#FAF9F8";

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/styles/v-stepper.scss
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/styles/v-stepper.scss
@@ -13,6 +13,9 @@
   color: #{$primary};
 }
 
-.v-stepper-item--completed {
+.v-stepper-item--complete {
   color: #{$links};
+  .v-stepper-item__avatar.v-avatar {
+    background: #{$links} !important;
+  }
 }


### PR DESCRIPTION
… professional development and references

## Title
ECER-3268: Stepper colors

## Description

- changed stepper colors to match figma (aside from opacity)
- add button colors for education, references and professional development are now primary
- fixed sentence casing for add education

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.
![image](https://github.com/user-attachments/assets/903258ff-9a33-452f-80fe-173772a33640)

![image](https://github.com/user-attachments/assets/4518ca34-d450-4039-975b-fadee0c593d5)


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.