### PR TITLE
ECER-3464: Character Reference Instruction spacing issue

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Wizard.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Wizard.vue
@@ -18,7 +18,7 @@
         :reverse-transition="false"
       >
         <v-container>
-          <v-row class="justify-space-between mb-4">
+          <v-row class="justify-space-between mb-4" v-if="step.title || wizardStore.currentStepStage === 'Review'">
             <v-col cols="auto">
               <h1>{{ step.title }}</h1>
             </v-col>
@@ -26,7 +26,7 @@
               <slot name="PrintPreview"></slot>
             </v-col>
           </v-row>
-          <h4>{{ step.subtitle }}</h4>
+          <h4 v-if="step.subtitle">{{ step.subtitle }}</h4>
           <v-row>
             <v-col cols="12">
               <EceForm :ref="step.form.id" :form="step.form" :form-data="wizardStore.wizardData" @updated-form-data="wizardStore.setWizardData" />

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReference.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReference.vue
@@ -88,7 +88,6 @@ import EceTextField from "@/components/inputs/EceTextField.vue";
 import { useAlertStore } from "@/store/alert";
 import { useApplicationStore } from "@/store/application";
 import { useWizardStore } from "@/store/wizard";
-import type { EceCharacterReferenceProps } from "@/types/input";
 import type { Components } from "@/types/openapi";
 import { isNumber } from "@/utils/formInput";
 import { isNotSpecialCharacterName } from "@/utils/formInput";

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceDateInput.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceDateInput.vue
@@ -2,7 +2,7 @@
   <label>
     {{ label }}
     <v-date-input
-      :model-value="new Date(modelValue ?? '')"
+      :model-value="value"
       :value="formattedDate"
       :aria-label="label"
       prepend-icon=""
@@ -49,6 +49,14 @@ export default defineComponent({
      */
     formattedDate() {
       return formatDate(this.modelValue ?? "", "LLLL d, yyyy");
+    },
+    value() {
+      if (!this.modelValue) {
+        return new Date(); // Return current date as default Date object
+      }
+      // Convert modelValue to a Date object for date picker consistency
+      const [year, month, day] = this.modelValue.split("-").map(Number);
+      return new Date(year, month - 1, day); // No UTC to keep in local time
     },
   },
 });

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceReferenceContact.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceReferenceContact.vue
@@ -104,6 +104,8 @@
                 v-if="wizardStore.wizardData.inviteType === PortalInviteType.CHARACTER"
                 :model-value="modelValue.certificateProvinceId"
                 label=""
+                variant="outlined"
+                color="primary"
                 class="pt-2"
                 :items="configStore?.provinceList"
                 clearable

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceReferenceContact.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceReferenceContact.vue
@@ -98,10 +98,9 @@
         </div>
         <v-row class="mt-5">
           <v-col cols="12" md="8" lg="6" xl="4">
-            <label>
+            <label v-if="wizardStore.wizardData.inviteType === PortalInviteType.CHARACTER">
               Province/Territory Certified/Registered In (Optional)
               <v-autocomplete
-                v-if="wizardStore.wizardData.inviteType === PortalInviteType.CHARACTER"
                 :model-value="modelValue.certificateProvinceId"
                 label=""
                 variant="outlined"
@@ -113,12 +112,13 @@
                 @click:clear="provinceClearClicked"
               ></v-autocomplete>
             </label>
-            <label>
+            <label v-if="wizardStore.wizardData.inviteType === PortalInviteType.WORK_EXPERIENCE">
               Province/Territory Certified/Registered In
               <v-autocomplete
-                v-if="wizardStore.wizardData.inviteType === PortalInviteType.WORK_EXPERIENCE"
                 :model-value="modelValue.certificateProvinceId"
                 label=""
+                variant="outlined"
+                color="primary"
                 class="pt-2"
                 :items="configStore?.provinceList.filter((province) => province.title !== ProvinceTerritoryType.OTHER)"
                 :rules="[Rules.required()]"


### PR DESCRIPTION
## Description

- `EceDateInput` adjustment for locale
- Spacing adjustment
- Missed styling in reference flows from ECER-2891

## Related Jira Issue(s)

- [ECER-2891](https://eccbc.atlassian.net/browse/ECER-2891)
- [ECER-3464](https://eccbc.atlassian.net/browse/ECER-3464)

## Checklist
- [X] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.