### PR TITLE
Stories/ecer 3141

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReference.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReference.vue
@@ -30,11 +30,11 @@
     <v-col cols="12" md="8" lg="6" xl="4">
       <EceTextField
         v-model="lastName"
-        :rules="[Rules.required('Enter your reference\'s last name'), Rules.noSpecialCharactersContactName()]"
+        :rules="[Rules.required('Enter your reference\'s last name'), Rules.validContactName()]"
         label="Last name"
         maxlength="100"
         @update:model-value="updateCharacterReference()"
-        @keypress="isNotSpecialCharacterName"
+        @keypress="validContactNameCharacter"
       ></EceTextField>
     </v-col>
   </v-row>
@@ -42,11 +42,11 @@
     <v-col cols="12" md="8" lg="6" xl="4">
       <EceTextField
         v-model="firstName"
-        :rules="[Rules.noSpecialCharactersContactName()]"
+        :rules="[Rules.validContactName()]"
         label="First name"
         maxlength="100"
         @update:model-value="updateCharacterReference()"
-        @keypress="isNotSpecialCharacterName"
+        @keypress="validContactNameCharacter"
       ></EceTextField>
     </v-col>
   </v-row>
@@ -90,7 +90,7 @@ import { useApplicationStore } from "@/store/application";
 import { useWizardStore } from "@/store/wizard";
 import type { Components } from "@/types/openapi";
 import { isNumber } from "@/utils/formInput";
-import { isNotSpecialCharacterName } from "@/utils/formInput";
+import { validContactNameCharacter } from "@/utils/formInput";
 import * as Rules from "@/utils/formRules";
 
 import Alert from "../Alert.vue";
@@ -158,7 +158,7 @@ export default defineComponent({
         { firstName: this.firstName, lastName: this.lastName, emailAddress: this.emailAddress, phoneNumber: this.phoneNumber },
       ] as Components.Schemas.CharacterReference);
     },
-    isNotSpecialCharacterName,
+    validContactNameCharacter,
   },
 });
 </script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/character-references-upsert-form.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/character-references-upsert-form.ts
@@ -11,7 +11,7 @@ const characterReferencesUpsertForm: Form = {
       component: EceTextField,
       props: {
         label: "Last Name",
-        rules: [Rules.required("Enter your reference's last name"), Rules.noSpecialCharactersContactName()],
+        rules: [Rules.required("Enter your reference's last name"), Rules.validContactName()],
         maxLength: 100,
       },
       cols: {
@@ -25,7 +25,7 @@ const characterReferencesUpsertForm: Form = {
       component: EceTextField,
       props: {
         label: "First Name",
-        rules: [Rules.noSpecialCharactersContactName()],
+        rules: [Rules.validContactName()],
         maxLength: 100,
       },
       cols: {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/previous-name-form.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/previous-name-form.ts
@@ -11,7 +11,7 @@ const previousNameForm: Form = {
       component: EceTextField,
       props: {
         label: "First name",
-        rules: [Rules.noSpecialCharactersContactName()],
+        rules: [Rules.validContactName()],
         maxLength: 100,
       },
       cols: {
@@ -25,7 +25,7 @@ const previousNameForm: Form = {
       component: EceTextField,
       props: {
         label: "Middle names (optional)",
-        rules: [Rules.noSpecialCharactersContactName()],
+        rules: [Rules.validContactName()],
         maxLength: 100,
       },
       cols: {
@@ -39,7 +39,7 @@ const previousNameForm: Form = {
       component: EceTextField,
       props: {
         label: "Last name",
-        rules: [Rules.required("Enter your legal name"), Rules.noSpecialCharactersContactName()],
+        rules: [Rules.required("Enter your legal name"), Rules.validContactName()],
         maxLength: 100,
       },
       cols: {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formInput.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formInput.ts
@@ -30,7 +30,7 @@ const isNotSpecialCharacterName = function (event: KeyboardEvent): void {
   const charCode = event instanceof KeyboardEvent ? event.key : "";
 
   // Check if the key pressed is not a number and not a valid input event
-  if (event instanceof KeyboardEvent && /[^A-Za-z\s-']/.test(charCode)) {
+  if (event instanceof KeyboardEvent && /[^a-zA-Z\u00C0-\u017F\s'-]/.test(charCode)) {
     event.preventDefault();
   }
 };

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formInput.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formInput.ts
@@ -26,7 +26,7 @@ const isNumber = function (event: KeyboardEvent | InputEvent): void {
  * @param {Object} event
  * @returns void
  */
-const isNotSpecialCharacterName = function (event: KeyboardEvent): void {
+const validContactNameCharacter = function (event: KeyboardEvent): void {
   const charCode = event instanceof KeyboardEvent ? event.key : "";
 
   // Check if the key pressed is not a number and not a valid input event
@@ -35,4 +35,4 @@ const isNotSpecialCharacterName = function (event: KeyboardEvent): void {
   }
 };
 
-export { isNotSpecialCharacterName, isNumber };
+export { validContactNameCharacter, isNumber };

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formRules.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formRules.ts
@@ -32,24 +32,6 @@ const number = (message = "Must be a number") => {
   return (v: string) => !v || /^\d+$/.test(v) || message;
 };
 
-/**
- * Form input must not contain special characters
- *
- * @param {String} [message]
- * @returns {(value: string) => true|string}
- */
-const noSpecialCharactersAddress =
-  (
-    message = "Special characters currently aren’t accepted, but we recognize their importance and are working on an update. For now, please remove or replace them.",
-  ) =>
-  (v: string) =>
-    !v || !/[^A-Za-z0-9\s-.#/]/.test(v) || message;
-
-const noSpecialCharactersContactTitle =
-  (message = "Remove or replace any special characters in this field.") =>
-  (v: string) =>
-    !v || !/[^A-Za-z.'\s-&()]/.test(v) || message;
-
 const noSpecialCharactersContactName =
   (message = "Remove or replace any special characters in this field.") =>
   (v: string) =>
@@ -225,9 +207,7 @@ export {
   email,
   futureDateNotAllowedRule,
   hasCheckbox,
-  noSpecialCharactersAddress,
   noSpecialCharactersContactName,
-  noSpecialCharactersContactTitle,
   number,
   phoneNumber,
   postalCode,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formRules.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formRules.ts
@@ -53,7 +53,7 @@ const noSpecialCharactersContactTitle =
 const noSpecialCharactersContactName =
   (message = "Remove or replace any special characters in this field.") =>
   (v: string) =>
-    !v || !/[^A-Za-z.'\s-]/.test(v) || message;
+    !v || !/[^a-zA-Z\u00C0-\u017F\s'-]/.test(v) || message;
 
 /**
  * Rule for phone numbers also works for fax numbers too

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formRules.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formRules.ts
@@ -32,7 +32,7 @@ const number = (message = "Must be a number") => {
   return (v: string) => !v || /^\d+$/.test(v) || message;
 };
 
-const noSpecialCharactersContactName =
+const validContactName =
   (message = "Remove or replace any special characters in this field.") =>
   (v: string) =>
     !v || !/[^a-zA-Z\u00C0-\u017F\s'-]/.test(v) || message;
@@ -207,7 +207,7 @@ export {
   email,
   futureDateNotAllowedRule,
   hasCheckbox,
-  noSpecialCharactersContactName,
+  validContactName,
   number,
   phoneNumber,
   postalCode,


### PR DESCRIPTION

## Title
ECER-3141: saving special characters in names

## Description

- Affects EceCharacterRefrence, characterReferencesUpsertForm, previousNameForm
- https://eccbc.atlassian.net/browse/ECER-3141
- For a list of unicode characters this is a good site to refer to https://symbl.cc/en/unicode-table/#latin-extended-a 

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/75bec61f-372d-4613-af18-cd23c1a95651)


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.