### PR TITLE
ECER-2702: New logic for certification query

### DIFF
--- a/src/ECER.Resources.Documents/Applications/ApplicationRepositoryMapper.cs
+++ b/src/ECER.Resources.Documents/Applications/ApplicationRepositoryMapper.cs
@@ -55,7 +55,9 @@ internal class ApplicationRepositoryMapper : Profile
        .ForMember(d => d.AddMoreCharacterReference, opts => opts.MapFrom(s => s.ecer_AddMoreCharacterReference))
        .ForMember(d => d.AddMoreWorkExperienceReference, opts => opts.MapFrom(s => s.ecer_AddMoreWorkExperienceReference))
        .ForMember(d => d.AddMoreProfessionalDevelopment, opts => opts.MapFrom(s => s.ecer_AddMoreProfessionalDevelopment))
-       .ForMember(d => d.Origin, opts => opts.MapFrom(s => s.ecer_Origin));
+       .ForMember(d => d.Origin, opts => opts.MapFrom(s => s.ecer_Origin))
+       .ForMember(d => d.Stage, opts => opts.MapFrom(s => string.IsNullOrEmpty(s.ecer_PortalStage) ? "ContactInformation": s.ecer_PortalStage));
+    
 
     CreateMap<ecer_Application, IEnumerable<CertificationType>>()
         .ConstructUsing((s, _) =>

--- a/src/ECER.Resources.Documents/Certifications/CertificationRepository.cs
+++ b/src/ECER.Resources.Documents/Certifications/CertificationRepository.cs
@@ -49,7 +49,10 @@ internal class CertificationRepository : ICertificationRepository
       queryWithJoin = queryWithJoin.Where(r => r.cert.ecer_CertificateNumber.Equals(query.ByCertificateNumber));
 
     //Order by latest first (based on expiry date),
-    queryWithJoin = queryWithJoin.OrderByDescending(r => r.cert.ecer_ExpiryDate).ThenBy(r => r.cert.ecer_BaseCertificateTypeID);
+    queryWithJoin = queryWithJoin
+      .OrderBy(r => r.cert.StatusCode)
+      .ThenByDescending(r => r.cert.ecer_ExpiryDate)
+      .ThenBy(r => r.cert.ecer_BaseCertificateTypeID);
 
     //Apply Pagination
     if (query.PageSize > 0)

--- a/src/ECER.Tests/Integration/RegistryApi/CertificationTests.cs
+++ b/src/ECER.Tests/Integration/RegistryApi/CertificationTests.cs
@@ -32,7 +32,7 @@ public class CertificationsTests : RegistryPortalWebAppScenarioBase
     var faker = new Faker("en_CA");
     int lookUpPageSize = 20;
 
-    var CertificationId = this.Fixture.certificationOneId;
+    var CertificationId = this.Fixture.activeCertificationOneId;
 
     var CertificationsIdResponse = await Host.Scenario(_ =>
     {
@@ -84,7 +84,7 @@ public class CertificationsTests : RegistryPortalWebAppScenarioBase
   {
     var faker = new Faker("en_CA");
 
-    var CertificationId = this.Fixture.certificationTwoId;
+    var CertificationId = this.Fixture.activeCertificationTwoId;
 
     var CertificationsIdResponse = await Host.Scenario(_ =>
     {

--- a/src/ECER.Tests/Integration/RegistryPortalWebAppScenarioBase.cs
+++ b/src/ECER.Tests/Integration/RegistryPortalWebAppScenarioBase.cs
@@ -39,8 +39,9 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
   private ecer_Communication testCommunication3 = null!;
   private ecer_Communication testCommunication4 = null!;
 
-  private ecer_Certificate testCertification = null!;
-  private ecer_Certificate testCertification2 = null!;
+  private ecer_Certificate testActiveCertification = null!;
+  private ecer_Certificate testActiveCertification2 = null!;
+  private ecer_Certificate testInactiveCertification = null!;
 
   private ecer_PortalInvitation testPortalInvitationOne = null!;
   private ecer_PortalInvitation testPortalInvitationCharacterReferenceSubmit = null!;
@@ -63,8 +64,9 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
   public string inProgressApplicationId => inProgressTestApplication.Id.ToString();
   public string draftTestApplicationId => draftTestApplication.Id.ToString();
 
-  public string certificationOneId => testCertification.Id.ToString();
-  public string certificationTwoId => testCertification2.Id.ToString();
+  public string activeCertificationOneId => testActiveCertification.Id.ToString();
+  public string activeCertificationTwoId => testActiveCertification2.Id.ToString();
+  public string inactiveCertificationId => testInactiveCertification.Id.ToString(); 
 
   public Guid portalInvitationOneId => testPortalInvitationOne.ecer_PortalInvitationId ?? Guid.Empty;
   public Guid portalInvitationCharacterReferenceIdSubmit => testPortalInvitationCharacterReferenceSubmit.ecer_PortalInvitationId ?? Guid.Empty;
@@ -150,9 +152,11 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
     testCommunication2 = GetOrAddCommunication(context, inProgressTestApplication, "comm2", null);
     testCommunication3 = GetOrAddCommunication(context, inProgressTestApplication, "comm3", null);
     testCommunication4 = GetOrAddCommunication(context, inProgressTestApplication, "comm4", null);
-    testCertification = GetOrAddCertification(context, AuthenticatedBcscUser);
-    testCertification2 = GetOrAddCertification(context, AuthenticatedBcscUser);
+    testActiveCertification = GetOrAddCertification(context, AuthenticatedBcscUser);
+    testActiveCertification2 = GetOrAddCertification(context, AuthenticatedBcscUser);
+    testInactiveCertification = GetOrAddCertification(context, AuthenticatedBcscUser, statusCode: ecer_Certificate_StatusCode.Inactive, stateCode: ecer_certificate_statecode.Inactive, expiryDate: DateTime.MaxValue);
 
+    
     previousName = GetOrAddPreviousName(context, AuthenticatedBcscUser);
     testPortalInvitationOne = GetOrAddPortalInvitation_CharacterReference(context, AuthenticatedBcscUser, "name1");
     testPortalInvitationCharacterReferenceSubmit = GetOrAddPortalInvitation_CharacterReference(context, AuthenticatedBcscUser, "name2");
@@ -361,7 +365,7 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
     return communication;
   }
 
-  private ecer_Certificate GetOrAddCertification(EcerContext context, Contact registrant)
+  private ecer_Certificate GetOrAddCertification(EcerContext context, Contact registrant, ecer_Certificate_StatusCode statusCode = ecer_Certificate_StatusCode.Active, ecer_certificate_statecode stateCode = ecer_certificate_statecode.Active, DateTime? expiryDate = null)
   {
     var certification = context.ecer_CertificateSet.FirstOrDefault(c => c.ecer_CertificateNumber == TestRunId + "cert");
 
@@ -371,8 +375,10 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
       {
         Id = Guid.NewGuid(),
         ecer_CertificateNumber = TestRunId + "cert",
-        StatusCode = ecer_Certificate_StatusCode.Active,
-        ecer_GenerateCertificate = true
+        StatusCode = statusCode,
+        StateCode = stateCode,
+        ecer_ExpiryDate = expiryDate ?? DateTime.Today, // Default to today if expiryDate is null
+        ecer_GenerateCertificate = true,
       };
       context.AddObject(certification);
 

--- a/src/ECER.Tests/Integration/RegistryPortalWebAppScenarioBase.cs
+++ b/src/ECER.Tests/Integration/RegistryPortalWebAppScenarioBase.cs
@@ -154,7 +154,7 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
     testCommunication4 = GetOrAddCommunication(context, inProgressTestApplication, "comm4", null);
     testActiveCertification = GetOrAddCertification(context, AuthenticatedBcscUser);
     testActiveCertification2 = GetOrAddCertification(context, AuthenticatedBcscUser);
-    testInactiveCertification = GetOrAddCertification(context, AuthenticatedBcscUser);
+    testInactiveCertification = GetOrAddCertification(context, AuthenticatedBcscUser, expiryDate: DateTime.MaxValue);
 
     previousName = GetOrAddPreviousName(context, AuthenticatedBcscUser);
     testPortalInvitationOne = GetOrAddPortalInvitation_CharacterReference(context, AuthenticatedBcscUser, "name1");
@@ -377,14 +377,13 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
     context.UpdateObject(certificate);
   }
 
-  private ecer_Certificate GetOrAddCertification(EcerContext context, Contact registrant, ecer_Certificate_StatusCode statusCode = ecer_Certificate_StatusCode.Active, ecer_certificate_statecode stateCode = ecer_certificate_statecode.Active, DateTime? expiryDate = null)
+  private ecer_Certificate GetOrAddCertification(EcerContext context, Contact registrant, DateTime? expiryDate = null)
   {
     var certification = new ecer_Certificate
     {
       Id = Guid.NewGuid(),
       ecer_CertificateNumber = TestRunId + "cert",
-      StatusCode = statusCode,
-      StateCode = stateCode,
+      StatusCode = ecer_Certificate_StatusCode.Active,
       ecer_ExpiryDate = expiryDate ?? DateTime.Today, // Default to today if expiryDate is null
       ecer_GenerateCertificate = true,
     };

--- a/src/ECER.Tests/Integration/RegistryPortalWebAppScenarioBase.cs
+++ b/src/ECER.Tests/Integration/RegistryPortalWebAppScenarioBase.cs
@@ -366,12 +366,15 @@ public class RegistryPortalWebAppFixture : WebAppFixtureBase
 
   private void MarkCertificateAsInactive(EcerContext context, Guid certificateId)
   {
-    var certificate = context.ecer_CertificateSet.SingleOrDefault(c => c.ecer_CertificateId == certificateId);
+    var certificate = context.ecer_CertificateSet.FirstOrDefault(d => d.Id == certificateId); ;
+    context.Detach(certificate);
     if (certificate != null)
     {
       certificate.StatusCode = ecer_Certificate_StatusCode.Inactive;
       certificate.StateCode = ecer_certificate_statecode.Inactive;
     }
+    context.Attach(certificate);
+    context.UpdateObject(certificate);
   }
 
   private ecer_Certificate GetOrAddCertification(EcerContext context, Contact registrant, ecer_Certificate_StatusCode statusCode = ecer_Certificate_StatusCode.Active, ecer_certificate_statecode stateCode = ecer_certificate_statecode.Active, DateTime? expiryDate = null)

--- a/src/ECER.Tests/Integration/Resources/Certifications/CertificationsRepositoryTests.cs
+++ b/src/ECER.Tests/Integration/Resources/Certifications/CertificationsRepositoryTests.cs
@@ -21,12 +21,20 @@ public class CertificationsRepositoryTests : RegistryPortalWebAppScenarioBase
   public async Task QueryCertifications_ById_Found()
   {
     // Arrange
-    var CertificationId = Fixture.certificationOneId;
+    var CertificationId = Fixture.activeCertificationOneId;
 
     // Act
     var Certifications = await repository.Query(new UserCertificationQuery { ById = CertificationId });
 
     // Assert
+    Certifications.ShouldHaveSingleItem();
+  }
+
+  [Fact]
+  public async Task QueryCertifications_ByApplicantId_Found()
+  {
+    var Certifications = await repository.Query(new UserCertificationQuery { ByApplicantId = Fixture.AuthenticatedBcscUserId });
+
     Certifications.ShouldHaveSingleItem();
   }
 

--- a/src/ECER.Tests/Integration/Resources/Certifications/CertificationsRepositoryTests.cs
+++ b/src/ECER.Tests/Integration/Resources/Certifications/CertificationsRepositoryTests.cs
@@ -34,8 +34,8 @@ public class CertificationsRepositoryTests : RegistryPortalWebAppScenarioBase
   public async Task QueryCertifications_ByApplicantId_Found()
   {
     var Certifications = await repository.Query(new UserCertificationQuery { ByApplicantId = Fixture.AuthenticatedBcscUserId });
-
     Certifications.ShouldHaveSingleItem();
+    Certifications.First().StatusCode.ShouldBe(CertificateStatusCode.Active);
   }
 
   [Fact]


### PR DESCRIPTION
## Description

- Added test with inactive certification record
- Sort by StatusCode first (Active)
- Set default PortalStage if not present in dynamics for applications that start as application origin 'Manual' but transitioned to 'Portal'

## Related Jira Issue(s)

- [ECER-2702](https://eccbc.atlassian.net/browse/ECER-2702)
- [ECER-2616](https://eccbc.atlassian.net/browse/ECER-2616)

## Checklist
- [X] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.