### PR TITLE
fix back button missing on reference pages

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/Reference.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/Reference.vue
@@ -7,14 +7,15 @@
             <v-col>
               <h1>{{ inviteTypeTitle }}</h1>
               <div role="doc-subtitle">{{ `For applicant: ${wizardStore.wizardData.applicantFirstName} ${wizardStore.wizardData.applicantLastName}` }}</div>
-
-              <v-btn v-if="wizardStore.step !== 1" slim variant="text" rounded="lg" color="primary" @click="handleBack">
-                <v-icon size="x-large" icon="mdi-chevron-left" />
-                Back
-              </v-btn>
             </v-col>
           </v-row>
         </v-container>
+      </v-container>
+      <v-container>
+        <v-btn v-if="wizardStore.step !== 1" slim variant="text" rounded="lg" color="primary" @click="handleBack">
+          <v-icon size="x-large" icon="mdi-chevron-left" />
+          Back
+        </v-btn>
       </v-container>
     </template>
     <template #PrintPreview>


### PR DESCRIPTION
## Title
[ECER-3277](https://eccbc.atlassian.net/browse/ECER-3277)

## Description

- showing the back button on reference screens. 
- It was hidden behind the blue banner

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/93bc51ee-d307-4e0d-94fa-cdbd82a36300)


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.