### PR TITLE
bug fix for registration 5yr + SNE not showing the correct text

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/lookupCertification.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/lookupCertification.ts
@@ -42,7 +42,7 @@ export const useLookupCertificationStore = defineStore("lookupCertification", {
         return "ECE Five Year with Infant and Toddler Educator (ITE)";
       }
 
-      if (levels.some((level) => level.type === "ECE 5 YR") && levels.some((level) => level.type === "ITE")) {
+      if (levels.some((level) => level.type === "ECE 5 YR") && levels.some((level) => level.type === "SNE")) {
         return "ECE Five Year with Special Needs Educator (SNE)";
       }
 


### PR DESCRIPTION
## Title
ECER-3973: Bug fix incorrect status text for 5 yr cert + SNE

## Description

- name generation wasn't checking for ITE status. Small fix. 

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
*before*
![image](https://github.com/user-attachments/assets/560f0faf-0a59-4aae-bce0-850a42a23366)

![image](https://github.com/user-attachments/assets/17fd8eba-f011-40a8-8f7c-a7d511cee873)

*after fix*
![image](https://github.com/user-attachments/assets/d54f5d5c-4321-491e-b9ac-e76d50497f6f)

![image](https://github.com/user-attachments/assets/7f14df9f-59fb-4be4-8bc8-ee215bb22518)


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.