### PR TITLE
ECER-3952: inactive certification conditions filtered out in public lookup

### DIFF
--- a/src/ECER.Resources.Documents/Certifications/CertificationRepositoryMapper.cs
+++ b/src/ECER.Resources.Documents/Certifications/CertificationRepositoryMapper.cs
@@ -22,7 +22,7 @@ internal class CertificationRepositoryMapper : Profile
      .ForMember(d => d.IneligibleReference, opts => opts.MapFrom(s => s.ecer_IneligibleReference))
      .ForMember(d => d.Levels, opts => opts.MapFrom(s => s.ecer_certifiedlevel_CertificateId))
      .ForMember(d => d.Files, opts => opts.MapFrom(s => s.ecer_documenturl_CertificateId))
-     .ForMember(d => d.CertificateConditions, opts => opts.MapFrom(s => s.ecer_certificate_Registrantid.ecer_certificateconditions_Registrantid));
+     .ForMember(d => d.CertificateConditions, opts => opts.MapFrom(s => s.ecer_certificate_Registrantid.ecer_certificateconditions_Registrantid.Where(cc => cc.StatusCode == ecer_CertificateConditions_StatusCode.Active)));
 
     CreateMap<ecer_CertificateConditions, CertificateCondition>(MemberList.Destination)
     .ForMember(d => d.Id, opts => opts.MapFrom(s => s.Id))


### PR DESCRIPTION
ECER-3952: inactive certification conditions filtered out in public lookup

## Checklist
- [ ] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.