### PR TITLE
fix for issue if country code doesn't exist in our database

### DIFF
--- a/src/ECER.Managers.Registry/ECER.Managers.Registry.csproj
+++ b/src/ECER.Managers.Registry/ECER.Managers.Registry.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\ECER.Managers.Registry.Contract\ECER.Managers.Registry.Contract.csproj" />
     <ProjectReference Include="..\ECER.Resources.Accounts\ECER.Resources.Accounts.csproj" />
     <ProjectReference Include="..\ECER.Resources.Documents\ECER.Resources.Documents.csproj" />
+    <ProjectReference Include="..\ECER.Utilities.Hosting\ECER.Utilities.Hosting.csproj" />
     <ProjectReference Include="..\ECER.Utilities.ObjectStorage\ECER.Utilities.ObjectStorage.csproj" />
     <ProjectReference Include="..\ECER.Utilities.Security\ECER.Utilities.Security.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Title

https://eccbc.atlassian.net/browse/ECER-3933 

## Description

- Issue with Bceid users registering with an invalid country code. 
- Fix was to just save countryName as empty so the user can update it the next time they edit their profile or start a new application. 
- May be difficult to test because our test bceid users have a valid country code. 

## Related Jira Issue(s)

## Checklist
- [x] I have tested these changes locally.
- [x] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.