### PR TITLE
ECER-4076 adding in github actions to promote images through the environments

### DIFF
--- a/.github/workflows/deploy-to-efxdev.yaml
+++ b/.github/workflows/deploy-to-efxdev.yaml
@@ -1,0 +1,61 @@
+name: Promote to EFXDev
+
+env:
+  # 🖊️ EDIT your repository secrets to log into your OpenShift cluster and set up the context.
+  # See https://github.com/redhat-actions/oc-login#readme for how to retrieve these values.
+  # To get a permanent token, refer to https://github.com/redhat-actions/oc-login/wiki/Using-a-Service-Account-for-GitHub-Actions
+  OPENSHIFT_SERVER: ${{ vars.OPENSHIFT_SERVER }}
+  OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
+  OPENSHIFT_NAMESPACE: ${{ secrets.ECER_NAMESPACE_NO_ENV }}-tools
+  APP_ENVIRONMENT_DESTINATION: "efxdev"
+
+on:
+  # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version ex. master, release-1.0.0 or release-1.0.1 .etc"
+        default: "master"
+        required: true
+
+jobs:
+  openshift-cd:
+    name: Promote Image
+    runs-on: ubuntu-22.04
+    environment: efxdev
+
+    outputs:
+      ROUTE: ${{ steps.deploy-and-expose.outputs.route }}
+      SELECTOR: ${{ steps.deploy-and-expose.outputs.selector }}
+
+    steps:
+      - name: Check User Input
+        run: |
+          echo SOURCE ${{github.event.inputs.version}}
+          if [[ "${{github.event.inputs.version}}" == "master" ]] || [[ "${{github.event.inputs.version}}" == "release-"* ]]; then
+            echo user input validated ${{github.event.inputs.version}}
+          else
+            echo ::error::input must be 'master' or 'release-*' your input was ${{github.event.inputs.version}}
+            exit 1
+          fi
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Install oc
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: 4
+
+        # https://github.com/redhat-actions/oc-login#readme
+      - uses: actions/checkout@v3
+      - name: Tag in OpenShift
+        run: |
+          set -eux
+          echo VERSION: ${{github.event.inputs.version}}
+          # Login to OpenShift and select project
+          oc login --token=${{ env.OPENSHIFT_TOKEN }} --server=${{ env.OPENSHIFT_SERVER }}
+          oc project ${{ env.OPENSHIFT_NAMESPACE }}
+
+          echo promoting ${{github.event.inputs.version}} imagestream to ${{env.APP_ENVIRONMENT_DESTINATION}}
+
+          oc tag -n ${{env.OPENSHIFT_NAMESPACE}} --alias=true registry-portal:${{github.event.inputs.version}} registry-portal:${{env.APP_ENVIRONMENT_DESTINATION}}
+          oc tag -n ${{env.OPENSHIFT_NAMESPACE}} --alias=true api:${{github.event.inputs.version}} api:${{env.APP_ENVIRONMENT_DESTINATION}}

--- a/.github/workflows/deploy-to-efxtest.yaml
+++ b/.github/workflows/deploy-to-efxtest.yaml
@@ -1,0 +1,47 @@
+name: Promote to EFXTest
+
+env:
+  # 🖊️ EDIT your repository secrets to log into your OpenShift cluster and set up the context.
+  # See https://github.com/redhat-actions/oc-login#readme for how to retrieve these values.
+  # To get a permanent token, refer to https://github.com/redhat-actions/oc-login/wiki/Using-a-Service-Account-for-GitHub-Actions
+  OPENSHIFT_SERVER: ${{ vars.OPENSHIFT_SERVER }}
+  OPENSHIFT_TOKEN: ${{ secrets.OPENSHIFT_TOKEN }}
+  OPENSHIFT_NAMESPACE: ${{ secrets.ECER_NAMESPACE_NO_ENV }}-tools
+  APP_ENVIRONMENT_SOURCE: "efxdev"
+  APP_ENVIRONMENT_DESTINATION: "efxtest"
+
+on:
+  # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+  workflow_dispatch:
+
+jobs:
+  openshift-cd:
+    name: Promote Image
+    runs-on: ubuntu-22.04
+    environment: efxtest
+
+    outputs:
+      ROUTE: ${{ steps.deploy-and-expose.outputs.route }}
+      SELECTOR: ${{ steps.deploy-and-expose.outputs.selector }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Install oc
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: 4
+
+        # https://github.com/redhat-actions/oc-login#readme
+      - uses: actions/checkout@v3
+      - name: Tag in OpenShift
+        run: |
+          set -eux
+          # Login to OpenShift and select project
+          oc login --token=${{ env.OPENSHIFT_TOKEN }} --server=${{ env.OPENSHIFT_SERVER }}
+          oc project ${{ env.OPENSHIFT_NAMESPACE }}
+
+          echo promoting ${{env.APP_ENVIRONMENT_SOURCE}} imagestream to ${{env.APP_ENVIRONMENT_DESTINATION}}
+
+          oc tag -n ${{env.OPENSHIFT_NAMESPACE}} registry-portal:${{env.APP_ENVIRONMENT_SOURCE}} registry-portal:${{env.APP_ENVIRONMENT_DESTINATION}}
+          oc tag -n ${{env.OPENSHIFT_NAMESPACE}} api:${{env.APP_ENVIRONMENT_SOURCE}} api:${{env.APP_ENVIRONMENT_DESTINATION}}


### PR DESCRIPTION
---
name: Pull Request Template
about: Template for creating pull requests
---

## Title
https://eccbc.atlassian.net/browse/ECER-4076 

## Description

- setting up our infrastructure to promote images through openshift using github actions. WIP alternative to pipelines. 
- Clicking deploy to EFXDev lets you input master or release-*
- If you choose another option it will not run ex. meow
- If you choose master, it will tag the portal + api imagestream from master -> efxdev

- likewise with deploy to EFXTest we will just take efxdev imagestream -> efxtest

- WIP when we get to production, we need to be able to choose between UAT or efxtest

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.