### PR TITLE
ECER-1746: (Enhancement) Accept international phone numbers

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/AddProfessionalDevelopment.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/AddProfessionalDevelopment.vue
@@ -191,10 +191,8 @@
               label="Phone number"
               :rules="[
                 Rules.required('Enter the phone number for your course or workshop contact'),
-                Rules.phoneNumber('Enter your reference\'s 10-digit phone number'),
+                Rules.phoneNumber('Enter your reference\'s valid phone number'),
               ]"
-              maxlength="10"
-              @keypress="isNumber($event)"
             ></EceTextField>
           </v-col>
         </v-row>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Profile.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Profile.vue
@@ -141,7 +141,7 @@
           <div class="d-flex flex-column ga-3">
             <p class="font-weight-bold mb-3">Primary phone number</p>
             <p>
-              {{ userStore.userProfile?.phone ? formatPhoneNumber(userStore.userProfile?.phone ?? "") : "—" }}
+              {{ userStore.userProfile?.phone || "—" }}
             </p>
           </div>
         </v-col>
@@ -149,7 +149,7 @@
           <div class="d-flex flex-column ga-3">
             <p class="font-weight-bold mb-3">Alternate phone number</p>
             <p>
-              {{ userStore.userProfile?.alternateContactPhone ? formatPhoneNumber(userStore.userProfile?.alternateContactPhone ?? "") : "—" }}
+              {{ userStore.userProfile?.alternateContactPhone || "—" }}
             </p>
           </div>
         </v-col>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Profile.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Profile.vue
@@ -167,7 +167,6 @@ import PageContainer from "@/components/PageContainer.vue";
 import { useUserStore } from "@/store/user";
 import type { Components } from "@/types/openapi";
 import { formatDate } from "@/utils/format";
-import { formatPhoneNumber } from "@/utils/format";
 import { areObjectsEqual } from "@/utils/functions";
 import { useLoadingStore } from "@/store/loading";
 import Loading from "@/components/Loading.vue";
@@ -202,7 +201,6 @@ export default defineComponent({
   }),
   methods: {
     formatDate,
-    formatPhoneNumber,
     areObjectsEqual,
     fullName(name: Components.Schemas.PreviousName) {
       return `${name.firstName ?? ""} ${name.middleName ?? ""} ${name.lastName}`.trim();

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ViewCharacterReference.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ViewCharacterReference.vue
@@ -33,7 +33,6 @@ import ResendEmail from "@/components/ResendEmail.vue";
 import { useAlertStore } from "@/store/alert";
 import { useApplicationStore } from "@/store/application";
 import type { Components } from "@/types/openapi";
-import { formatPhoneNumber } from "@/utils/format";
 
 export default defineComponent({
   name: "ViewCharacterReference",
@@ -85,7 +84,6 @@ export default defineComponent({
   },
 
   methods: {
-    formatPhoneNumber,
     async handleResendReference() {
       const { error } = await resendCharacterReference({
         applicationId: this.applicationId,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ViewCharacterReference.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ViewCharacterReference.vue
@@ -8,7 +8,7 @@
     <p class="mt-8"><b>Name</b></p>
     <p>{{ reference?.firstName }} {{ reference?.lastName }}</p>
     <p class="mt-6"><b>Phone number</b></p>
-    <p>{{ formatPhoneNumber(reference?.phoneNumber || "") }}</p>
+    <p>{{ reference?.phoneNumber }}</p>
     <p class="mt-6"><b>Email</b></p>
     <p class="mb-10">{{ reference?.emailAddress }}</p>
     <ECEHeader title="Options" />

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ViewWorkExperienceReference.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ViewWorkExperienceReference.vue
@@ -35,7 +35,6 @@ import ResendEmail from "@/components/ResendEmail.vue";
 import { useAlertStore } from "@/store/alert";
 import { useApplicationStore } from "@/store/application";
 import type { Components } from "@/types/openapi";
-import { formatPhoneNumber } from "@/utils/format";
 
 export default defineComponent({
   name: "ViewWorkExperienceReference",
@@ -93,7 +92,6 @@ export default defineComponent({
   },
 
   methods: {
-    formatPhoneNumber,
     async handleResendReference() {
       const { error } = await resendWorkExperienceReference({
         applicationId: this.applicationId,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ViewWorkExperienceReference.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ViewWorkExperienceReference.vue
@@ -8,7 +8,7 @@
     <p class="mt-8"><b>Name</b></p>
     <p>{{ reference?.firstName }} {{ reference?.lastName }}</p>
     <p class="mt-6"><b>Phone number</b></p>
-    <p>{{ formatPhoneNumber(reference?.phoneNumber || "") }}</p>
+    <p>{{ reference?.phoneNumber }}</p>
     <p class="mt-6"><b>Email</b></p>
     <p>{{ reference?.emailAddress }}</p>
     <p class="mt-6"><b>Work Experience Hours</b></p>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReference.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReference.vue
@@ -68,12 +68,9 @@
     <v-col cols="12" md="8" lg="6" xl="4">
       <EceTextField
         v-model="phoneNumber"
-        :rules="[Rules.phoneNumber('Enter your reference\'s 10-digit phone number')]"
+        :rules="[Rules.phoneNumber('Enter your reference\'s valid phone number')]"
         label="Phone number (optional)"
-        length="10"
-        maxlength="10"
         @update:model-value="updateCharacterReference()"
-        @keypress="isNumber($event)"
       ></EceTextField>
     </v-col>
   </v-row>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceProfessionalDevelopment.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceProfessionalDevelopment.vue
@@ -186,11 +186,9 @@
             label="Phone number"
             :rules="[
               Rules.required('Enter the phone number for your course or workshop contact'),
-              Rules.phoneNumber('Enter your reference\'s 10-digit phone number'),
+              Rules.phoneNumber('Enter your reference\'s valid phone number'),
             ]"
             color="primary"
-            maxlength="10"
-            @keypress="isNumber($event)"
           ></EceTextField>
         </v-col>
       </v-row>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceWorkExperienceReferences.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceWorkExperienceReferences.vue
@@ -32,10 +32,8 @@
           <v-col cols="12">
             <EceTextField
               v-model="phoneNumber"
-              :rules="[Rules.phoneNumber('Enter your reference\'s 10-digit phone number')]"
+              :rules="[Rules.phoneNumber('Enter your reference\'s valid phone number')]"
               label="Reference phone number (Optional)"
-              maxlength="20"
-              @keypress="isNumber($event)"
             ></EceTextField>
           </v-col>
         </v-row>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Dashboard.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Dashboard.vue
@@ -176,7 +176,6 @@ import { useCertificationStore } from "@/store/certification";
 import { useMessageStore } from "@/store/message";
 import { useUserStore } from "@/store/user";
 import { useLoadingStore } from "@/store/loading";
-import { formatPhoneNumber } from "@/utils/format";
 import { useOidcStore } from "@/store/oidc";
 import type { Application, Certification, UserInfo, UserProfile } from "@/types/openapi";
 
@@ -290,7 +289,6 @@ export default defineComponent({
   },
 
   methods: {
-    formatPhoneNumber,
     async cancelApplication() {
       this.showCancelDialog = false;
       const { data: cancelledApplicationId } = await cancelDraftApplication(this.applicationStore.draftApplication.id!);

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/NewUser.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/NewUser.vue
@@ -96,12 +96,7 @@
               <v-row>
                 <!-- Phone Field -->
                 <v-col cols="12" sm="6">
-                  <EceTextField
-                    v-model="phoneNumber"
-                    label="Phone number"
-                    :rules="[Rules.required(), Rules.phoneNumber()]"
-                    @keypress="isNumber($event)"
-                  ></EceTextField>
+                  <EceTextField v-model="phoneNumber" label="Phone number" :rules="[Rules.required(), Rules.phoneNumber()]"></EceTextField>
                 </v-col>
               </v-row>
             </v-col>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceReferenceContact.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceReferenceContact.vue
@@ -42,12 +42,10 @@
         <v-col cols="12" md="8" lg="6" xl="4">
           <EceTextField
             :model-value="modelValue.phoneNumber"
-            :rules="[Rules.required(), Rules.phoneNumber('Enter your 10-digit phone number')]"
+            :rules="[Rules.required('Enter a phone number'), Rules.phoneNumber('Enter your valid phone number')]"
             label="Phone Number"
             autocomplete="tel"
-            maxlength="10"
             @input="updateField('phoneNumber', $event)"
-            @keypress="isNumber($event)"
           ></EceTextField>
         </v-col>
       </v-row>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/character-references-upsert-form.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/character-references-upsert-form.ts
@@ -56,8 +56,7 @@ const characterReferencesUpsertForm: Form = {
       component: EceTextField,
       props: {
         label: "Phone Number (optional)",
-        rules: [Rules.phoneNumber("Enter your reference's 10-digit phone number")],
-        maxLength: 10,
+        rules: [Rules.phoneNumber("Enter your reference's valid phone number")],
       },
       cols: {
         md: 4,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/profile-information-form.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/profile-information-form.ts
@@ -95,8 +95,7 @@ const profileInformationForm: Form = {
       component: EceTextField,
       props: {
         label: "Primary contact number",
-        isNumeric: true,
-        rules: [Rules.phoneNumber("Enter your primary 10-digit phone number"), Rules.required()],
+        rules: [Rules.phoneNumber("Enter a valid phone number"), Rules.required("Enter a phone number")],
       },
       cols: {
         md: 8,
@@ -109,8 +108,7 @@ const profileInformationForm: Form = {
       component: EceTextField,
       props: {
         label: "Alternate phone (optional)",
-        isNumeric: true,
-        rules: [Rules.phoneNumber("Enter your alternate 10-digit phone number")],
+        rules: [Rules.phoneNumber("Enter a valid alternate phone number")],
       },
       cols: {
         md: 8,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/work-experience-reference-upsert-form.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/config/work-experience-reference-upsert-form.ts
@@ -52,8 +52,7 @@ const workExperienceReferencesUpsertForm: Form = {
       component: EceTextField,
       props: {
         label: "Phone number (optional)",
-        rules: [Rules.phoneNumber("Enter your reference's 10-digit phone number")],
-        maxLength: 10,
+        rules: [Rules.phoneNumber("Enter your reference's valid phone number")],
       },
       cols: {
         md: 4,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formRules.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formRules.ts
@@ -38,12 +38,19 @@ const validContactName =
     !v || !/[^a-zA-Z\u00C0-\u017F\s'-]/.test(v) || message;
 
 /**
- * Rule for phone numbers also works for fax numbers too
- * @param {String} message
+ * Rule for phone numbers
+ *
+ * The validator checks that the input is empty or:
+ * - 7 to 20 characters long,
+ * - Optionally starts with a '+',
+ * - Contains only digits, spaces, and dashes.
+ *
+ * @param {string} message
  * @returns Function
  */
-const phoneNumber = (message = "Enter a valid, 10-digit phone number") => {
-  return (v: string) => !v || /^(\+\d{1,2}\s)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/.test(v) || message;
+
+const phoneNumber = (message = "Enter a valid phone number") => {
+  return (v: string) => !v || /^(?=.{7,20}$)(?:\+)?[\d\s\-]+$/.test(v) || message;
 };
 
 /**

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formRules.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formRules.ts
@@ -50,7 +50,7 @@ const validContactName =
  */
 
 const phoneNumber = (message = "Enter a valid phone number") => {
-  return (v: string) => !v || /^(?=.{7,20}$)(?:\+)?[\d\s\-]+$/.test(v) || message;
+  return (v: string) => !v || /^(?=.{7,20}$)(?:\+)?[\d\s-]+$/.test(v) || message;
 };
 
 /**

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/format.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/format.ts
@@ -1,26 +1,5 @@
 import { DateTime } from "luxon";
 
-export function formatPhoneNumber(input: string): string {
-  // Strip all characters from the input except digits
-  input = input.replace(/\D/g, "");
-
-  // Trim the remaining input to ten characters, to preserve phone number format
-  input = input.substring(0, 10);
-
-  // Based upon the length of the string, we add formatting as necessary
-  const size = input.length;
-  if (size === 0) {
-    input = "";
-  } else if (size < 4) {
-    input = "(" + input;
-  } else if (size < 7) {
-    input = "(" + input.substring(0, 3) + ") " + input.substring(3, 6);
-  } else {
-    input = "(" + input.substring(0, 3) + ") " + input.substring(3, 6) + "-" + input.substring(6, 10);
-  }
-  return input;
-}
-
 export function formatDate(inputDate: string, toFormat: DateFormat = "yyyy-MM-dd") {
   if (inputDate) {
     const formattedDate = DateTime.fromISO(inputDate).toFormat(toFormat);


### PR DESCRIPTION
## Title
ECER-1746: (Enhancement) Accept international phone numbers

## Description

Update validation to all phone number fields to accept 7 to 20 digits or spaces, dashes or plus symbol.

-Update error message from:
 Enter a 10-digit phone number

-When required, and field is empty, on submit show:
 Enter a phone number

-When a value is entered in the field, and it's less than 7 or more than 20, on submit show:
 Enter a valid phone number

This update is applied in:

- In creating an account (BCSC and BCeID)
- In contact form
- In edit profile
- In reference collection in application
- In reference forms

## Related Jira Issue(s)

- ECER-1746

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)

On "Edit Profile" page:

Errors out on entering more than 20 characters. Accepts spaces, dashes or plus symbol (in the beginning)
![image](https://github.com/user-attachments/assets/ec323bed-b71e-4132-afe5-b27f06a06b9f)

Errors out on entering less than 7 characters. Accepts spaces, dashes or plus symbol (in the beginning)
![image](https://github.com/user-attachments/assets/a594ea38-a4a2-46b4-bcad-42da37f0639d)


