### PR TITLE
ECER-3095: Accept international addresses and save province name from standard list

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/ConfigurationEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/ConfigurationEndpoints.cs
@@ -28,6 +28,14 @@ public class ConfigurationEndpoints : IRegisterEndpoints
       .WithOpenApi("Handles province queries", string.Empty, "province_get")
       .CacheOutput(p => p.Expire(TimeSpan.FromMinutes(5)));
 
+    endpointRouteBuilder.MapGet("/api/countrylist", async (HttpContext ctx, IMediator messageBus, IMapper mapper, CancellationToken ct) =>
+    {
+      var results = await messageBus.Send(new CountriesQuery(), ct);
+      return TypedResults.Ok(mapper.Map<IEnumerable<Country>>(results.Items));
+    })
+  .WithOpenApi("Handles country queries", string.Empty, "country_get")
+  .CacheOutput(p => p.Expire(TimeSpan.FromMinutes(5)));
+
     endpointRouteBuilder.MapGet("/api/systemMessages", async (HttpContext ctx, IMediator messageBus, IMapper mapper, CancellationToken ct) =>
     {
       var results = await messageBus.Send(new SystemMessagesQuery(), ct);
@@ -73,7 +81,9 @@ public record OidcAuthenticationSettings
 }
 public record IdentificationType(string Id, string Name, bool ForPrimary, bool ForSecondary);
 
-public record Province(string ProvinceId, string ProvinceName);
+public record Province(string ProvinceId, string ProvinceName, string ProvinceCode);
+
+public record Country(string CountryId, string CountryName, string CountryCode);
 public record SystemMessage(string Name, string Subject, string Message)
 {
   public DateTime StartDate { get; set; }

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/ConfigurationMapper.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/ConfigurationMapper.cs
@@ -7,6 +7,7 @@ public class ConfigurationMapper : Profile
   public ConfigurationMapper()
   {
     CreateMap<Managers.Admin.Contract.Metadatas.Province, Province>();
+    CreateMap<Managers.Admin.Contract.Metadatas.Country, Country>();
     CreateMap<Managers.Admin.Contract.Metadatas.SystemMessage, SystemMessage>();
     CreateMap<Managers.Admin.Contract.Metadatas.IdentificationType, IdentificationType>();
   }

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/api/configuration.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/api/configuration.ts
@@ -11,6 +11,11 @@ const getProvinceList = async (): Promise<Components.Schemas.Province[] | null |
   return (await client.province_get()).data;
 };
 
+const getCountryList = async (): Promise<Components.Schemas.Country[] | null | undefined> => {
+  const client = await getClient(false);
+  return (await client.country_get()).data;
+};
+
 const getSystemMessages = async (): Promise<Components.Schemas.SystemMessage[] | null | undefined> => {
   const client = await getClient(false);
   return (await client.systemMessage_get()).data;
@@ -26,4 +31,4 @@ const getIdentificationTypes = async (): Promise<Components.Schemas.Identificati
   return (await client.identificationTypes_get()).data;
 };
 
-export { getConfiguration, getProvinceList, getRecaptchaSiteKey, getSystemMessages, getIdentificationTypes };
+export { getConfiguration, getProvinceList, getCountryList, getRecaptchaSiteKey, getSystemMessages, getIdentificationTypes };

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceAddress.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceAddress.vue
@@ -49,7 +49,7 @@
         :rules="[Rules.required('Select your city/town')]"
         variant="outlined"
         color="primary"
-        maxlength="50"
+        maxlength="100"
         @update:model-value="(value: string) => updateField('city', value)"
       ></EceTextField>
     </v-col>
@@ -86,7 +86,7 @@
         label="Province or State"
         variant="outlined"
         color="primary"
-        maxlength="50"
+        maxlength="100"
         @update:model-value="(value: string) => updateField('province', value)"
       ></EceTextField>
     </v-col>
@@ -101,7 +101,7 @@
         :rules="[Rules.conditionalWrapper(isCanada, Rules.required('Postal code required')), Rules.conditionalWrapper(isCanada, Rules.postalCode())]"
         variant="outlined"
         color="primary"
-        maxlength="7"
+        maxlength="20"
         @update:model-value="(value: string) => updateField('postalCode', value)"
       ></EceTextField>
     </v-col>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceAddress.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceAddress.vue
@@ -8,8 +8,9 @@
   <!-- Country selection -->
   <v-row>
     <v-col cols="12">
-      <label>Country</label>
+      <label for="country-autocomplete">Country</label>
       <v-autocomplete
+        id="country-autocomplete"
         :model-value="modelValue.country"
         variant="outlined"
         color="primary"
@@ -58,8 +59,9 @@
   <!-- For Canada: Show Province/Territory list -->
   <v-row v-if="isCanada">
     <v-col cols="12">
-      <label>Province / Territory</label>
+      <label for="province-autocomplete">Province / Territory</label>
       <v-autocomplete
+        id="province-autocomplete"
         :model-value="modelValue.province"
         variant="outlined"
         color="primary"

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceAddress.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceAddress.vue
@@ -1,10 +1,31 @@
-addressLabel
 <template>
   <v-row>
     <v-col cols="12">
       <h2>{{ `${addressLabel} address` }}</h2>
     </v-col>
   </v-row>
+
+  <!-- Country selection -->
+  <v-row>
+    <v-col cols="12">
+      <label>
+        Country
+        <v-autocomplete
+          :model-value="modelValue.country"
+          variant="outlined"
+          color="primary"
+          class="pt-2"
+          :rules="[Rules.required('Select your country')]"
+          :items="configStore?.countryList"
+          clearable
+          hide-details="auto"
+          @update:model-value="(value: string) => updateField('country', value)"
+        ></v-autocomplete>
+      </label>
+    </v-col>
+  </v-row>
+
+  <!-- Street Address (always required) -->
   <v-row>
     <v-col cols="12">
       <EceTextField
@@ -19,11 +40,13 @@ addressLabel
       ></EceTextField>
     </v-col>
   </v-row>
+
+  <!-- City/Town (always required) -->
   <v-row>
     <v-col cols="12">
       <EceTextField
         :model-value="modelValue.city"
-        label="City/Town"
+        label="City or town"
         :rules="[Rules.required('Select your city/town')]"
         variant="outlined"
         color="primary"
@@ -32,12 +55,37 @@ addressLabel
       ></EceTextField>
     </v-col>
   </v-row>
-  <v-row>
+
+  <!-- Province Input: Render based on Country -->
+  <!-- For Canada: Show Province/Territory list -->
+  <v-row v-if="isCanada">
+    <v-col cols="12">
+      <label>
+        Province / Territory
+        <v-autocomplete
+          :model-value="modelValue.province"
+          variant="outlined"
+          color="primary"
+          class="pt-2"
+          :rules="[Rules.required('Select your province/territory')]"
+          :items="filteredProvinceList"
+          item-title="title"
+          item-value="code"
+          clearable
+          hide-details="auto"
+          @update:model-value="(value: string) => updateField('province', value)"
+        ></v-autocomplete>
+      </label>
+    </v-col>
+  </v-row>
+
+  <!-- For non-Canada: Show Province/State text field -->
+
+  <v-row v-else>
     <v-col cols="12">
       <EceTextField
         :model-value="modelValue.province"
-        label="Province"
-        :rules="[Rules.required('Select your province')]"
+        label="Province or State"
         variant="outlined"
         color="primary"
         maxlength="50"
@@ -45,12 +93,14 @@ addressLabel
       ></EceTextField>
     </v-col>
   </v-row>
+
+  <!-- Postal Code Input -->
   <v-row>
     <v-col cols="12">
       <EceTextField
         :model-value="modelValue.postalCode"
-        label="Postal code"
-        :rules="[Rules.required('Postal code required'), Rules.postalCode()]"
+        :label="isCanada ? 'Postal code' : 'Postal / Zip code'"
+        :rules="postalRules"
         variant="outlined"
         color="primary"
         maxlength="7"
@@ -58,27 +108,15 @@ addressLabel
       ></EceTextField>
     </v-col>
   </v-row>
-  <v-row>
-    <v-col cols="12">
-      <EceTextField
-        :model-value="modelValue.country"
-        label="Country"
-        :rules="[Rules.required('Select your country')]"
-        variant="outlined"
-        color="primary"
-        maxlength="50"
-        @update:model-value="(value: string) => updateField('country', value)"
-      ></EceTextField>
-    </v-col>
-  </v-row>
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
-
+import { defineComponent, computed } from "vue";
 import type { Components } from "@/types/openapi";
 import * as Rules from "@/utils/formRules";
 import EceTextField from "@/components/inputs/EceTextField.vue";
+import { useConfigStore } from "@/store/config";
+import { ProvinceTerritoryType } from "@/utils/constant";
 
 export default defineComponent({
   name: "EceAddress",
@@ -96,11 +134,46 @@ export default defineComponent({
   emits: {
     "update:model-value": (_addressData: Components.Schemas.Address) => true,
   },
-  data: function () {
+  setup() {
+    const configStore = useConfigStore();
+    return { configStore };
+  },
+
+  computed: {
+    // Check if the selected country is Canada.
+    isCanada(): boolean {
+      return this.modelValue.country === "Canada";
+    },
+    // Set postal code validation rules based on the country.
+    postalRules(): any[] {
+      return this.isCanada ? [Rules.required("Postal code required"), Rules.postalCode()] : [];
+    },
+    filteredProvinceList() {
+      return (this.configStore?.provinceList || []).filter((province) => province.title !== ProvinceTerritoryType.OTHER);
+    },
+  },
+  data() {
     return {
-      checked: true,
       Rules,
     };
+  },
+  mounted() {
+    // On mount, default the country to Canada if not set.
+    if (!this.modelValue.country) {
+      this.updateField("country", "Canada");
+    }
+    // If country is Canada and province is not set, default it to British Columbia.
+    if (this.modelValue.country === "Canada" && !this.modelValue.province) {
+      this.updateField("province", "BC");
+    }
+  },
+  watch: {
+    // When switching back to Canada, if no province is set, reset it to British Columbia.
+    "modelValue.country"(newVal: string) {
+      if (newVal === "Canada" && !this.modelValue.province) {
+        this.updateField("province", "BC");
+      }
+    },
   },
   methods: {
     updateField(fieldName: keyof Components.Schemas.Address, value: string) {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceAddress.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceAddress.vue
@@ -8,9 +8,9 @@
   <!-- Country selection -->
   <v-row>
     <v-col cols="12">
-      <label for="country-autocomplete">Country</label>
+      <label :for="`${addressLabel}-country-autocomplete`">Country</label>
       <v-autocomplete
-        id="country-autocomplete"
+        :id="`${addressLabel}-country-autocomplete`"
         :model-value="modelValue.country"
         variant="outlined"
         color="primary"
@@ -59,14 +59,14 @@
   <!-- For Canada: Show Province/Territory list -->
   <v-row v-if="isCanada">
     <v-col cols="12">
-      <label for="province-autocomplete">Province / Territory</label>
+      <label :for="`${addressLabel}-province-autocomplete`">Province / Territory</label>
       <v-autocomplete
-        id="province-autocomplete"
+        :id="`${addressLabel}-province-autocomplete`"
         :model-value="modelValue.province"
         variant="outlined"
         color="primary"
         class="pt-2"
-        :rules="[Rules.required('Select your province/territory')]"
+        :rules="[Rules.required('Select your province/territory'), Rules.mustExistInDropdown(filteredProvinceList, 'code')]"
         :items="filteredProvinceList"
         item-title="title"
         item-value="code"
@@ -98,7 +98,7 @@
       <EceTextField
         :model-value="modelValue.postalCode"
         :label="isCanada ? 'Postal code' : 'Postal / Zip code'"
-        :rules="postalRules"
+        :rules="[Rules.conditionalWrapper(isCanada, Rules.required('Postal code required')), Rules.conditionalWrapper(isCanada, Rules.postalCode())]"
         variant="outlined"
         color="primary"
         maxlength="7"
@@ -141,10 +141,6 @@ export default defineComponent({
     // Check if the selected country is Canada.
     isCanada(): boolean {
       return this.modelValue.country === "Canada";
-    },
-    // Set postal code validation rules based on the country.
-    postalRules(): any[] {
-      return this.isCanada ? [Rules.required("Postal code required"), Rules.postalCode()] : [];
     },
     filteredProvinceList() {
       return (this.configStore?.provinceList || []).filter((province) => province.title !== ProvinceTerritoryType.OTHER);

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceAddress.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceAddress.vue
@@ -8,20 +8,18 @@
   <!-- Country selection -->
   <v-row>
     <v-col cols="12">
-      <label>
-        Country
-        <v-autocomplete
-          :model-value="modelValue.country"
-          variant="outlined"
-          color="primary"
-          class="pt-2"
-          :rules="[Rules.required('Select your country')]"
-          :items="configStore?.countryList"
-          clearable
-          hide-details="auto"
-          @update:model-value="(value: string) => updateField('country', value)"
-        ></v-autocomplete>
-      </label>
+      <label>Country</label>
+      <v-autocomplete
+        :model-value="modelValue.country"
+        variant="outlined"
+        color="primary"
+        class="pt-2"
+        :rules="[Rules.required('Select your country')]"
+        :items="configStore?.countryList"
+        clearable
+        hide-details="auto"
+        @update:model-value="(value: string) => updateField('country', value)"
+      ></v-autocomplete>
     </v-col>
   </v-row>
 
@@ -60,22 +58,20 @@
   <!-- For Canada: Show Province/Territory list -->
   <v-row v-if="isCanada">
     <v-col cols="12">
-      <label>
-        Province / Territory
-        <v-autocomplete
-          :model-value="modelValue.province"
-          variant="outlined"
-          color="primary"
-          class="pt-2"
-          :rules="[Rules.required('Select your province/territory')]"
-          :items="filteredProvinceList"
-          item-title="title"
-          item-value="code"
-          clearable
-          hide-details="auto"
-          @update:model-value="(value: string) => updateField('province', value)"
-        ></v-autocomplete>
-      </label>
+      <label>Province / Territory</label>
+      <v-autocomplete
+        :model-value="modelValue.province"
+        variant="outlined"
+        color="primary"
+        class="pt-2"
+        :rules="[Rules.required('Select your province/territory')]"
+        :items="filteredProvinceList"
+        item-title="title"
+        item-value="code"
+        clearable
+        hide-details="auto"
+        @update:model-value="(value: string) => updateField('province', value)"
+      ></v-autocomplete>
     </v-col>
   </v-row>
 
@@ -111,7 +107,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from "vue";
+import { defineComponent } from "vue";
 import type { Components } from "@/types/openapi";
 import * as Rules from "@/utils/formRules";
 import EceTextField from "@/components/inputs/EceTextField.vue";

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/config.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/config.ts
@@ -1,7 +1,7 @@
 import type { UserManagerSettings } from "oidc-client-ts";
 import { defineStore } from "pinia";
 
-import { getConfiguration, getProvinceList, getSystemMessages, getIdentificationTypes } from "@/api/configuration";
+import { getConfiguration, getProvinceList, getCountryList, getSystemMessages, getIdentificationTypes } from "@/api/configuration";
 import oidcConfig from "@/oidc-config";
 import type { DropdownWrapper } from "@/types/form";
 import type { Components, SystemMessage } from "@/types/openapi";
@@ -12,6 +12,7 @@ export interface UserState {
   applicationConfiguration: Components.Schemas.ApplicationConfiguration;
   systemMessages: SystemMessage[];
   provinceList: DropdownWrapper<String>[];
+  countryList: DropdownWrapper<String>[];
   identificationTypes: Components.Schemas.IdentificationType[];
 }
 
@@ -22,6 +23,7 @@ export const useConfigStore = defineStore("config", {
   state: (): UserState => ({
     applicationConfiguration: {} as Components.Schemas.ApplicationConfiguration,
     provinceList: [] as DropdownWrapper<String>[],
+    countryList: [] as DropdownWrapper<String>[],
     systemMessages: [] as SystemMessage[],
     identificationTypes: [] as Components.Schemas.IdentificationType[],
   }),
@@ -53,9 +55,10 @@ export const useConfigStore = defineStore("config", {
 
   actions: {
     async initialize(): Promise<Components.Schemas.ApplicationConfiguration | null | undefined> {
-      const [configuration, provinceList, identificationTypes, systemMessages] = await Promise.all([
+      const [configuration, provinceList, countryList, identificationTypes, systemMessages] = await Promise.all([
         getConfiguration(),
         getProvinceList(),
+        getCountryList(),
         getIdentificationTypes(),
         getSystemMessages(),
       ]);
@@ -72,10 +75,23 @@ export const useConfigStore = defineStore("config", {
             return {
               value: province.provinceId as string,
               title: province.provinceName as string,
+              code: province.provinceCode as string,
             };
           })
           .sort((a, b) => sortArray(a, b, "title", [ProvinceTerritoryType.OTHER]));
       }
+
+      if (countryList !== null && countryList !== undefined) {
+        this.countryList = countryList
+          .map((country) => {
+            return {
+              value: country.countryName as string,
+              title: country.countryName as string,
+            };
+          })
+          .sort((a, b) => sortArray(a, b, "title"));
+      }
+
       if (identificationTypes !== null && identificationTypes !== undefined) {
         this.identificationTypes = identificationTypes;
       }

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/config.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/config.ts
@@ -12,7 +12,7 @@ export interface UserState {
   applicationConfiguration: Components.Schemas.ApplicationConfiguration;
   systemMessages: SystemMessage[];
   provinceList: DropdownWrapper<String>[];
-  countryList: DropdownWrapper<String>[];
+  countryList: DropdownWrapper<string>[];
   identificationTypes: Components.Schemas.IdentificationType[];
 }
 
@@ -23,7 +23,7 @@ export const useConfigStore = defineStore("config", {
   state: (): UserState => ({
     applicationConfiguration: {} as Components.Schemas.ApplicationConfiguration,
     provinceList: [] as DropdownWrapper<String>[],
-    countryList: [] as DropdownWrapper<String>[],
+    countryList: [] as DropdownWrapper<string>[],
     systemMessages: [] as SystemMessage[],
     identificationTypes: [] as Components.Schemas.IdentificationType[],
   }),

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/form.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/form.d.ts
@@ -12,6 +12,7 @@ interface Form {
 interface DropdownWrapper<T> {
   title: string;
   value: T;
+  code?: string;
 }
 
 // Wrap any type to a Radio button list for v-radio

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
@@ -210,6 +210,11 @@ declare namespace Components {
         export interface CommunicationsStatusResults {
             status?: CommunicationsStatus;
         }
+        export interface Country {
+            countryId?: string | null;
+            countryName?: string | null;
+            countryCode?: string | null;
+        }
         export interface DraftApplication {
             id?: string | null;
             signedDate?: string | null; // date-time
@@ -374,6 +379,7 @@ declare namespace Components {
         export interface Province {
             provinceId?: string | null;
             provinceName?: string | null;
+            provinceCode?: string | null;
         }
         export interface ReferenceContactInformation {
             lastName?: string | null;
@@ -756,6 +762,11 @@ declare namespace Paths {
             export type $200 = Components.Schemas.ApplicationConfiguration;
         }
     }
+    namespace CountryGet {
+        namespace Responses {
+            export type $200 = Components.Schemas.Country[];
+        }
+    }
     namespace DeleteFile {
         namespace Parameters {
             export type FileId = string;
@@ -986,6 +997,14 @@ export interface OperationMethods {
     data?: any,
     config?: AxiosRequestConfig  
   ): OperationResponse<Paths.ProvinceGet.Responses.$200>
+  /**
+   * country_get - Handles country queries
+   */
+  'country_get'(
+    parameters?: Parameters<UnknownParamsObject> | null,
+    data?: any,
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.CountryGet.Responses.$200>
   /**
    * systemMessage_get - Handles system messages queries
    */
@@ -1286,6 +1305,16 @@ export interface PathsDictionary {
       data?: any,
       config?: AxiosRequestConfig  
     ): OperationResponse<Paths.ProvinceGet.Responses.$200>
+  }
+  ['/api/countrylist']: {
+    /**
+     * country_get - Handles country queries
+     */
+    'get'(
+      parameters?: Parameters<UnknownParamsObject> | null,
+      data?: any,
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.CountryGet.Responses.$200>
   }
   ['/api/systemMessages']: {
     /**
@@ -1664,6 +1693,7 @@ export type CommunicationSeenRequest = Components.Schemas.CommunicationSeenReque
 export type CommunicationStatus = Components.Schemas.CommunicationStatus;
 export type CommunicationsStatus = Components.Schemas.CommunicationsStatus;
 export type CommunicationsStatusResults = Components.Schemas.CommunicationsStatusResults;
+export type Country = Components.Schemas.Country;
 export type DraftApplication = Components.Schemas.DraftApplication;
 export type DraftApplicationResponse = Components.Schemas.DraftApplicationResponse;
 export type EducationOrigin = Components.Schemas.EducationOrigin;

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formRules.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formRules.ts
@@ -12,6 +12,7 @@
 //  import * as Rule from @/utils/institute/form
 //  under data do rules: Rules <- allows you to use in <template>.
 
+import type { DropdownWrapper } from "@/types/form";
 import { DateTime } from "luxon";
 
 /**
@@ -60,6 +61,12 @@ const phoneNumber = (message = "Enter a valid phone number") => {
  */
 const postalCode = (message = "Enter your postal code in the format 'A1A 1A1'") => {
   return (v: string) => /^[ABCEGHJ-NPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][ -]?\d[ABCEGHJ-NPRSTV-Z]\d$/i.test(v) || message;
+};
+
+const mustExistInDropdown = (dropdown: DropdownWrapper<any>[], key: keyof DropdownWrapper<any>, message: string = "Must choose a valid option") => {
+  return (v: string) => {
+    return dropdown.some((item) => item[key] === v) || message;
+  };
 };
 
 /**
@@ -237,6 +244,7 @@ export {
   futureDateNotAllowedRule,
   hasCheckbox,
   validContactName,
+  mustExistInDropdown,
   number,
   numberToDecimalPlace as numberToDecimalPlaces,
   phoneNumber,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formRules.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/formRules.ts
@@ -63,7 +63,7 @@ const postalCode = (message = "Enter your postal code in the format 'A1A 1A1'") 
   return (v: string) => /^[ABCEGHJ-NPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][ -]?\d[ABCEGHJ-NPRSTV-Z]\d$/i.test(v) || message;
 };
 
-const mustExistInDropdown = (dropdown: DropdownWrapper<any>[], key: keyof DropdownWrapper<any>, message: string = "Must choose a valid option") => {
+const mustExistInDropdown = (dropdown: DropdownWrapper<any>[], key: keyof DropdownWrapper<any>, message: string = "Please select a valid option") => {
   return (v: string) => {
     return dropdown.some((item) => item[key] === v) || message;
   };

--- a/src/ECER.Managers.Admin.Contract/Metadatas/Contract.cs
+++ b/src/ECER.Managers.Admin.Contract/Metadatas/Contract.cs
@@ -31,7 +31,7 @@ public record SystemMessagesQueryResults(IEnumerable<SystemMessage> Items);
 public record IdentificationTypesQueryResults(IEnumerable<IdentificationType> Items);
 public record ProvincesQueryResults(IEnumerable<Province> Items);
 public record CountriesQueryResults(IEnumerable<Country> Items);
-public record Province(string ProvinceId, string ProvinceName);
+public record Province(string ProvinceId, string ProvinceName, string ProvinceCode);
 public record Country(string CountryId, string CountryName, string CountryCode);
 public record IdentificationType(string Id, string Name, bool ForPrimary, bool ForSecondary);
 public record SystemMessage(string Name, string Subject, string Message)

--- a/src/ECER.Resources.Documents/MetadataResources/IMetadataResourceRepository.cs
+++ b/src/ECER.Resources.Documents/MetadataResources/IMetadataResourceRepository.cs
@@ -11,7 +11,7 @@ public interface IMetadataResourceRepository
   Task<IEnumerable<IdentificationType>> QueryIdentificationTypes(IdentificationTypesQuery query, CancellationToken cancellationToken);
 }
 
-public record Province(string ProvinceId, string ProvinceName);
+public record Province(string ProvinceId, string ProvinceName, string ProvinceCode);
 public record Country(string CountryId, string CountryName, string CountryCode);
 public record IdentificationType(string Id, string Name, bool ForPrimary, bool ForSecondary);
 

--- a/src/ECER.Resources.Documents/MetadataResources/MetadataResourceRepositoryMapper.cs
+++ b/src/ECER.Resources.Documents/MetadataResources/MetadataResourceRepositoryMapper.cs
@@ -11,6 +11,7 @@ internal class MetadataResourceRepositoryMapper : Profile
     CreateMap<ecer_Province, Province>(MemberList.Source)
     .ForCtorParam(nameof(Province.ProvinceId), opt => opt.MapFrom(src => src.ecer_ProvinceId))
     .ForCtorParam(nameof(Province.ProvinceName), opt => opt.MapFrom(src => src.ecer_Name))
+    .ForCtorParam(nameof(Province.ProvinceCode), opt => opt.MapFrom(src => src.ecer_Abbreviation))
     .ValidateMemberList(MemberList.Destination);
 
     CreateMap<ecer_SystemMessage, SystemMessage>(MemberList.Source)

--- a/src/ECER.Tests/Integration/RegistryApi/ConfigurationTests.cs
+++ b/src/ECER.Tests/Integration/RegistryApi/ConfigurationTests.cs
@@ -5,6 +5,7 @@ using ECER.Managers.Admin;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Xunit.Abstractions;
+using static Pipelines.Sockets.Unofficial.SocketConnection;
 
 namespace ECER.Tests.Integration.RegistryApi;
 
@@ -26,6 +27,22 @@ public class ConfigurationTests : RegistryPortalWebAppScenarioBase
 
     var provinces = await provincesResponse.ReadAsJsonAsync<Province[]>();
     provinces.ShouldNotBeNull();
+    provinces.Length.ShouldBeGreaterThan(0);
+  }
+
+  [Fact]
+  public async Task GetCountries_ReturnsCountries()
+  {
+    var countriesResponse = await Host.Scenario(_ =>
+    {
+      _.WithExistingUser(this.Fixture.AuthenticatedBcscUserIdentity, this.Fixture.AuthenticatedBcscUser);
+      _.Get.Url("/api/countrylist");
+      _.StatusCodeShouldBeOk();
+    });
+
+    var countries = await countriesResponse.ReadAsJsonAsync<Country[]>();
+    countries.ShouldNotBeNull();
+    countries.Length.ShouldBeGreaterThan(0);
   }
 
   [Fact]


### PR DESCRIPTION
## Title
ECER-3095: Accept international addresses and save province name from standard list

## Description

Changes apply to home address and mailing address.

Show list of countries
--- Use Autocomplete vuetifyjs component (see links)
--- Comes from ecer_country in dynamics (ECER-3180)
--- Does NOT include 'Other'
--- Default value to Canada if no value already set

If Country = Canada,
- Postal code updates
--- Label should be "Postal code” 

- Hide "Province / State" text box
- Show "Province / Territory"  list
--- Options come from ecer_province (same as used in references)
--- Does NOT include 'Other'
--- Value of list is ecer_abbreviation, Text is ecer_name
------ The user should be able to pick "British Columbia", and then in dynamics it saves the abbreviation BC
--- Default value to British Columbia if no value is already set

If Country != Canada, 
- Postal code updates
--- Label should be "Postal / Zip code” 

- Hide Province / Territory list
- Show Province / State text box
--- Label should be "Province or state"

-------------------
On checking "Same as home address", 
set values in mailing address same as home address



---------------------
On saving form,
validate
-- If Country = Canada, the Required Fields are:
---- Street address
---- City or town
---- Province / Territory
---- Postal code
-- If Country = Canada, validate postal code format of A1A 1A1, show this error message "Enter the postal code in the format of A1A 1A1"
- If Country != Canada, the required fields are: 
---- Street address
---- City or town
- No validating format of postal / zip code


Saving data:
- Value of any list is saved as text in dynamics
- Make sure to save abbreviation of Canadian province
- Make sure to save full name of country (Canada, not CA)
- Either value of "Province / state" textbox or value of "Province / terrirotry" list is saved in address1_stateorprovince or address2_stateorprovince
- Either value of "Postal code" or "Postal / Zip code" is saved in address1_postalcode or address2_postalcode


## Related Jira Issue(s)

- ECER-3095
- ECER-4287
- ECER-4288

## Checklist
- [x] I have tested these changes locally.
- [x] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/20aa4589-875d-44f2-a697-6e1eab450e19)

![image](https://github.com/user-attachments/assets/0240393b-950c-4a7b-92b0-44ec3af1fe1a)

![image](https://github.com/user-attachments/assets/edb9186f-b36f-4d71-a695-0fdefe3c639e)

![image](https://github.com/user-attachments/assets/f59a99dc-e705-4e10-9de8-0e0f5d58c28e)

**Validations:**

Country = Canada:
![image](https://github.com/user-attachments/assets/60de12bf-eba2-477b-b95f-ab870d41e5e9)

Country !=  Canada:
![image](https://github.com/user-attachments/assets/b789a320-f1d0-4355-bf87-ab6c4350c564)

