### PR TITLE
ECER-1732: Education: Remove field for language of institution

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationMapper.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationMapper.cs
@@ -53,8 +53,6 @@ public class ApplicationMapper : Profile
          opt => opt.MapFrom(src => src.EducationOrigin))
       .ForMember(d => d.CampusLocation,
              opts => opts.MapFrom(src => src.CampusLocation))
-      .ForMember(d => d.LanguageofInstruction,
-             opts => opts.MapFrom(src => src.LanguageofInstruction))
       .ForMember(d => d.StudentMiddleName,
        opts => opts.MapFrom(src => src.StudentMiddleName))
       .ReverseMap();

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Applications/ApplicationsEndpoints.cs
@@ -380,8 +380,6 @@ public record Transcript([Required] string EducationalInstitutionName, [Required
   public string StudentFirstName { get; set; } = string.Empty;
   public string? StudentMiddleName { get; set; }
   public string? StudentNumber { get; set; }
-  public string? LanguageofInstruction { get; set; }
-
   public bool IsECEAssistant { get; set; }
   public bool DoesECERegistryHaveTranscript { get; set; }
   public bool IsOfficialTranscriptRequested { get; set; }

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
@@ -148,11 +148,6 @@
         </v-row>
         <v-row>
           <v-col>
-            <EceTextField v-model="language" label="Language of institution (optional)" variant="outlined" color="primary" maxlength="100"></EceTextField>
-          </v-col>
-        </v-row>
-        <v-row>
-          <v-col>
             <h3>Name and student number on transcript</h3>
             <br />
             <p>Make sure this exactly matches your transcript. It may cause delays if we cannot match a transcript we receive to your application.</p>
@@ -259,7 +254,6 @@ interface EceEducationData {
   program: string;
   campusLocation: string;
   studentNumber: string;
-  language: string;
   startYear: string;
   endYear: string;
   transcriptStatus: "received" | "requested" | "";
@@ -316,7 +310,6 @@ export default defineComponent({
       program: "",
       campusLocation: "",
       studentNumber: "",
-      language: "",
       startYear: "",
       endYear: "",
       transcriptStatus: "",
@@ -400,7 +393,6 @@ export default defineComponent({
           studentMiddleName: this.studentMiddleName,
           studentLastName: this.studentLastName,
           studentNumber: this.studentNumber,
-          languageofInstruction: this.language,
           startDate: this.startYear,
           endDate: this.endYear,
           doesECERegistryHaveTranscript: this.transcriptStatus === "received",
@@ -460,7 +452,6 @@ export default defineComponent({
         (this.studentLastName = educationData.education.studentLastName ?? ""),
         (this.studentNumber = educationData.education.studentNumber ?? "");
       this.isNameUnverified = educationData.education.isNameUnverified ?? false;
-      this.language = educationData.education.languageofInstruction ?? "";
       this.startYear = formatDate(educationData.education.startDate || "") ?? "";
       this.endYear = formatDate(educationData.education.endDate || "") ?? "";
       this.educationRecognition = educationData.education.educationRecognition;
@@ -526,7 +517,6 @@ export default defineComponent({
       this.program = "";
       this.campusLocation = "";
       this.studentNumber = "";
-      this.language = "";
       this.startYear = "";
       this.endYear = "";
       this.transcriptStatus = "";

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducationPreview.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducationPreview.vue
@@ -72,14 +72,6 @@
             <p class="small font-weight-bold">{{ studentFullName(education) }}</p>
           </v-col>
         </v-row>
-        <v-row>
-          <v-col cols="4">
-            <p class="small">Language of institution</p>
-          </v-col>
-          <v-col>
-            <p class="small font-weight-bold">{{ education.languageofInstruction }}</p>
-          </v-col>
-        </v-row>
       </div>
     </template>
   </PreviewCard>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
@@ -465,7 +465,6 @@ declare namespace Components {
             studentFirstName?: string | null;
             studentMiddleName?: string | null;
             studentNumber?: string | null;
-            languageofInstruction?: string | null;
             isECEAssistant?: boolean;
             doesECERegistryHaveTranscript?: boolean;
             isOfficialTranscriptRequested?: boolean;
@@ -898,6 +897,7 @@ declare namespace Paths {
         namespace Responses {
             export interface $200 {
             }
+            export type $400 = Components.Schemas.ProblemDetails | Components.Schemas.HttpValidationProblemDetails;
         }
     }
     namespace ProvinceGet {

--- a/src/ECER.Managers.Registry.Contract/Applications/Contract.cs
+++ b/src/ECER.Managers.Registry.Contract/Applications/Contract.cs
@@ -74,7 +74,6 @@ public record Application(string? Id, string RegistrantId, ApplicationStatus Sta
 public record Transcript(string? Id, string? EducationalInstitutionName, string? ProgramName, string? StudentNumber, DateTime StartDate, DateTime EndDate, bool IsECEAssistant, bool DoesECERegistryHaveTranscript, bool IsOfficialTranscriptRequested, string StudentFirstName, string StudentLastName, bool IsNameUnverified, EducationRecognition EducationRecognition, EducationOrigin EducationOrigin)
 {
   public string? CampusLocation { get; set; }
-  public string? LanguageofInstruction { get; set; }
   public TranscriptStage? Status { get; set; }
   public string? StudentMiddleName { get; set; }
 }

--- a/src/ECER.Resources.Documents/Applications/ApplicationRepositoryMapper.cs
+++ b/src/ECER.Resources.Documents/Applications/ApplicationRepositoryMapper.cs
@@ -111,7 +111,6 @@ internal class ApplicationRepositoryMapper : Profile
            .ForMember(d => d.ecer_StudentLastName, opts => opts.MapFrom(s => s.StudentLastName))
            .ForMember(d => d.ecer_StudentNumber, opts => opts.MapFrom(s => s.StudentNumber))
            .ForMember(d => d.ecer_EducationInstitutionFullName, opts => opts.MapFrom(s => s.EducationalInstitutionName))
-           .ForMember(d => d.ecer_LanguageofInstruction, opts => opts.MapFrom(s => s.LanguageofInstruction))
            .ForMember(d => d.ecer_TranscriptId, opts => opts.MapFrom(s => s.Id))
            .ForMember(d => d.ecer_IsECEAssistant, opts => opts.MapFrom(s => s.IsECEAssistant))
            .ForMember(d => d.ecer_DoesECERegistryHaveTranscript, opts => opts.MapFrom(s => s.DoesECERegistryHaveTranscript))
@@ -137,7 +136,6 @@ internal class ApplicationRepositoryMapper : Profile
           .ForCtorParam(nameof(Transcript.EducationRecognition), opt => opt.MapFrom(src => src.ecer_EducationRecognition))
           .ForCtorParam(nameof(Transcript.EducationOrigin), opt => opt.MapFrom(src => src.ecer_EducationOrigin))
           .ForMember(d => d.CampusLocation, opts => opts.MapFrom(s => s.ecer_CampusLocation))
-          .ForMember(d => d.LanguageofInstruction, opts => opts.MapFrom(s => s.ecer_LanguageofInstruction))
           .ForMember(d => d.Status, opts => opts.MapFrom(s => s.StatusCode))
           .ForMember(d => d.StudentMiddleName, opts => opts.MapFrom(s => s.ecer_StudentMiddleName))
     .ValidateMemberList(MemberList.Destination);

--- a/src/ECER.Resources.Documents/Applications/IApplicationRepository.cs
+++ b/src/ECER.Resources.Documents/Applications/IApplicationRepository.cs
@@ -60,7 +60,6 @@ public record Application(string? Id, string ApplicantId, IEnumerable<Certificat
 public record Transcript(string? Id, string? EducationalInstitutionName, string? ProgramName, string? StudentNumber, DateTime StartDate, DateTime EndDate, bool IsECEAssistant, bool DoesECERegistryHaveTranscript, bool IsOfficialTranscriptRequested, string StudentFirstName, string StudentLastName, bool IsNameUnverified, EducationRecognition EducationRecognition, EducationOrigin EducationOrigin)
 {
   public string? CampusLocation { get; set; }
-  public string? LanguageofInstruction { get; set; }
   public TranscriptStage? Status { get; set; }
   public string? StudentMiddleName { get; set; }
 }

--- a/src/ECER.Tests/Integration/RegistryApi/ApplicationTests.cs
+++ b/src/ECER.Tests/Integration/RegistryApi/ApplicationTests.cs
@@ -545,8 +545,6 @@ public class ApplicationTests : RegistryPortalWebAppScenarioBase
 
   private static Transcript CreateTranscript()
   {
-    var languages = new List<string> { "English", "French", "Spanish", "German", "Mandarin", "Japanese", "Russian", "Arabic", "Portuguese", "Hindi" };
-
     // Use Faker to generate values for the required parameters
     var faker = new Faker("en_CA");
     var educationalInstitutionName = faker.Company.CompanyName();
@@ -575,7 +573,6 @@ public class ApplicationTests : RegistryPortalWebAppScenarioBase
       CampusLocation = faker.Address.City(),
       StudentFirstName = faker.Name.FirstName(),
       StudentNumber = faker.Random.Number(10000000, 99999999).ToString(),
-      LanguageofInstruction = faker.PickRandom(languages),
       IsECEAssistant = faker.Random.Bool(),
       DoesECERegistryHaveTranscript = faker.Random.Bool(),
       IsOfficialTranscriptRequested = faker.Random.Bool()

--- a/src/ECER.Tests/Integration/Resources/Applications/ApplicationRepositoryTests.cs
+++ b/src/ECER.Tests/Integration/Resources/Applications/ApplicationRepositoryTests.cs
@@ -482,12 +482,9 @@ public class ApplicationRepositoryTests : RegistryPortalWebAppScenarioBase
   {
     var faker = new Faker("en_CA");
 
-    var languages = new List<string> { "English", "French", "Spanish", "German", "Mandarin", "Japanese", "Russian", "Arabic", "Portuguese", "Hindi" };
-
     return new Transcript(null, faker.Company.CompanyName(), $"{faker.Hacker.Adjective()} Program", faker.Random.Number(10000000, 99999999).ToString(), faker.Date.Past(), faker.Date.Recent(), faker.Random.Bool(), faker.Random.Bool(), faker.Random.Bool(), faker.Name.FirstName(), faker.Name.LastName(), faker.Random.Bool(), EducationRecognition.Recognized, EducationOrigin.InsideBC
     )
     {
-      LanguageofInstruction = faker.PickRandom(languages),
       CampusLocation = faker.Address.City(),
       Status = TranscriptStage.Draft
     };

--- a/src/ECER.Tests/Unit/ApplicationRenewalValidationEngineTests.cs
+++ b/src/ECER.Tests/Unit/ApplicationRenewalValidationEngineTests.cs
@@ -412,7 +412,6 @@ public class ApplicationRenewalValidationEngineTests
     )
     {
       CampusLocation = _faker.Address.City(), // Random city for CampusLocation
-      LanguageofInstruction = "English",
       Status = _faker.Random.Enum<TranscriptStage>(), // Random enum value for Status
       StudentMiddleName = _faker.Name.FirstName() // Random middle name
     };


### PR DESCRIPTION

## Title
ECER-1732: Education: Remove field for language of institution

## Description

- BE: Remove language of institution field on transcript
- FE: Remove language of institution field on education form
- BE: Update automated tests

## Related Jira Issue(s)

- ECER-1732
- ECER-3320
- ECER-3321
- ECER-3322

## Checklist
- [x] I have tested these changes locally.
- [x] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)

**On add/edit education form:**

Before:
![image](https://github.com/user-attachments/assets/6c338f47-affa-42a2-86a7-bd1a3fdcbb13)
After:
![image](https://github.com/user-attachments/assets/323d05cc-887d-4a25-bbf9-b8eedd859753)


**On the review page**

Before:
![image](https://github.com/user-attachments/assets/57b5314e-549f-49be-86b9-07ff1371d094)
After:
![image](https://github.com/user-attachments/assets/727e13ad-ff31-4a99-ba13-5bd71b033ad9)


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.