### PR TITLE
Fix/ecer 2855 new user

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Users/UserInfoEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Users/UserInfoEndpoints.cs
@@ -36,7 +36,12 @@ public class UserInfoEndpoints : IRegisterEndpoints
     endpointRouteBuilder.MapPost("api/userinfo", async Task<Ok> (UserInfo userInfo, HttpContext ctx, CancellationToken ct, IMediator bus, IMapper mapper) =>
         {
           var user = ctx.User.GetUserContext()!;
-          userInfo.MiddleName = ECER.Infrastructure.Common.Utility.GetMiddleName(userInfo.FirstName!, userInfo.GivenName!);
+          if (user.Identity.IdentityProvider == "bcsc")
+          {
+            //for bcsc users we need to derive middle name from user info
+            userInfo.MiddleName = ECER.Infrastructure.Common.Utility.GetMiddleName(userInfo.FirstName!, userInfo.GivenName!);
+          }
+
           await bus.Send(new RegisterNewUserCommand(mapper.Map<Managers.Registry.Contract.Registrants.UserProfile>(userInfo)!, user.Identity), ct);
           return TypedResults.Ok();
         })

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/NewUser.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/NewUser.vue
@@ -51,7 +51,13 @@
           <v-row>
             <!-- Date of birth Field -->
             <v-col sm="12" md="4" xl="2">
-              <EceDateInput v-model="dateOfBirth" :rules="[Rules.required()]" label="Date of birth (yyyy-mm-dd)"></EceDateInput>
+              <EceDateInput
+                v-model="dateOfBirth"
+                :rules="[Rules.required(), Rules.futureDateNotAllowedRule()]"
+                :max="today"
+                label="Date of birth"
+                placeholder=""
+              ></EceDateInput>
             </v-col>
           </v-row>
         </v-col>
@@ -183,6 +189,8 @@ import * as Rules from "@/utils/formRules";
 
 import PageContainer from "../PageContainer.vue";
 import { useRouter } from "vue-router";
+import { DateTime } from "luxon";
+import { formatDate } from "@/utils/format";
 
 export default defineComponent({
   name: "NewUser",
@@ -234,6 +242,11 @@ export default defineComponent({
     eceCertificateStatus: undefined as boolean | undefined,
     Rules,
   }),
+  computed: {
+    today() {
+      return formatDate(DateTime.now().toString());
+    },
+  },
   methods: {
     isNumber,
     async submit() {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/oidc.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/oidc.ts
@@ -1,6 +1,7 @@
 import { type SignoutResponse, User } from "oidc-client-ts";
 import { UserManager } from "oidc-client-ts";
 import { defineStore } from "pinia";
+import { parseFirstNameLastName } from "../utils/functions";
 
 import type { Components } from "@/types/openapi";
 
@@ -17,15 +18,30 @@ export const useOidcStore = defineStore("oidc", {
   actions: {
     async oidcUserInfo(): Promise<any> {
       const user = await this.getUser();
-      return {
-        dateOfBirth: user ? (user.profile.birthdate ?? undefined) : undefined,
-        firstName: user ? (user.profile.given_name ?? "") : "",
-        givenName: user ? (user.profile.given_names ?? "") : "",
-        lastName: user ? (user.profile.family_name ?? "") : "",
-        phone: user ? (user.profile.phone_number ?? "") : "",
-        email: user ? (user.profile.email ?? "") : "",
-        address: user ? (user.profile.address ?? "") : "",
-      };
+
+      if (user?.profile.identity_provider === "bceidbasic") {
+        let { firstName, lastName } = parseFirstNameLastName(user?.profile.given_name || "");
+        console.log(user.profile);
+        return {
+          dateOfBirth: undefined,
+          firstName: firstName,
+          givenName: "",
+          lastName: lastName,
+          phone: "",
+          email: user ? (user.profile.email ?? "") : "",
+          address: "",
+        };
+      } else if (user?.profile.identity_provider === "bcsc") {
+        return {
+          dateOfBirth: user ? (user.profile.birthdate ?? undefined) : undefined,
+          firstName: user ? (user.profile.given_name ?? "") : "",
+          givenName: user ? (user.profile.given_names ?? "") : "",
+          lastName: user ? (user.profile.family_name ?? "") : "",
+          phone: user ? (user.profile.phone_number ?? "") : "",
+          email: user ? (user.profile.email ?? "") : "",
+          address: user ? (user.profile.address ?? "") : "",
+        };
+      }
     },
     async oidcAddress(): Promise<Components.Schemas.Address> {
       const user = await this.getUser();

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/functions.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/utils/functions.ts
@@ -174,3 +174,36 @@ export function scrollToElement(
 
   element.scrollIntoView({ behavior, block, inline });
 }
+
+/**
+ * Parses a full name string into first and last name components.
+ *
+ * This function handles various name formats, including single names,
+ * names with multiple first names, and names with leading/trailing spaces.
+ * It treats a single name as the last name. Empty or null input will
+ * return empty strings for both first and last name.
+ *
+ * @param {string} name The full name string to parse.
+ * @returns {{ firstName: string; lastName: string }} An object containing the parsed first and last names.
+ *         If the input is null, undefined, or an empty string, both firstName and lastName will be empty strings.
+ *         If the input string contains only spaces, both firstName and lastName will be empty strings.
+ */
+export function parseFirstNameLastName(name: string) {
+  let firstName = "";
+  let lastName = "";
+  if (!name) {
+    return { firstName, lastName };
+  }
+
+  name = name.trim();
+
+  let nameArray = name.split(" ");
+  if (nameArray.length === 1) {
+    lastName = nameArray[0];
+  } else if (nameArray.length > 1) {
+    lastName = nameArray.pop() || "";
+    firstName = nameArray.join(" ");
+  }
+
+  return { firstName, lastName };
+}


### PR DESCRIPTION
## Title
https://eccbc.atlassian.net/browse/ECER-2855 
associated bug tickets
https://eccbc.atlassian.net/browse/ECER-4339
https://eccbc.atlassian.net/browse/ECER-4340
https://eccbc.atlassian.net/browse/ECER-4343

## Description

- middle name saves for basic bceid users 
- date of birth field doesn't have format 
- future date not allowed as an input for date of birth
- newUser page splits firstName and lastName for bceid users.

## Related Jira Issue(s)

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
future date restrictions 
![image](https://github.com/user-attachments/assets/42eb98c5-3d9a-420d-b837-8750497eb96d)

user inputs for bceidbasic user. Date of birth removal of label and format
![image](https://github.com/user-attachments/assets/846acc92-ddbe-4259-9438-f27fe76a7588)

name inputs and display screen 
![image](https://github.com/user-attachments/assets/8190600c-95ae-4a43-9fcf-f5a0a755c091)
