### PR TITLE
ecer-4373 renewal error on day of expiry

### DIFF
--- a/src/ECER.Engines.Validation/Applications/ApplicationRenewalValidationEngine.cs
+++ b/src/ECER.Engines.Validation/Applications/ApplicationRenewalValidationEngine.cs
@@ -45,13 +45,13 @@ internal sealed partial class ApplicationRenewalValidationEngine : IApplicationV
     try
     {
       var expiryDate = await getLastCertificateExpiryDate(applicantId);
-      var now = DateTime.Now;
+      var now = DateTime.Now.Date; //sets time stamp to 00:00:00
 
-      if (expiryDate > now)
+      if (expiryDate >= now)
       {
         return CertificateStatus.Active;
       }
-      else if (expiryDate <= now && expiryDate > now.AddYears(-5))
+      else if (expiryDate < now && expiryDate > now.AddYears(-5))
       {
         return CertificateStatus.ExpiredLessThanFiveYearsAgo;
       }


### PR DESCRIPTION
https://eccbc.atlassian.net/browse/ECER-4373

## Description

- Production support issue for applicants applying on the day of expiry. 
- Backend considers someone applying on the day of expiry is Expired. 
- Changed logic to consider today as active. 

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

User sees this when they try to submit a five year renewal on the day of expiry. 
![image](https://github.com/user-attachments/assets/815fbd16-f833-4f04-844d-68f78d22a136) 

