### PR TITLE
ecer-4389 production support making it so when user applies on the da…

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/certification.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/certification.ts
@@ -25,7 +25,7 @@ export const useCertificationStore = defineStore("certification", {
     },
     latestExpiredMoreThan5Years(state): boolean {
       if (!state.latestCertification?.expiryDate) return false;
-      const dt1 = DateTime.now();
+      const dt1 = DateTime.now().startOf("day");
       const dt2 = DateTime.fromISO(state.latestCertification?.expiryDate);
       const differenceInYears = Math.abs(dt1.diff(dt2, "years").years);
       return differenceInYears > 5;

--- a/src/ECER.Engines.Validation/Applications/ApplicationRenewalValidationEngine.cs
+++ b/src/ECER.Engines.Validation/Applications/ApplicationRenewalValidationEngine.cs
@@ -51,7 +51,7 @@ internal sealed partial class ApplicationRenewalValidationEngine : IApplicationV
       {
         return CertificateStatus.Active;
       }
-      else if (expiryDate < now && expiryDate > now.AddYears(-5))
+      else if (expiryDate < now && expiryDate >= now.AddYears(-5))
       {
         return CertificateStatus.ExpiredLessThanFiveYearsAgo;
       }


### PR DESCRIPTION
…y of expiry that they are considered as not expired over 5 years criteria

## Title
https://eccbc.atlassian.net/browse/ECER-4389

## Description

- normalizing date.now to start of day. 
- making it consistent how we determine when a certificate has expired more than 5 years ago. It must be greater than 5 years ago. 
- This is important when we consider whether someone requires 400 hours of work experience or 500 hours of work experience when renewing a 5 year certification. 

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.