### PR TITLE
ecer-4511 update content for toast messags with portal renewal

### DIFF
--- a/src/ECER.Engines.Validation/Applications/RenewalValidationConditions/EceAssistant.cs
+++ b/src/ECER.Engines.Validation/Applications/RenewalValidationConditions/EceAssistant.cs
@@ -28,7 +28,7 @@ internal sealed partial class ApplicationRenewalValidationEngine
         if (application.WorkExperienceReferences
        .Sum(we => we.Hours) < 400)
         {
-          validationErrors.Add("Work experience does not meet 400 hours");
+          validationErrors.Add("You must provide 400 hours of work experience");
         }
         break;
 

--- a/src/ECER.Engines.Validation/Applications/RenewalValidationConditions/FiveYears.cs
+++ b/src/ECER.Engines.Validation/Applications/RenewalValidationConditions/FiveYears.cs
@@ -26,7 +26,7 @@ internal sealed partial class ApplicationRenewalValidationEngine
         if (application.WorkExperienceReferences
        .Sum(we => we.Hours) < 400)
         {
-          validationErrors.Add("Work experience does not meet 400 hours");
+          validationErrors.Add("You must provide 400 hours of work experience");
         }
         break;
 
@@ -39,7 +39,7 @@ internal sealed partial class ApplicationRenewalValidationEngine
 
         if (application.FiveYearRenewalExplanationChoice == null)
         {
-          validationErrors.Add("five year explanation choice cannot be null");
+          validationErrors.Add("You must provide a reason for late renewal");
         }
         // each application should contain explanation letter
         if (string.IsNullOrEmpty(application.RenewalExplanationOther) && application.FiveYearRenewalExplanationChoice == FiveYearRenewalExplanations.Other)
@@ -55,7 +55,7 @@ internal sealed partial class ApplicationRenewalValidationEngine
         if (application.WorkExperienceReferences
        .Sum(we => we.Hours) < 400)
         {
-          validationErrors.Add("Work experience does not meet 400 hours");
+          validationErrors.Add("You must provide 400 hours of work experience");
         }
         break;
 
@@ -74,7 +74,7 @@ internal sealed partial class ApplicationRenewalValidationEngine
         if (application.WorkExperienceReferences
        .Sum(we => we.Hours) < 500)
         {
-          validationErrors.Add("Work experience does not meet 500 hours");
+          validationErrors.Add("You must provide 500 hours of work experience");
         }
         break;
 

--- a/src/ECER.Engines.Validation/Applications/RenewalValidationConditions/OneYear.cs
+++ b/src/ECER.Engines.Validation/Applications/RenewalValidationConditions/OneYear.cs
@@ -54,7 +54,7 @@ internal sealed partial class ApplicationRenewalValidationEngine
         if (application.WorkExperienceReferences
        .Sum(we => we.Hours) < 400)
         {
-          validationErrors.Add("Work experience does not meet 400 hours");
+          validationErrors.Add("You must provide 400 hours of work experience");
         }
         break;
 

--- a/src/ECER.Tests/Unit/ApplicationRenewalValidationEngineTests.cs
+++ b/src/ECER.Tests/Unit/ApplicationRenewalValidationEngineTests.cs
@@ -165,7 +165,7 @@ public class ApplicationRenewalValidationEngineTests
     var result = await _validator.Validate(application);
 
     // Assert
-    Assert.Contains("Work experience does not meet 500 hours", result.ValidationErrors);
+    Assert.Contains("You must provide 500 hours of work experience", result.ValidationErrors);
   }
 
   private Certification CreateMockCertification(DateTime expiryDate, CertificateStatusCode statusCode)
@@ -294,7 +294,7 @@ public class ApplicationRenewalValidationEngineTests
     var result = await _validator.Validate(application);
 
     // Assert
-    Assert.Contains("five year explanation choice cannot be null", result.ValidationErrors);
+    Assert.Contains("You must provide a reason for late renewal", result.ValidationErrors);
   }
 
   [Fact]


### PR DESCRIPTION
## Title

## Description

- updating toast messages when user applies before and after expiry date cutoffs. 

## Related Jira Issue(s)

https://eccbc.atlassian.net/browse/ECER-4511 
- etc.

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/d1d7cc6c-60fe-4d62-85e1-176256c4e988)

![image](https://github.com/user-attachments/assets/7a09943b-4f5b-4f13-9efb-ddcfffdbef59)
