### PR TITLE
fix for province dropdown in references

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceReferenceContact.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/reference/inputs/EceReferenceContact.vue
@@ -64,6 +64,8 @@
                 color="primary"
                 class="pt-2"
                 :items="configStore?.provinceList"
+                item-title="provinceName"
+                item-value="provinceId"
                 clearable
                 hide-details="auto"
                 @update:model-value="certificateProvinceIdChanged"
@@ -106,6 +108,8 @@
                 class="pt-2"
                 :items="configStore?.provinceList"
                 clearable
+                item-title="provinceName"
+                item-value="provinceId"
                 @update:model-value="certificateProvinceIdChanged"
                 @click:clear="provinceClearClicked"
               ></v-autocomplete>
@@ -118,6 +122,8 @@
                 variant="outlined"
                 color="primary"
                 class="pt-2"
+                item-title="provinceName"
+                item-value="provinceId"
                 :items="configStore?.provinceList.filter((province) => province.provinceName !== ProvinceTerritoryType.OTHER)"
                 :rules="[Rules.required()]"
                 @update:model-value="certificateProvinceIdChanged"


### PR DESCRIPTION
## Title
https://eccbc.atlassian.net/browse/ECER-4513

## Description

- allowing dropdowns to show the appropriate value. 

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
reference is able to submit and the correct province is saved into dynamics.
![image](https://github.com/user-attachments/assets/9b4599e2-d7de-4049-9b80-79484253dec3)


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.