### PR TITLE
prevent user from going into the /application route directly without …

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Application.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Application.vue
@@ -144,6 +144,10 @@ export default defineComponent({
     },
   },
   mounted() {
+    if (this.applicationStore.draftApplication.signedDate === null || this.applicationStore.draftApplication.certificationTypes?.length === 0) {
+      console.warn("user entered into /application route without a signedDate or certificationType");
+      this.router.push("/");
+    }
     this.mode = "list";
   },
   methods: {

--- a/src/ECER.Engines.Validation/Applications/ApplicationRenewalValidationEngine.cs
+++ b/src/ECER.Engines.Validation/Applications/ApplicationRenewalValidationEngine.cs
@@ -17,6 +17,11 @@ internal sealed partial class ApplicationRenewalValidationEngine : IApplicationV
     await Task.CompletedTask;
     var validationErrors = new List<string>();
 
+    if (!application.CertificationTypes.Any())
+    {
+      validationErrors.Add("Application is not associated with a certification type");
+    }
+
     if (application.CertificationTypes.Contains(CertificationType.EceAssistant))
     {
       validationErrors = await EceAssistant(application);

--- a/src/ECER.Engines.Validation/Applications/LabourMobilityApplicationSubmissionValidationEngine.cs
+++ b/src/ECER.Engines.Validation/Applications/LabourMobilityApplicationSubmissionValidationEngine.cs
@@ -10,6 +10,11 @@ internal sealed class LabourMobilityApplicationSubmissionValidationEngine : IApp
 
     var validationErrors = new List<string>();
 
+    if (!application.CertificationTypes.Any())
+    {
+      validationErrors.Add("Application is not associated with a certification type");
+    }
+
     // each application should contain at least one character reference
     if (!application.CharacterReferences.Any())
     {

--- a/src/ECER.Engines.Validation/Applications/NewApplicationSubmissionValidationEngine.cs
+++ b/src/ECER.Engines.Validation/Applications/NewApplicationSubmissionValidationEngine.cs
@@ -10,6 +10,11 @@ internal sealed class NewApplicationSubmissionValidationEngine : IApplicationVal
 
     var validationErrors = new List<string>();
 
+    if (!application.CertificationTypes.Any())
+    {
+      validationErrors.Add("Application is not associated with a certification type");
+    }
+
     // each application should contain at least one education
     if (!application.Transcripts.Any())
     {

--- a/src/ECER.Tests/Unit/ApplicationRenewalValidationEngineTests.cs
+++ b/src/ECER.Tests/Unit/ApplicationRenewalValidationEngineTests.cs
@@ -392,6 +392,19 @@ public class ApplicationRenewalValidationEngineTests
     Assert.Empty(result.ValidationErrors);
   }
 
+  [Fact]
+  public async Task Validate_DraftApplicationWithoutCertificationType_ReturnsError()
+  {
+    // Arrange
+    var application = new Application("id", "registrantId", ApplicationStatus.Draft){};
+
+    // Act
+    var result = await _validator.Validate(application);
+
+    // Assert
+    Assert.Contains("Application is not associated with a certification type", result.ValidationErrors);
+  }
+
   private Transcript CreateMockTranscript()
   {
     return new Transcript(

--- a/src/ECER.Tests/Unit/ApplicationSubmissionValidationEngineTests.cs
+++ b/src/ECER.Tests/Unit/ApplicationSubmissionValidationEngineTests.cs
@@ -88,6 +88,19 @@ public class ApplicationSubmissionValidationEngineTests
     Assert.Empty(result.ValidationErrors);
   }
 
+  [Fact]
+  public async Task Validate_DraftApplicationWithoutCertificationType_ReturnsError()
+  {
+    // Arrange
+    var application = new Application("id", "registrantId", ApplicationStatus.Draft) { };
+
+    // Act
+    var result = await _validator.Validate(application);
+
+    // Assert
+    Assert.Contains("Application is not associated with a certification type", result.ValidationErrors);
+  }
+
   private static Transcript CreateMockTranscript(bool invalid)
   {
     DateTime startDate = DateTime.Now.AddYears(-2);

--- a/src/ECER.Tests/Unit/LabourMobilityApplicationSubmissionValidationEngineTests.cs
+++ b/src/ECER.Tests/Unit/LabourMobilityApplicationSubmissionValidationEngineTests.cs
@@ -73,6 +73,19 @@ public class LabourMobilityApplicationSubmissionValidationEngineTests
     Assert.Empty(result.ValidationErrors);
   }
 
+  [Fact]
+  public async Task Validate_DraftApplicationWithoutCertificationType_ReturnsError()
+  {
+    // Arrange
+    var application = new Application("id", "registrantId", ApplicationStatus.Draft) { };
+
+    // Act
+    var result = await _validator.Validate(application);
+
+    // Assert
+    Assert.Contains("Application is not associated with a certification type", result.ValidationErrors);
+  }
+
   private static Transcript CreateMockTranscript(bool invalid)
   {
     DateTime startDate = DateTime.Now.AddYears(-2);


### PR DESCRIPTION
…choosing a certification type or declaration first

## Title
https://eccbc.atlassian.net/browse/ECER-4515

## Description

- User was able to submit an application and then submitted a second application without a certificationType 
- I believe this was caused by the user manually typing in /application into the url bar. 
- Added a check in /application page to prevent this
- further added additional validation in the backend to prevent a user from submitting said application


## Checklist
- [x] I have tested these changes locally.
- [x] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.