### PR TITLE
ecer-4539 user with multiple one year certificates cannot renew 5 yea…

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/RenewCard.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/RenewCard.vue
@@ -59,7 +59,10 @@ export default defineComponent({
       return this.todaysDate >= this.latestRenewalDate;
     },
     canRenew() {
-      return !this.certificationStore.hasMultipleEceOneYearCertifications && !(this.certificationStore.latestIsEceOneYear && this.expiredOverFiveYears);
+      return (
+        !(this.certificationStore.hasMultipleEceOneYearCertifications && this.certificationStore.latestIsEceOneYear) &&
+        !(this.certificationStore.latestIsEceOneYear && this.expiredOverFiveYears)
+      );
     },
     title() {
       return this.canRenew ? "Renew" : "Renew unavailable";


### PR DESCRIPTION
…r certificate

---
name: Pull Request Template
about: Template for creating pull requests
---

## Title
https://eccbc.atlassian.net/browse/ECER-4539

## Description

- renew check depends whether the latest certificate is one year. 

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
user still cannot renew one year more than once (consecutively)
![image](https://github.com/user-attachments/assets/8629014b-084b-4154-a0e2-edb4b91df3a8)
5 year certificate renewal works
![image](https://github.com/user-attachments/assets/a7c91bdb-d06f-4612-afbe-9b02eed3efcb)



## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.