### PR TITLE
bug fix address would not be up to date identified during demo

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceAddress.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceAddress.vue
@@ -159,14 +159,14 @@ export default defineComponent({
     }
     // If country is Canada and province is not set, default it to British Columbia.
     if (this.modelValue.country === "Canada" && !this.modelValue.province) {
-      this.updateField("province", this.configStore.britishColumbia?.provinceName ?? "");
+      this.updateField("province", this.configStore.britishColumbia?.provinceCode ?? "");
     }
   },
   watch: {
     // When switching back to Canada, if no province is set, reset it to British Columbia.
     "modelValue.country"(newVal: string) {
       if (newVal === "Canada" && !this.modelValue.province) {
-        this.updateField("province", this.configStore.britishColumbia?.provinceName ?? "");
+        this.updateField("province", this.configStore.britishColumbia?.provinceCode ?? "");
       }
     },
   },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Application.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/pages/Application.vue
@@ -52,7 +52,7 @@
               <v-col>
                 <v-btn
                   v-if="showSaveButtons"
-                  :loading="loadingStore.isLoading('draftapplication_put')"
+                  :loading="loadingStore.isLoading('draftapplication_put') || loadingStore.isLoading('profile_put') || loadingStore.isLoading('profile_get')"
                   rounded="lg"
                   color="primary"
                   @click="handleSaveAndContinue"
@@ -165,7 +165,7 @@ export default defineComponent({
       } else {
         switch (this.wizardStore.currentStepStage) {
           case "ContactInformation":
-            this.saveProfile(false);
+            await this.saveProfile(false);
             this.incrementWizard();
             break;
           case "ProfessionalDevelopment":
@@ -252,6 +252,16 @@ export default defineComponent({
         let message = "Information saved. If you save and exit, you can resume your application later.";
         if (exit) message = "Information saved. You can resume your application later.";
         this.alertStore.setSuccessAlert(message);
+        console.log(
+          "user info set" +
+            {
+              firstName: this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.profile.form.inputs.legalFirstName.id],
+              lastName: this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.profile.form.inputs.legalLastName.id],
+              email: this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.profile.form.inputs.email.id],
+              phone: this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.profile.form.inputs.primaryContactNumber.id],
+              dateOfBirth: this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.profile.form.inputs.dateOfBirth.id],
+            },
+        );
 
         this.userStore.setUserInfo({
           firstName: this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.profile.form.inputs.legalFirstName.id],
@@ -260,6 +270,12 @@ export default defineComponent({
           phone: this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.profile.form.inputs.primaryContactNumber.id],
           dateOfBirth: this.wizardStore.wizardData[this.wizardStore.wizardConfig.steps.profile.form.inputs.dateOfBirth.id],
         });
+
+        //we should get the latest from getProfile and update the wizard. In case the wizard refreshes with stale profile data.
+        const userProfile = await getProfile();
+        if (userProfile !== null) {
+          this.userStore.setUserProfile(userProfile);
+        }
       }
     },
     printPage() {


### PR DESCRIPTION
## Title
https://eccbc.atlassian.net/browse/ECER-4532 

## Description

- Cause when user changed their address and then added / deleted education.
- We would initialize the wizard after saving the draft  
![image](https://github.com/user-attachments/assets/ea073914-8530-4629-bfaf-f47737d9f8dc)

- When we initialize wizard we set the address information from userProfile (Which would not be updated) Hence resetting address to null on future steps. 
![image](https://github.com/user-attachments/assets/aff45196-f27a-41d7-9d27-e8d2f8086923)


Solution
- after saving profile during the application, we need to refresh our userProfile. 
- also added loading spinner to prevent user from going forward until we save profile and update userProfile. 

Additional Fixes 
- Province would be set to British Columbia, however user would be unable to proceed. Small fix to use province code instead of province name. 

## Checklist
- [ ] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Initially, province would be set to British Columbia which is caught by validation
![image](https://github.com/user-attachments/assets/a88a14d3-7c45-40bd-8c67-5d9a8457f7a0)
![image](https://github.com/user-attachments/assets/1dd54bbd-d04f-432b-9bd0-19b248109d7a)
After fix we set it to province code
![image](https://github.com/user-attachments/assets/7f0f4c84-cf59-4b1b-9185-439d4e771487)


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.