### PR TITLE
ECER-3091: Add validation to education form when application is ECE Assistant + Renewal type

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
@@ -41,10 +41,10 @@
               item-value="countryId"
               :rules="[
                 Rules.required('Select your country', 'countryId'),
-                (value) =>
-                  !isDraftApplicationAssistantRenewal ||
-                  value?.countryId === configStore.canada?.countryId ||
-                  'New course must be part of a recognized program',
+                Rules.conditionalWrapper(
+                  isDraftApplicationAssistantRenewal,
+                  (value: Country) => value?.countryId === configStore.canada?.countryId || 'New course must be part of a recognized program',
+                ),
               ]"
               @update:modelValue="onCountryChange"
               return-object
@@ -82,10 +82,11 @@
               v-model="postSecondaryInstitution"
               :rules="[
                 Rules.required('Select your post secondary institution', 'id'),
-                () =>
-                  !isDraftApplicationAssistantRenewal ||
-                  recognizedPostSecondaryInstitution !== 'NotRecognized' ||
-                  'New course must be part of a recognized program at one of the schools listed',
+                Rules.conditionalWrapper(
+                  isDraftApplicationAssistantRenewal,
+                  () =>
+                    recognizedPostSecondaryInstitution !== 'NotRecognized' || 'New course must be part of a recognized program at one of the schools listed',
+                ),
               ]"
               return-object
             ></v-select>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
@@ -39,7 +39,13 @@
               v-model="country"
               item-title="countryName"
               item-value="countryId"
-              :rules="[Rules.required('Select your country', 'countryId')]"
+              :rules="[
+                Rules.required('Select your country', 'countryId'),
+                (value) =>
+                  !isDraftApplicationAssistantRenewal ||
+                  value?.countryId === configStore.canada?.countryId ||
+                  'New course must be part of a recognized program',
+              ]"
               @update:modelValue="onCountryChange"
               return-object
             ></v-select>
@@ -74,7 +80,13 @@
               item-title="name"
               item-value="id"
               v-model="postSecondaryInstitution"
-              :rules="[Rules.required('Select your post secondary institution', 'id')]"
+              :rules="[
+                Rules.required('Select your post secondary institution', 'id'),
+                () =>
+                  !isDraftApplicationAssistantRenewal ||
+                  recognizedPostSecondaryInstitution !== 'NotRecognized' ||
+                  'New course must be part of a recognized program at one of the schools listed',
+              ]"
               return-object
             ></v-select>
           </v-col>


### PR DESCRIPTION
## Description

- Added validation

## Related Jira Issue(s)

- [ECER-3091](https://eccbc.atlassian.net/browse/ECER-3091)

## Checklist
- [X] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
<img width="815" alt="Screenshot 2025-03-31 at 1 51 22 PM" src="https://github.com/user-attachments/assets/a84f32c6-de81-4313-961e-5615f296907f" />
<img width="662" alt="Screenshot 2025-03-31 at 1 51 28 PM" src="https://github.com/user-attachments/assets/58442f18-b2e9-4086-bbc5-a2d222baac56" />


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.