### PR TITLE
ECER-4365: Do not set comprehensive report received flag from portal (REWORK)

### DIFF
--- a/src/ECER.Resources.Documents/Applications/ApplicationChildren/Transcripts.cs
+++ b/src/ECER.Resources.Documents/Applications/ApplicationChildren/Transcripts.cs
@@ -115,8 +115,6 @@ internal sealed partial class ApplicationRepository
         transcript.ecer_iwishtoapplyforafeewaiver = false;
         transcript.ecer_ihavesubmittedanapplicationtobcits = false;
         transcript.ecer_ECERegistryalreadyhasmyComprehensiveReport = true;
-
-        transcript.ecer_ComprehensiveEvaluationReportReceived = true;
       }
 
     }


### PR DESCRIPTION
## Description

- Do not set comprehensive report received flag from portal

## Related Jira Issue(s)

- [ECER-4365](https://eccbc.atlassian.net/browse/ECER-4365)

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.