### PR TITLE
ECER-3350 removing duplicate work experience reference requirements w…

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEAssistantRequirements.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEAssistantRequirements.vue
@@ -66,7 +66,6 @@
         <li>Can speak to your ability to educate and care for young children</li>
         <li>Has known you for at least 6 months</li>
         <li>Is not your relative, partner, spouse or yourself</li>
-        <li>Is not the same person as your work experience reference</li>
       </ul>
       <br />
       <p>We recommend the person is a certified ECE who has directly observed you working with young children.</p>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEIteRegistrantRequirements.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEIteRegistrantRequirements.vue
@@ -66,7 +66,6 @@
         <li>Can speak to your ability to educate and care for young children</li>
         <li>Has known you for at least 6 months</li>
         <li>Is not your relative, partner, spouse or yourself</li>
-        <li>Is not the same person as your work experience reference</li>
       </ul>
       <br />
       <p>We recommend the person is a certified ECE who has directly observed you working with young children.</p>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEOneYearRenewalRequirements.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEOneYearRenewalRequirements.vue
@@ -62,7 +62,7 @@
         <li>Can speak to your ability to educate and care for young children</li>
         <li>Has known you for at least 6 months</li>
         <li>Is not your relative, partner, spouse or yourself</li>
-        <li>Is not the same person as your work experience reference</li>
+        <li v-if="expired">Is not the same person as your work experience reference</li>
       </ul>
       <p>We recommend the person is a certified ECE who has directly observed you working with young children.</p>
     </div>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECESneRegistrantRequirements.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECESneRegistrantRequirements.vue
@@ -66,7 +66,6 @@
         <li>Can speak to your ability to educate and care for young children</li>
         <li>Has known you for at least 6 months</li>
         <li>Is not your relative, partner, spouse or yourself</li>
-        <li>Is not the same person as your work experience reference</li>
       </ul>
       <br />
       <p>We recommend the person is a certified ECE who has directly observed you working with young children.</p>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReference.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReference.vue
@@ -12,7 +12,7 @@
       <br />
       <p>We recommend the person is a certified ECE who has directly observed you working with young children.</p>
       <br />
-      <p v-if="applicationStore.isDraftCertificateTypeFiveYears">
+      <p v-if="hasWorkExperienceReferenceStep">
         The person
         <strong>cannot</strong>
         be any of your work experience references.
@@ -149,6 +149,14 @@ export default defineComponent({
         }
       }
 
+      return false;
+    },
+    hasWorkExperienceReferenceStep() {
+      this.wizardStore.steps.some((step) => {
+        if (step.stage === "WorkReferences") {
+          return true;
+        }
+      });
       return false;
     },
   },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReference.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceCharacterReference.vue
@@ -12,7 +12,7 @@
       <br />
       <p>We recommend the person is a certified ECE who has directly observed you working with young children.</p>
       <br />
-      <p v-if="hasWorkExperienceReferenceStep">
+      <p v-if="wizardStore.hasStep('WorkReferences')">
         The person
         <strong>cannot</strong>
         be any of your work experience references.
@@ -149,14 +149,6 @@ export default defineComponent({
         }
       }
 
-      return false;
-    },
-    hasWorkExperienceReferenceStep() {
-      this.wizardStore.steps.some((step) => {
-        if (step.stage === "WorkReferences") {
-          return true;
-        }
-      });
       return false;
     },
   },

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/wizard.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/store/wizard.ts
@@ -39,6 +39,11 @@ export const useWizardStore = defineStore("wizard", {
     currentStepStage(state): ApplicationStage | ReferenceStage | RenewStage {
       return this.steps[state.step - 1].stage;
     },
+    hasStep() {
+      return (step: ApplicationStage | ReferenceStage | RenewStage) => {
+        return this.steps.some((s) => s.stage === step);
+      };
+    },
   },
   actions: {
     async initializeWizard(wizard: Wizard, draftApplication: Components.Schemas.DraftApplication): Promise<void> {


### PR DESCRIPTION


## Title
https://eccbc.atlassian.net/jira/software/c/projects/ECER/boards/16?assignee=712020%3A18f8a1f8-9f58-4ec4-a786-ce49c3498dc3&selectedIssue=ECER-3350

## Description

- Removing work experience duplicate requirements from character references if flow does not have a work experience requirements. 
- simplified showing the requirement on the character reference page. We check to see if the flow has work experience requirement. 
- removed from ITE, SNE, EceAssistant, OneYearRenewalFlow for non expired applications. 

## Related Jira Issue(s)

- ECER-{###}
- etc.

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.