### PR TITLE
ecer-4837 transcript status option no need for translation if school …

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/inputs/EceEducation.vue
@@ -80,6 +80,7 @@
               item-title="name"
               item-value="id"
               v-model="postSecondaryInstitution"
+              @update:modelValue="onPostSecondaryInstitutionChange"
               :rules="[
                 Rules.required('Select an educational institution', 'id'),
                 Rules.conditionalWrapper(
@@ -241,6 +242,7 @@
             value="OfficialTranscriptRequested"
           ></v-radio>
           <v-radio
+            v-if="!(recognizedPostSecondaryInstitution === 'Recognized' && province?.provinceId === configStore.britishColumbia?.provinceId)"
             label="My transcript needs English translation. I will ask my educational institution to send my transcript to me to be professionally translated."
             value="TranscriptWillRequireEnglishTranslation"
           ></v-radio>
@@ -651,11 +653,16 @@ export default defineComponent({
     onProvinceChange() {
       this.postSecondaryInstitution = undefined;
       this.school = "";
+      this.transcriptStatusOption = undefined;
     },
     onCountryChange() {
       this.province = undefined;
       this.postSecondaryInstitution = undefined;
       this.school = "";
+      this.transcriptStatusOption = undefined;
+    },
+    onPostSecondaryInstitutionChange() {
+      this.transcriptStatusOption = undefined;
     },
     handleCancel() {
       // Change mode to education list


### PR DESCRIPTION
…is recognized + in BC

---
name: Pull Request Template
about: Template for creating pull requests
---

## Title
https://eccbc.atlassian.net/browse/ECER-4837 

## Description

- if user chooses a school that is recognized and in BC they should not have the option say they require translation. 
- on change of fields that might determine whether a school is recognized or not, we wipe out the transcriptStatusOption to ensure invalid data doesn't remain. 

## Related Jira Issue(s)

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

BC School recognized school shows two options 

![image](https://github.com/user-attachments/assets/2859c726-eb13-4be0-b019-44852a4adb43)
![image](https://github.com/user-attachments/assets/0df38564-3bf7-4c42-a15c-70986ac97ccc)

BC unrecognized school "other" 
We see the additional 3rd option and our previous selection was wiped out
![image](https://github.com/user-attachments/assets/ad166544-cd65-4413-8a1d-5e32d01637f2)

Out of Canada or unrecognized school in other provinces we show 3 options.
![image](https://github.com/user-attachments/assets/e5622cba-81c1-412e-af0e-54fc73827d4a)





## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.