### PR TITLE
Stories/ecer 4436

### DIFF
--- a/src/ECER.Tests/Integration/RegistryApi/CertificationTests.cs
+++ b/src/ECER.Tests/Integration/RegistryApi/CertificationTests.cs
@@ -126,7 +126,26 @@ public class CertificationsTests : RegistryPortalWebAppScenarioBase
 
     var Certifications = await CertificationsResponse.ReadAsJsonAsync<Clients.RegistryPortal.Server.Certifications.CertificationLookupResponse[]>().ShouldNotBeNull();
     Certifications.ShouldNotBeEmpty();
-    Certifications.ShouldHaveSingleItem();
     Certifications[0].RegistrationNumber.ShouldBe(certificateNumber);
   }
+  [Fact]
+  public async Task CertificationsLookup_ByRegistrant_ReturnsCertifications()
+  {
+    var faker = new Faker("en_CA");
+
+    var user = this.Fixture.AuthenticatedBcscUser;
+
+    var certificationLookupRequest = new CertificationLookupRequest(faker.Random.Word()) { FirstName=user.FirstName,LastName=user.LastName };
+    var CertificationsResponse = await Host.Scenario(_ =>
+    {
+      _.Post.Json(certificationLookupRequest).ToUrl($"/api/certifications/lookup");
+      _.StatusCodeShouldBeOk();
+    });
+
+    var Certifications = await CertificationsResponse.ReadAsJsonAsync<Clients.RegistryPortal.Server.Certifications.CertificationLookupResponse[]>().ShouldNotBeNull();
+    Certifications.ShouldNotBeEmpty();
+    Certifications.Length.ShouldBeGreaterThan(1);
+
+  }
+  
 }


### PR DESCRIPTION
## Title
ECER-4436: Multiple active certificates now appear in public lookup page

## Description
- Manager Layer adjusted to return multiple active certifications in public lookup api
- Automated tests added to cover new implementation

## Related Jira Issue(s)

- ECER-4436
- etc.

## Checklist
- [ ] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
<img width="911" alt="image" src="https://github.com/user-attachments/assets/6bb3111e-1408-4fa0-ba7f-540136db90ee" />
