### PR TITLE
ecer-5081 bug fix simplified learn more renewal flow

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/CertificationRequirements.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/CertificationRequirements.vue
@@ -2,21 +2,9 @@
   <v-container>
     <Breadcrumb :items="items" />
     <div v-for="certificationType in certificationTypes" :key="certificationType">
-      <template v-if="certificationType === CertificationType.ECE_ASSISTANT">
-        <ECEAssistantRenewalRequirements v-if="isRenewal" />
-        <ECEAssistantLaborMobilityRequirements v-else-if="isLaborMobility" />
-        <ECEAssistantRequirements v-else />
-      </template>
-      <template v-if="certificationType === CertificationType.ONE_YEAR">
-        <ECEOneYearRenewalRequirements v-if="isRenewal" />
-        <ECEOneYearLaborMobilityRequirements v-else-if="isLaborMobility" />
-        <ECEOneYearRequirements v-else />
-      </template>
-      <template v-if="certificationType === CertificationType.FIVE_YEAR">
-        <ECEFiveYearRenewalRequirements v-if="isRenewal" />
-        <ECEFiveYearLaborMobilityRequirements v-else-if="isLaborMobility" />
-        <ECEFiveYearRequirements v-else />
-      </template>
+      <ECEAssistantRenewalRequirements v-if="certificationType === CertificationType.ECE_ASSISTANT" />
+      <ECEOneYearRenewalRequirements v-if="certificationType === CertificationType.ONE_YEAR" />
+      <ECEFiveYearRenewalRequirements v-if="certificationType === CertificationType.FIVE_YEAR" />
     </div>
   </v-container>
 </template>
@@ -26,29 +14,17 @@ import { defineComponent, type PropType } from "vue";
 
 import Breadcrumb from "@/components/Breadcrumb.vue";
 import ECEAssistantRenewalRequirements from "@/components/ECEAssistantRenewalRequirements.vue";
-import ECEAssistantLaborMobilityRequirements from "@/components/ECEAssistantLaborMobilityRequirements.vue";
-import ECEOneYearLaborMobilityRequirements from "@/components/ECEOneYearLaborMobilityRequirements.vue";
-import ECEFiveYearLaborMobilityRequirements from "@/components/ECEFiveYearLaborMobilityRequirements.vue";
-import ECEAssistantRequirements from "@/components/ECEAssistantRequirements.vue";
 import ECEFiveYearRenewalRequirements from "@/components/ECEFiveYearRenewalRequirements.vue";
-import ECEFiveYearRequirements from "@/components/ECEFiveYearRequirements.vue";
 import ECEOneYearRenewalRequirements from "@/components/ECEOneYearRenewalRequirements.vue";
-import ECEOneYearRequirements from "@/components/ECEOneYearRequirements.vue";
 import type { Components } from "@/types/openapi";
 import { CertificationType } from "@/utils/constant";
 
 export default defineComponent({
   name: "CertificationTypeRequirements",
   components: {
-    ECEAssistantRequirements,
-    ECEOneYearRequirements,
-    ECEFiveYearRequirements,
     ECEAssistantRenewalRequirements,
     ECEOneYearRenewalRequirements,
     ECEFiveYearRenewalRequirements,
-    ECEAssistantLaborMobilityRequirements,
-    ECEOneYearLaborMobilityRequirements,
-    ECEFiveYearLaborMobilityRequirements,
     Breadcrumb,
   },
   props: {
@@ -56,55 +32,25 @@ export default defineComponent({
       type: Array as PropType<Components.Schemas.CertificationType[]>,
       required: true,
     },
-    applicationType: {
-      type: String as PropType<Components.Schemas.ApplicationTypes>,
-      required: true,
-    },
   },
   setup: () => {
     return { CertificationType };
   },
-  data(props) {
-    const items = props.isRenewal
-      ? [
-          {
-            title: "Home",
-            disabled: false,
-            href: "/",
-          },
-          {
-            title: "Renew",
-            disabled: true,
-            href: "/application/certification/requirements",
-          },
-        ]
-      : [
-          {
-            title: "Home",
-            disabled: false,
-            href: "/",
-          },
-          {
-            title: "Application types",
-            disabled: false,
-            href: "/application/certification",
-          },
-          {
-            title: "Requirements",
-            disabled: true,
-            href: "/application/certification/requirements",
-          },
-        ];
-
-    return { items };
-  },
-  computed: {
-    isRenewal() {
-      return this.applicationType === "Renewal";
-    },
-    isLaborMobility() {
-      return this.applicationType === "LabourMobility";
-    },
+  data() {
+    return {
+      items: [
+        {
+          title: "Home",
+          disabled: false,
+          href: "/",
+        },
+        {
+          title: "Renew",
+          disabled: true,
+          href: "/application/certification/requirements",
+        },
+      ],
+    };
   },
 });
 </script>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/RenewCard.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/RenewCard.vue
@@ -119,7 +119,7 @@ export default defineComponent({
     handleLearnAboutRenewalRequirementsClicked() {
       this.router.push({
         name: "certification-requirements",
-        query: { certificationTypes: this.certificationStore.latestCertificationTypes, isRenewal: "true" },
+        query: { certificationTypes: this.certificationStore.latestCertificationTypes },
       });
     },
     handleRenewClicked() {

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/router.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/router.ts
@@ -194,7 +194,7 @@ const router = createRouter({
           certificationTypes = [certificationTypes];
         }
 
-        return { certificationTypes: certificationTypes ?? [], applicationType: query.applicationType ?? "New" };
+        return { certificationTypes: certificationTypes ?? [] };
       },
     },
     {


### PR DESCRIPTION
---
name: Pull Request Template
about: Template for creating pull requests
---

Bug was that the user could click into application-requirements when they were trying to learn more during the renewal. 

## Title
https://eccbc.atlassian.net/browse/ECER-5081

## Description

- Simplified certification-requirements page. Confirmed this was only used for renewal flows before a user is able to renew. Requirements are always the same so we didn't need the additional checks for Labour Mobility + New applications. 

## Related Jira Issue(s)

- ECER-{###}
- etc.

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.
<img width="1466" height="856" alt="image" src="https://github.com/user-attachments/assets/17394fa8-9bd8-4c07-9d33-6d85a034cd12" />


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.