### PR TITLE
ecer-5262 post-basic bug. should not be pre-checked for new/registran…

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ApplicationRequirements.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ApplicationRequirements.vue
@@ -17,7 +17,7 @@
     </template>
 
     <!-- Labor Mobility -->
-    <template v-if="applicationStore.isDraftApplicationLaborMobility">
+    <template v-else-if="applicationStore.isDraftApplicationLaborMobility">
       <ECEAssistantLaborMobilityRequirements v-if="applicationStore.isDraftCertificateTypeEceAssistant" />
       <ECEOneYearLaborMobilityRequirements v-if="applicationStore.isDraftCertificateTypeOneYear" />
       <ECEFiveYearLaborMobilityRequirements
@@ -145,6 +145,9 @@ export default defineComponent({
             draftApplication: { certificationTypes: ["FiveYears", ...this.specializationSelection] },
           });
         }
+        this.router.push({ name: "declaration" });
+      } else if (this.applicationStore.isDraftApplicationRenewal) {
+        //for renewal applications we do not need to perform any additional checks. The certification types should be correctly set in the draft application store.
         this.router.push({ name: "declaration" });
       } else {
         let currentTypes = this.applicationStore.draftApplication.certificationTypes || [];

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEFiveYearRegistrantRequirements.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEFiveYearRegistrantRequirements.vue
@@ -51,7 +51,7 @@
   </v-row>
   <v-row>
     <v-col cols="12">
-      <SpecializedCertificationOptions ref="SpecializedCertificationOptions" :pre-selected="['Ite', 'Sne']" />
+      <SpecializedCertificationOptions ref="SpecializedCertificationOptions" />
     </v-col>
   </v-row>
 </template>

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEFiveYearRequirements.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/ECEFiveYearRequirements.vue
@@ -82,7 +82,7 @@
   </v-row>
   <v-row>
     <v-col cols="12">
-      <SpecializedCertificationOptions :pre-selected="['Ite', 'Sne']" />
+      <SpecializedCertificationOptions />
     </v-col>
   </v-row>
 </template>


### PR DESCRIPTION
…t applications. Renew option should clone the correct certificate types over

---
name: Pull Request Template
about: Template for creating pull requests
---

## Title
https://eccbc.atlassian.net/browse/ECER-5286 

## Description

- changed logic for renewal applications to not wipe out ITE + SNE certifications
- no longer pre-selecting SNE + ITE when applying (unless we are in labor mobility) 
-
## Related Jira Issue(s)



## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

Brand new and registrant 5 year the selection is unchecked
 
<img width="975" height="468" alt="image" src="https://github.com/user-attachments/assets/e34fd23e-2b3a-4aae-ab49-cdbfe43e68d7" />

Renew application does not show certification pathway
Labour Mobility will be prechecked if eligible
 
<img width="975" height="587" alt="image" src="https://github.com/user-attachments/assets/8a107870-b5c0-4043-b4c5-1af954111aa4" />


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.