### PR TITLE
ecer-5739 fix for potential bug where user would navigate to icra-eli…

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Declaration.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/Declaration.vue
@@ -101,12 +101,29 @@ export default defineComponent({
     };
   },
   mounted() {
+    //check if user has a draftApplication in progress (They should not be coming to this screen vice versa)
+    if (
+      (this.stream === "Eligibility" && this.applicationStore.hasDraftApplication) ||
+      (this.stream === "Application" && this.icraStore.hasDraftIcraEligibility)
+    ) {
+      console.warn(
+        `User should not be trying to apply for ${this.stream === "Eligibility" ? "icra eligibility" : "an application"} if they have a ${this.stream === "Eligibility" ? "draft application" : "draft icra eligibility"} in progress. Sending user back to home page`,
+      );
+      this.router.push("/");
+    }
     this.checkboxValue = this.applicationStore.draftApplication.signedDate ? true : false;
     this.name = this.userStore.fullName;
-    this.date =
-      this.applicationStore.hasDraftApplication && this.applicationStore?.draftApplication?.signedDate
-        ? formatDate(this.applicationStore?.draftApplication?.signedDate, "yyyy-MM-dd")
-        : formatDate(DateTime.now().toString(), "yyyy-MM-dd");
+    if (this.stream === "Application") {
+      this.date =
+        this.applicationStore.hasDraftApplication && this.applicationStore?.draftApplication?.signedDate
+          ? formatDate(this.applicationStore?.draftApplication?.signedDate, "yyyy-MM-dd")
+          : formatDate(DateTime.now().toString(), "yyyy-MM-dd");
+    } else if (this.stream === "Eligibility") {
+      this.date =
+        this.icraStore.hasDraftIcraEligibility && this.icraStore?.draftIcraEligibility?.signedDate
+          ? formatDate(this.icraStore?.draftIcraEligibility?.signedDate, "yyyy-MM-dd")
+          : formatDate(DateTime.now().toString(), "yyyy-MM-dd");
+    }
   },
   methods: {
     async continueClick() {


### PR DESCRIPTION
…giblity declaration screen with a draft application and see the incorrect date

---
name: Pull Request Template
about: Template for creating pull requests
---

## Title
https://eccbc.atlassian.net/browse/ECER-5739?search_id=1008cf91-604e-4f93-aaf9-604dc923c3cd

## Description

- Change 1 detailed description
- Change 2 detailed description
- etc.

## Related Jira Issue(s)

- ECER-{###}
- etc.

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

re: https://eccbc.atlassian.net/browse/ECER-5739?search_id=1008cf91-604e-4f93-aaf9-604dc923c3cd 
Date issue
 
I don't think it's a timezone related issue. 
we send a string to the backend when we create a draftApplication + eligibilityAssessment like "2025-01-15" that will get saved. 
 
dynamics then sends us back a string without a timezone, and I don't think this gets converted when we call .toISODate with luxon. 
 
I was able to recreate something "quite janky" 
 
Where a user has a draftApplication with a signedDate say tomorrow Jan 15, 2025
 
and then they navigate to the icraEligibility declaration screen. 
http://localhost:5121/icra-eligibility/declaration
 
they will see Jan 15, 2025 instead of Jan 13, 2025 (today)
 
 
<img width="1896" height="862" alt="image" src="https://github.com/user-attachments/assets/51642091-f3c0-4521-96a2-146b1bcf3beb" />

 
------------------------------------
 
Issue is this code in declaration.vue. 
 
the fix is commented out. Where we will set the date depending which "stream" they are coming in from. 
 
I think another fix to implement would be to actually prevent someone from coming to the declaration screen for icraEligibilityAssessment when they have a draftApplication 
 
And vice versa...
 
JSON
mounted() {
    this.checkboxValue = this.applicationStore.draftApplication.signedDate ? true : false;
    this.name = this.userStore.fullName;
    // if (this.stream === "Application") {
    //   this.date =
    //     this.applicationStore.hasDraftApplication && this.applicationStore?.draftApplication?.signedDate
    //       ? formatDate(this.applicationStore?.draftApplication?.signedDate, "yyyy-MM-dd")
    //       : formatDate(DateTime.now().toString(), "yyyy-MM-dd");
    // } else if (this.stream === "Eligibility") {
    //   this.date =
    //     this.icraStore.hasDraftIcraEligibility && this.icraStore?.draftIcraEligibility?.signedDate
    //       ? formatDate(this.icraStore?.draftIcraEligibility?.signedDate, "yyyy-MM-dd")
    //       : formatDate(DateTime.now().toString(), "yyyy-MM-dd");
    // }
    this.date =
      this.applicationStore.hasDraftApplication && this.applicationStore?.draftApplication?.signedDate
        ? formatDate(this.applicationStore?.draftApplication?.signedDate, "yyyy-MM-dd")
        : formatDate(DateTime.now().toString(), "yyyy-MM-dd");
  },
 

## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.