### PR TITLE
ecer-5798 version 2. Save to NewDescriptiveProgramName field only if …

### DIFF
--- a/src/ECER.Resources.Documents/Programs/ProgramRepository.cs
+++ b/src/ECER.Resources.Documents/Programs/ProgramRepository.cs
@@ -108,6 +108,9 @@ internal sealed class ProgramRepository : IProgramRepository
       var existing = context.ecer_ProgramSet.SingleOrDefault(p => p.ecer_ProgramId == ecerProgram.ecer_ProgramId);
       if (existing == null) throw new InvalidOperationException($"ecer_Program '{ecerProgram.ecer_ProgramId}' not found");
 
+      //check for existing values, if they are the same do not map. 
+      ecerProgram.ecer_NewDescriptiveProgramName = existing.ecer_DescriptiveProgramName == ecerProgram.ecer_NewDescriptiveProgramName ? string.Empty : ecerProgram.ecer_NewDescriptiveProgramName;
+
       ecerProgram.StatusCode = existing.StatusCode ?? defaultStatus;
       if (string.IsNullOrWhiteSpace(ecerProgram.ecer_Name))
       {


### PR DESCRIPTION
…it differs from the original DescriptiveProgramName field.

---
name: Pull Request Template
about: Template for creating pull requests
---

## Title
https://eccbc.atlassian.net/browse/ECER-5798 

## Description

- version 2 of the same issue mapping original + newFields to make sure they are not the same. This seems less verbose. 

## Related Jira Issue(s)

- ECER-{###}
- etc.

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.
Saving with a different programName saves to Dynamics
<img width="1680" height="65" alt="image" src="https://github.com/user-attachments/assets/c9b1146b-75a9-4a62-bc51-090a7066669e" />
Trying to save with the same name test program
<img width="729" height="627" alt="image" src="https://github.com/user-attachments/assets/3383a180-292e-49a7-977a-9e75b18925c6" />
will not save to dynamics
<img width="1505" height="88" alt="image" src="https://github.com/user-attachments/assets/82d386e3-993b-4c67-b3c5-d842a6cc9ac5" />


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.