### PR TITLE
Icra manage page showing references were received when they were stil…

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/IcraEligibilityManageWorkExperienceReferences.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/IcraEligibilityManageWorkExperienceReferences.vue
@@ -138,7 +138,7 @@ import Loading from "./Loading.vue";
 import { useLoadingStore } from "@/store/loading";
 
 export default defineComponent({
-  name: "ManageWorkExperienceReferenceList",
+  name: "IcraEligibilityManageWorkExperienceReferenceList",
   components: { Breadcrumb, Callout, Loading },
   props: {
     icraEligibilityId: {
@@ -208,13 +208,12 @@ export default defineComponent({
     statusText(reference: Components.Schemas.EmploymentReferenceStatus) {
       switch (reference.status) {
         case "ICRAEligibilitySubmitted":
+        case "Draft":
           return "Not yet received";
         case "ApplicationSubmitted":
         case "Approved":
-        case "Draft":
         case "EligibilityResponseSubmitted":
         case "InProgress":
-
         case "Submitted":
         case "UnderReview":
         case "WaitingforResponse":

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/IcraEligibilitySummary.vue
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/components/IcraEligibilitySummary.vue
@@ -272,7 +272,8 @@ export default defineComponent({
           (reference) => {
             if (
               reference.status === "ICRAEligibilitySubmitted" ||
-              reference.status === "WaitingforResponse"
+              reference.status === "WaitingforResponse" ||
+              reference.status === "Draft"
             ) {
               return true;
             }


### PR DESCRIPTION
…l in draft mode waiting to be sent out

---
name: Pull Request Template
about: Template for creating pull requests
---

## Title
no ticket, this was flagged while doing QA testing

## Description

- Issue happened when a Icra eligibility application was submitted. 
- there can be a gap in time where the work experience status is still in Draft mode before an email is sent out and the frontend would consider this as having all references received. 
- Changed logic to say that work experience references that are still in draft mode are assumed to not have been received. 

## Related Jira Issue(s)

- ECER-{###}
- etc.

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

<img width="1342" height="430" alt="image" src="https://github.com/user-attachments/assets/dd3d0ae7-856b-43ea-afae-33d116502682" />


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.