### PR TITLE
ECER-5772, ECER-5597, ECER-5733: Add All Program Profiles page and related components

### DIFF
--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/api/program.ts
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/api/program.ts
@@ -70,7 +70,7 @@ const updateCourse = async (
   };
   const body: Paths.CoursePut.RequestBody = {
     courses: courses,
-    type : "ProgramProfile"
+    type: "ProgramProfile",
   };
 
   return apiResultHandler.execute<string | null | undefined>({

--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/Breadcrumb.vue
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/Breadcrumb.vue
@@ -72,6 +72,21 @@ export default defineComponent({
           },
         ];
       }
+      if (this.route.name === "all-program-profiles") {
+        return [
+          { title: "Home", disabled: false, href: "/" },
+          {
+            title: "Program profiles",
+            disabled: false,
+            href: "/program-profiles",
+          },
+          {
+            title: "All program profiles",
+            disabled: true,
+            href: "/all-program-profiles",
+          },
+        ];
+      }
       if (this.route.name === "initiate-program-update") {
         return [
           { title: "Home", disabled: false, href: "/" },

--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/ProgramProfilesList.stories.ts
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/ProgramProfilesList.stories.ts
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from "@storybook/vue3";
+import ProgramProfilesList from "./ProgramProfilesList.vue";
+import type { Components } from "@/types/openapi";
+
+const meta: Meta<typeof ProgramProfilesList> = {
+  title: "Components/ProgramProfilesList",
+  component: ProgramProfilesList,
+  tags: ["autodocs"],
+  argTypes: {
+    programs: {
+      description: "Array of program objects to display",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ProgramProfilesList>;
+
+const baseProgram: Components.Schemas.Program = {
+  id: "c21d913a-e2ec-f011-8406-7ced8d050c09",
+  portalStage: null as unknown as string,
+  createdOn: "2026-01-08T22:34:44Z",
+  name: "Early Childhood Education Certificate",
+  postSecondaryInstituteName: "Selkirk College",
+  startDate: "2026-01-08T00:00:00",
+  endDate: "2026-01-21T00:00:00",
+  programTypes: ["Basic"],
+  courses: [],
+  status: "Approved",
+};
+
+//   This story demonstrates that programs with start dates before 2023 are filtered out.
+//   The list includes:
+//   - 2 programs from 2022 (should NOT appear)
+//   - 1 program from 2021 (should NOT appear)
+//   - 2 programs from 2023 (should appear)
+//   - 1 program from 2024 (should appear)
+//   Expected result: Only 3 programs should be visible (2023 and 2024 programs)
+export const FiltersOut2022AndOlderProfiles: Story = {
+  args: {
+    programs: [
+      // These should NOT show up (2022 and earlier)
+      {
+        ...baseProgram,
+        id: "program-2022-a",
+        name: "2022 Program A - Should NOT Display",
+        startDate: "2022-09-01T00:00:00",
+        status: "Approved",
+      },
+      {
+        ...baseProgram,
+        id: "program-2022-b",
+        name: "2022 Program B - Should NOT Display",
+        startDate: "2022-01-15T00:00:00",
+        status: "Draft",
+      },
+      {
+        ...baseProgram,
+        id: "program-2021",
+        name: "2021 Program - Should NOT Display",
+        startDate: "2021-06-01T00:00:00",
+        status: "Approved",
+      },
+      // These SHOULD show up (2023 and later)
+      {
+        ...baseProgram,
+        id: "program-2023-a",
+        name: "2023 Program A - Should Display",
+        startDate: "2023-01-01T00:00:00",
+        status: "Approved",
+      },
+      {
+        ...baseProgram,
+        id: "program-2023-b",
+        name: "2023 Program B - Should Display",
+        startDate: "2023-09-15T00:00:00",
+        status: "UnderReview",
+      },
+      {
+        ...baseProgram,
+        id: "program-2024",
+        name: "2024 Program - Should Display",
+        startDate: "2024-03-01T00:00:00",
+        status: "Approved",
+      },
+    ],
+  },
+};

--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/ProgramProfilesList.vue
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/ProgramProfilesList.vue
@@ -1,0 +1,44 @@
+<template>
+  <v-row>
+    <v-col
+      v-for="(program, index) in filteredPrograms"
+      :key="getProgramKey(program, index)"
+      cols="12"
+      md="6"
+      lg="4"
+    >
+      <ProgramProfileCard :program="program" @withdrawn="$emit('withdrawn')" />
+    </v-col>
+  </v-row>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from "vue";
+import ProgramProfileCard from "@/components/program-profile/ProgramProfileCard.vue";
+import type { Components } from "@/types/openapi";
+import { shouldDisplayProfile } from "@/utils/functions";
+
+export default defineComponent({
+  name: "ProgramProfilesList",
+  components: {
+    ProgramProfileCard,
+  },
+  props: {
+    programs: {
+      type: Array as PropType<Components.Schemas.Program[]>,
+      required: true,
+    },
+  },
+  emits: ["withdrawn"],
+  computed: {
+    filteredPrograms(): Components.Schemas.Program[] {
+      return this.programs.filter(shouldDisplayProfile);
+    },
+  },
+  methods: {
+    getProgramKey(program: Components.Schemas.Program, index: number): string {
+      return program.id ?? `program-${index}`;
+    },
+  },
+});
+</script>

--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/pages/InitiateProgramUpdate.vue
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/pages/InitiateProgramUpdate.vue
@@ -17,54 +17,64 @@
     <div>
       <div>
         <v-row>
-            <v-col>
-              <div>
-                <svg width="36" height="4">
-                  <rect width="36" height="4" fill="#FFC72C" />
-                </svg>
-                <h2>{{ programTitle }}</h2>
-              </div>
-            </v-col>
+          <v-col>
+            <div>
+              <svg width="36" height="4">
+                <rect width="36" height="4" fill="#FFC72C" />
+              </svg>
+              <h2>{{ programTitle }}</h2>
+            </div>
+          </v-col>
         </v-row>
         <v-row>
-            <v-col cols="12">
-              <p>
-                Make updates to your program profile that do not affect program requirements or competencies (for example, start date, course name, etc.). 
-                You can indicate the date on which your changes come into effect.
-              </p>
-              <br />
-              <p>Review your program profile by clicking the button below and update any of the following:</p>
-              <br />
-              <ul class="ml-8">
-                  <li>Program name</li>
-                  <li>Program start date</li>
-                  <li>Course code</li>
-                  <li>Course name</li>
-                  <li>Course hours (Note: total hours and competency requirements for all areas of instruction must be met)</li>
-              </ul>           
-            </v-col>
+          <v-col cols="12">
+            <p>
+              Make updates to your program profile that do not affect program
+              requirements or competencies (for example, start date, course
+              name, etc.). You can indicate the date on which your changes come
+              into effect.
+            </p>
+            <br />
+            <p>
+              Review your program profile by clicking the button below and
+              update any of the following:
+            </p>
+            <br />
+            <ul class="ml-8">
+              <li>Program name</li>
+              <li>Program start date</li>
+              <li>Course code</li>
+              <li>Course name</li>
+              <li>
+                Course hours (Note: total hours and competency requirements for
+                all areas of instruction must be met)
+              </li>
+            </ul>
+          </v-col>
         </v-row>
 
         <Callout class="mt-3" type="warning">
           <div class="d-flex flex-column ga-3">
-              <h3>Need to make a change to a program?</h3>
-              <p>If your update will affect program requirements or competencies (for example, adding or removing courses), please 
-                <a @click="submitChangeRequest()">submit a change request</a> instead.</p>
-              <p></p>
-              <p>Learn more about program changes</p>
+            <h3>Need to make a change to a program?</h3>
+            <p>
+              If your update will affect program requirements or competencies
+              (for example, adding or removing courses), please
+              <a @click="submitChangeRequest()">submit a change request</a>
+              instead.
+            </p>
+            <p></p>
+            <p>Learn more about program changes</p>
           </div>
         </Callout>
-        <br /><br />
+        <br />
+        <br />
         <div v-if="program?.status != 'ChangeRequestInProgress'">
-          <v-btn  rounded="lg" 
-                  color="primary" 
-                  @click="initiateUpdate">Continue to program profile</v-btn>
+          <v-btn rounded="lg" color="primary" @click="initiateUpdate">
+            Continue to program profile
+          </v-btn>
         </div>
         <div v-else>
-          <div
-            v-if="showProgressMeter"
-            class="mt-8"
-          >
+          <div v-if="showProgressMeter" class="mt-8">
             <v-progress-circular
               class="mb-2"
               color="primary"
@@ -148,8 +158,8 @@ export default defineComponent({
       }
       return types;
     },
-    showProgressMeter(): boolean {    
-        return this.updateInProgress;
+    showProgressMeter(): boolean {
+      return this.updateInProgress;
     },
   },
   async mounted() {
@@ -185,7 +195,7 @@ export default defineComponent({
       }
     },
     async initiateUpdate() {
-      if (this.program != null){
+      if (this.program != null) {
         this.updateInProgress = true;
         const response = await initiateProgramChange(this.program);
         if (response.error) {
@@ -213,12 +223,12 @@ export default defineComponent({
     },
     submitChangeRequest() {
       this.router.push({
-        name: 'newMessage',
-          params: {
-            initialCategory: 'ProgramChangeRequest',
-          },
+        name: "newMessage",
+        params: {
+          initialCategory: "ProgramChangeRequest",
+        },
       });
-    }
+    },
   },
 });
 </script>

--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/pages/ProgramProfiles.vue
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/pages/ProgramProfiles.vue
@@ -13,149 +13,123 @@
 
     <Loading v-if="isLoading"></Loading>
 
-    <div>
+    <div v-else>
       <!-- Program profile review section - only shown when there are programs with Draft or UnderReview status -->
       <div v-if="programsRequiringReview.length > 0">
-        <v-row>
-          <v-col>
-            <ECEHeader title="Program profile review" />
-          </v-col>
-        </v-row>
-        <v-row>
-          <v-col cols="12">
-            <div class="d-flex flex-column ga-3 pb-5">
-              <p>
-                The program profile review process is conducted annually by the
-                ECE Registry to ensure requirements are met for continued
-                recognition in B.C.
-              </p>
-              <p class="font-weight-bold">
-                You will need to review your program profile for accuracy and to
-                ensure that courses meet the minimum hours for each of the
-                provincially-required areas of instruction.
-              </p>
-            </div>
-            <v-sheet color="support-surface-info " class="w-100 px-12 py-7">
-              <div class="text-support-border-info">
-                <h2 class="mb-3">Review process</h2>
-                <p>Click the "Review now" button to begin.</p>
-                <ol class="ml-8 pb-3">
-                  <li>
-                    Review the information we have for your program(s) and make
-                    changes if required.
-                  </li>
-                  <li>
-                    Confirm and submit the program profile to the ECE Registry.
-                    You will be asked to sign off on the changes as the final
-                    step.
-                  </li>
-                  <li>
-                    The ECE Registry will then proceed with their review as
-                    required.
-                  </li>
-                </ol>
+        <div v-if="!onlyChangeRequestInProgress">
+          <v-row>
+            <v-col>
+              <ECEHeader title="Program profile review" />
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col cols="12">
+              <div class="d-flex flex-column ga-3 pb-5">
                 <p>
-                  In some cases, the ECE Registry may request additional
-                  information about a program, particularly if changes were
-                  made.
+                  The program profile review process is conducted annually by
+                  the ECE Registry to ensure requirements are met for continued
+                  recognition in B.C.
                 </p>
                 <p class="font-weight-bold">
-                  You will be notified when the review process has been
-                  completed by the ECE Registry.
+                  You will need to review your program profile for accuracy and
+                  to ensure that courses meet the minimum hours for each of the
+                  provincially-required areas of instruction.
                 </p>
               </div>
-            </v-sheet>
-          </v-col>
-        </v-row>
+              <v-sheet color="support-surface-info " class="w-100 px-12 py-7">
+                <div class="text-support-border-info">
+                  <h2 class="mb-3">Review process</h2>
+                  <p>Click the "Review now" button to begin.</p>
+                  <ol class="ml-8 pb-3">
+                    <li>
+                      Review the information we have for your program(s) and
+                      make changes if required.
+                    </li>
+                    <li>
+                      Confirm and submit the program profile to the ECE
+                      Registry. You will be asked to sign off on the changes as
+                      the final step.
+                    </li>
+                    <li>
+                      The ECE Registry will then proceed with their review as
+                      required.
+                    </li>
+                  </ol>
+                  <p>
+                    In some cases, the ECE Registry may request additional
+                    information about a program, particularly if changes were
+                    made.
+                  </p>
+                  <p class="font-weight-bold">
+                    You will be notified when the review process has been
+                    completed by the ECE Registry.
+                  </p>
+                </div>
+              </v-sheet>
+            </v-col>
+          </v-row>
+        </div>
         <v-row>
           <v-col>
             <ECEHeader title="Program profiles requiring review" />
           </v-col>
         </v-row>
-        <v-row>
-          <v-col
-            v-for="(program, index) in programsRequiringReview"
-            :key="getProgramKey(program, index, 'review')"
-            cols="12"
-            md="6"
-            lg="4"
-          >
-            <ProgramProfileCard :program="program" @withdrawn="fetchPrograms" />
-          </v-col>
-        </v-row>
+        <ProgramProfilesList
+          :programs="programsRequiringReview"
+          @withdrawn="fetchPrograms"
+        />
       </div>
 
-      <div v-if="programsRequiringReview.length === 0">
-        <!-- Current program profiles section -->
-        <div v-if="filter === 'current'">
-          <v-row>
-            <v-col>
-              <ECEHeader title="Current program profiles" />
-            </v-col>
-          </v-row>
-        </div>
-        <div v-else>
-          <v-row>
-            <v-col>
-              <ECEHeader title="All program profiles" />
-            </v-col>
-          </v-row>
-          <v-row>
-            <v-col>
-              <p>
-                This page contains program profiles for your institution dating
-                back to {{ earliestProfileYear }}.
-              </p>
-            </v-col>
-          </v-row>
-        </div>
-      </div>
+      <!-- Current program profiles section -->
       <v-row>
-        <v-col
-          v-for="(program, index) in displayProgramProfiles"
-          :key="getProgramKey(program, index, 'current')"
-          cols="12"
-          md="6"
-          lg="4"
-        >
-          <ProgramProfileCard :program="program" @withdrawn="fetchPrograms" />
+        <v-col>
+          <ECEHeader title="Current program profiles" />
         </v-col>
       </v-row>
+      <ProgramProfilesList
+        :programs="currentProgramProfiles"
+        @withdrawn="fetchPrograms"
+      />
       <!-- Empty state -->
       <v-row
         v-if="
           programsRequiringReview.length === 0 &&
-          displayProgramProfiles.length === 0
+          currentProgramProfiles.length === 0
         "
       >
         <v-col cols="12">
           <p>No program profiles found.</p>
         </v-col>
       </v-row>
-      <div v-if="filter === 'current' && programsRequiringReview.length === 0">
-        <v-row>
-          <v-col>
-            <v-card variant="outlined" rounded="lg">
-              <v-btn-toggle v-model="filter" color="primary" mandatory>
-                <v-btn value="all">
-                  View all program profiles
-                  <v-icon size="large" icon="mdi-arrow-right" />
-                </v-btn>
-              </v-btn-toggle>
-            </v-card>
-          </v-col>
-        </v-row>
-      </div>
+      <v-row>
+        <v-col>
+          <div>
+            <v-btn
+              block
+              size="x-large"
+              variant="outlined"
+              color="primary"
+              @click="router.push('/all-program-profiles')"
+              class="force-full-content"
+            >
+              View all program profiles
+              <v-icon size="large" icon="mdi-arrow-right" />
+            </v-btn>
+          </div>
+        </v-col>
+      </v-row>
     </div>
   </PageContainer>
 </template>
 
 <script lang="ts">
 import { defineComponent } from "vue";
+import { DateTime } from "luxon";
 import PageContainer from "@/components/PageContainer.vue";
 import Loading from "@/components/Loading.vue";
 import Breadcrumb from "@/components/Breadcrumb.vue";
 import ProgramProfileCard from "@/components/program-profile/ProgramProfileCard.vue";
+import ProgramProfilesList from "@/components/ProgramProfilesList.vue";
 import { getPrograms } from "@/api/program";
 import { useLoadingStore } from "@/store/loading";
 import { useRouter } from "vue-router";
@@ -172,6 +146,7 @@ export default defineComponent({
     Loading,
     Breadcrumb,
     ProgramProfileCard,
+    ProgramProfilesList,
   },
   setup() {
     const loadingStore = useLoadingStore();
@@ -184,7 +159,6 @@ export default defineComponent({
       programCount: -1,
       page: 1,
       loading: true,
-      filter: "current",
     };
   },
   computed: {
@@ -196,22 +170,16 @@ export default defineComponent({
         (p) => p.status === "Draft" || p.status === "UnderReview",
       );
     },
+    onlyChangeRequestInProgress(): boolean {
+      return !this.programsRequiringReview.some(
+        (p) => p.programProfileType === "AnnualReview",
+      );
+    },
     currentProgramProfiles(): Components.Schemas.Program[] {
-      const yearStartDate = this.currentYearStart;
-      return this.programs
-        .filter((p) => "Approved" === p.status || "Inactive" === p.status)
-        .filter((p2) => {
-          const itemDate = new Date(p2.startDate!);
-          return yearStartDate <= itemDate;
-        });
-    },
-    allProgramProfiles(): Components.Schemas.Program[] {
-      return this.programs.filter((p) => p.status !== "Withdrawn");
-    },
-    displayProgramProfiles() {
-      return this.filter === "current"
-        ? this.currentProgramProfiles
-        : this.allProgramProfiles;
+      return this.programs.filter(
+        (p) =>
+          "Approved" === p.status || "ChangeRequestInProgress" === p.status,
+      );
     },
     currentYearStart(): Date {
       let yearStart;
@@ -224,22 +192,12 @@ export default defineComponent({
       yearStart.setHours(0, 0, 0, 0);
       return yearStart;
     },
-    earliestProfileYear(): string {
-      return "2023";
-    },
   },
   async mounted() {
     await this.fetchPrograms();
     this.loading = false;
   },
   methods: {
-    getProgramKey(
-      program: Components.Schemas.Program,
-      index: number,
-      prefix: string,
-    ): string {
-      return program.id ?? `${prefix}-${index}`;
-    },
     async fetchPrograms(page: number = 1) {
       const params = { page, pageSize: PAGE_SIZE };
       const response = await getPrograms("", [], params);
@@ -251,3 +209,10 @@ export default defineComponent({
   },
 });
 </script>
+
+<style scoped>
+::v-deep(.force-full-content .v-btn__content) {
+  flex: 1 1 auto !important;
+  justify-content: space-between;
+}
+</style>

--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/program-profile/ProgramProfileCard.vue
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/program-profile/ProgramProfileCard.vue
@@ -8,10 +8,7 @@
     <div class="d-flex justify-end">
       <v-row>
         <v-col></v-col>
-        <v-col 
-          v-if="showProgressMeter"
-          class="d-flex justify-end"
-        >
+        <v-col v-if="showProgressMeter" class="d-flex justify-end">
           <p>Loading...</p>
           <v-progress-circular
             indeterminate
@@ -231,7 +228,10 @@ export default defineComponent({
     },
   },
   async mounted() {
-    if (this.updatedProgram.programProfileType == "ChangeRequest" && !this.updatedProgram.readyForReview){
+    if (
+      this.updatedProgram.programProfileType == "ChangeRequest" &&
+      !this.updatedProgram.readyForReview
+    ) {
       this.startPolling();
     }
   },
@@ -250,14 +250,14 @@ export default defineComponent({
       this.updateInProgress = true;
       this.pollInterval = setInterval(() => {
         this.fetchProgram();
-        if(this.updatedProgram.readyForReview){
+        if (this.updatedProgram.readyForReview) {
           /* Ready for review flag has been set. Stop polling. */
           this.updateInProgress = false;
           clearInterval(this.pollInterval);
         }
       }, IntervalTime.INTERVAL_10_SECONDS);
       setTimeout(() => {
-        clearInterval(this.pollInterval)
+        clearInterval(this.pollInterval);
       }, IntervalTime.INTERVAL_10_SECONDS * 10);
     },
     openProfile() {

--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/router.ts
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/router.ts
@@ -94,6 +94,12 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
+      path: "/all-program-profiles",
+      component: () => import("./components/pages/AllProgramProfiles.vue"),
+      name: "all-program-profiles",
+      meta: { requiresAuth: true },
+    },
+    {
       path: "/program/:programId/initiate-update",
       component: () => import("./components/pages/InitiateProgramUpdate.vue"),
       name: "initiate-program-update",

--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/types/openapi.d.ts
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/types/openapi.d.ts
@@ -4,1154 +4,1190 @@ import type {
   UnknownParamsObject,
   OperationResponse,
   AxiosRequestConfig,
-} from 'openapi-client-axios';
+} from "openapi-client-axios";
 
 declare namespace Components {
-    namespace Schemas {
-        export interface ApplicationConfiguration {
-            clientAuthenticationMethods?: {
-                [name: string]: OidcAuthenticationSettings;
-            } | null;
-        }
-        export interface AreaOfInstruction {
-            id?: string | null;
-            name?: string | null;
-            programTypes?: ProgramTypes[] | null;
-            minimumHours?: number | null; // int32
-            displayOrder?: string | null;
-        }
-        export interface AreaOfInstructionListResponse {
-            areaOfInstruction?: AreaOfInstruction[] | null;
-        }
-        export type Auspice = "ContinuingEducation" | "PublicOOP" | "Private" | "Public";
-        export interface Communication {
-            id?: string | null;
-            category?: CommunicationCategory;
-            subject?: string | null;
-            text?: string | null;
-            from?: InitiatedFrom;
-            acknowledged?: boolean;
-            notifiedOn?: string; // date-time
-            status?: CommunicationStatus;
-            doNotReply?: boolean;
-            latestMessageNotifiedOn?: string | null; // date-time
-            isRead?: boolean | null;
-            applicationId?: string | null;
-            icraEligibilityId?: string | null;
-            programRepresentativeId?: string | null;
-            educationInstituteName?: string | null;
-            documents?: CommunicationDocument[] | null;
-        }
-        export type CommunicationCategory = "ProgramChangeRequest" | "PracticumInquiry" | "ECEProgramApplicationInquiry" | "ECEProgramApplicationRequirements" | "ProgramProfileInquiry" | "IndividualEducationPlanIEP" | "MeetingRequest" | "RequestforAdditionalInformation" | "Other";
-        export interface CommunicationDocument {
-            id?: string | null;
-            url?: string | null;
-            extention?: string | null;
-            name?: string | null;
-            size?: string | null;
-        }
-        /**
-         * Save communication response
-         */
-        export interface CommunicationResponse {
-            /**
-             * The communication id
-             */
-            communicationId?: string | null;
-        }
-        /**
-         * Communication seen request
-         */
-        export interface CommunicationSeenRequest {
-            /**
-             * The communication ID
-             */
-            communicationId?: string | null;
-        }
-        export type CommunicationStatus = "Draft" | "NotifiedRecipient" | "Acknowledged" | "Inactive";
-        export interface CommunicationsStatus {
-            count?: number; // int32
-            hasUnread?: boolean;
-        }
-        export interface CommunicationsStatusResults {
-            status?: CommunicationsStatus;
-        }
-        export interface Country {
-            countryId?: string | null;
-            countryName?: string | null;
-            countryCode?: string | null;
-            isICRA?: boolean;
-        }
-        export interface Course {
-            courseId: string;
-            courseNumber: string;
-            courseTitle: string;
-            newCourseNumber?: string | null;
-            newCourseTitle?: string | null;
-            courseAreaOfInstruction?: CourseAreaOfInstruction[] | null;
-            programType: string;
-        }
-        export interface CourseAreaOfInstruction {
-            courseAreaOfInstructionId?: string | null;
-            newHours?: string | null;
-            areaOfInstructionId?: string | null;
-        }
-        export interface DraftProgramResponse {
-            program?: Program;
-        }
-        export interface EducationInstitution {
-            id?: string | null;
-            name?: string | null;
-            auspice?: Auspice;
-            websiteUrl?: string | null;
-            street1?: string | null;
-            street2?: string | null;
-            street3?: string | null;
-            city?: string | null;
-            province?: string | null;
-            country?: string | null;
-            postalCode?: string | null;
-        }
-        /**
-         * file Response
-         */
-        export interface FileResponse {
-            /**
-             *
-             */
-            fileId?: string | null;
-            url?: string | null;
-        }
-        export type FunctionType = "ProgramProfile" | "ProgramApplication";
-        export interface GetMessagesResponse {
-            communications?: Communication[] | null;
-            totalMessagesCount?: number; // int32
-        }
-        export interface GetProgramsResponse {
-            programs?: Program[] | null;
-            totalProgramsCount?: number; // int32
-        }
-        export interface HttpValidationProblemDetails {
-            [name: string]: any;
-            type?: string | null;
-            title?: string | null;
-            status?: number | null; // int32
-            detail?: string | null;
-            instance?: string | null;
-            errors?: {
-                [name: string]: string[];
-            } | null;
-        }
-        export type InitiatedFrom = "Investigation" | "PortalUser" | "Registry" | "ProgramRepresentative";
-        export type InviteType = "PSIProgramRepresentative";
-        export interface NewPspUserResponse {
-            id?: string | null;
-        }
-        export interface OidcAuthenticationSettings {
-            authority?: string | null;
-            clientId?: string | null;
-            scope?: string | null;
-            idp?: string | null;
-        }
-        export type PortalAccessStatus = "Invited" | "Active" | "Disabled";
-        export interface PortalInvitation {
-            id?: string | null;
-            pspProgramRepresentativeId?: string | null;
-            inviteType?: InviteType;
-            bceidBusinessName?: string | null;
-            isLinked?: boolean;
-        }
-        export interface PortalInvitationQueryResult {
-            portalInvitation?: PortalInvitation;
-        }
-        export interface ProblemDetails {
-            [name: string]: any;
-            type?: string | null;
-            title?: string | null;
-            status?: number | null; // int32
-            detail?: string | null;
-            instance?: string | null;
-        }
-        export interface Program {
-            id?: string | null;
-            portalStage?: string | null;
-            status?: ProgramStatus;
-            createdOn?: string | null; // date-time
-            name?: string | null;
-            programName?: string | null;
-            postSecondaryInstituteName?: string | null;
-            startDate?: string | null; // date-time
-            endDate?: string | null; // date-time
-            newBasicTotalHours?: string | null;
-            newSneTotalHours?: string | null;
-            newIteTotalHours?: string | null;
-            declarationDate?: string | null;
-            declarationUserName?: string | null;
-            programProfileType?: ProgramProfileType;
-            programTypes?: ProgramTypes[] | null;
-            offeredProgramTypes?: string[] | null;
-            courses?: Course[] | null;
-            changesMade?: boolean;
-            fromProgramProfileId?: string | null;
-            readyForReview?: boolean | null;
-        }
-        export type ProgramProfileType = "ChangeRequest" | "AnnualReview";
-        export type ProgramStatus = "Draft" | "UnderReview" | "Approved" | "Denied" | "Inactive" | "ChangeRequestInProgress" | "Withdrawn";
-        export type ProgramTypes = "Basic" | "SNE" | "ITE";
-        export interface Province {
-            provinceId?: string | null;
-            provinceName?: string | null;
-            provinceCode?: string | null;
-        }
-        /**
-         * Error codes for PSP user registration failures
-         */
-        export type PspRegistrationError = "PostSecondaryInstitutionNotFound" | "PortalInvitationTokenInvalid" | "PortalInvitationWrongStatus" | "BceidBusinessIdDoesNotMatch" | "GenericError";
-        /**
-         * Error response for PSP user registration failures. Returns only the error code for frontend handling.
-         */
-        export interface PspRegistrationErrorResponse {
-            errorCode?: /* Error codes for PSP user registration failures */ PspRegistrationError;
-        }
-        export interface PspUserListItem {
-            id?: string | null;
-            profile?: /* User profile information */ PspUserProfile;
-            accessToPortal?: PortalAccessStatus;
-            postSecondaryInstituteId?: string | null;
-        }
-        /**
-         * User profile information
-         */
-        export interface PspUserProfile {
-            id?: string | null;
-            firstName?: string | null;
-            lastName?: string | null;
-            preferredName?: string | null;
-            phone?: string | null;
-            phoneExtension?: string | null;
-            jobTitle?: string | null;
-            role?: /* Role of the PSP user */ PspUserRole;
-            unreadMessagesCount?: number; // int32
-            email?: string | null;
-            hasAcceptedTermsOfUse?: boolean | null;
-        }
-        /**
-         * Role of the PSP user
-         */
-        export type PspUserRole = "Primary" | "Secondary";
-        /**
-         * Request to register a new psp user
-         */
-        export interface RegisterPspUserRequest {
-            token?: string | null;
-            programRepresentativeId?: string | null;
-            bceidBusinessId?: string | null;
-            bceidBusinessName?: string | null;
-            profile: /* User profile information */ PspUserProfile;
-        }
-        export interface SaveDraftProgramRequest {
-            program?: Program;
-        }
-        /**
-         * Send Message Request
-         */
-        export interface SendMessageRequest {
-            communication?: Communication;
-        }
-        /**
-         * Send Message Response
-         */
-        export interface SendMessageResponse {
-            /**
-             *
-             */
-            communicationId?: string | null;
-        }
-        export interface SubmitProgramRequest {
-            programId?: string | null;
-        }
-        export interface UpdateCourseRequest {
-            courses?: Course[] | null;
-            type?: FunctionType;
-        }
-        export interface VersionMetadata {
-            version?: string | null;
-            timestamp?: string | null;
-            commit?: string | null;
-        }
+  namespace Schemas {
+    export interface ApplicationConfiguration {
+      clientAuthenticationMethods?: {
+        [name: string]: OidcAuthenticationSettings;
+      } | null;
     }
+    export interface AreaOfInstruction {
+      id?: string | null;
+      name?: string | null;
+      programTypes?: ProgramTypes[] | null;
+      minimumHours?: number | null; // int32
+      displayOrder?: string | null;
+    }
+    export interface AreaOfInstructionListResponse {
+      areaOfInstruction?: AreaOfInstruction[] | null;
+    }
+    export type Auspice =
+      | "ContinuingEducation"
+      | "PublicOOP"
+      | "Private"
+      | "Public";
+    export interface Communication {
+      id?: string | null;
+      category?: CommunicationCategory;
+      subject?: string | null;
+      text?: string | null;
+      from?: InitiatedFrom;
+      acknowledged?: boolean;
+      notifiedOn?: string; // date-time
+      status?: CommunicationStatus;
+      doNotReply?: boolean;
+      latestMessageNotifiedOn?: string | null; // date-time
+      isRead?: boolean | null;
+      applicationId?: string | null;
+      icraEligibilityId?: string | null;
+      programRepresentativeId?: string | null;
+      educationInstituteName?: string | null;
+      documents?: CommunicationDocument[] | null;
+    }
+    export type CommunicationCategory =
+      | "ProgramChangeRequest"
+      | "PracticumInquiry"
+      | "ECEProgramApplicationInquiry"
+      | "ECEProgramApplicationRequirements"
+      | "ProgramProfileInquiry"
+      | "IndividualEducationPlanIEP"
+      | "MeetingRequest"
+      | "RequestforAdditionalInformation"
+      | "Other";
+    export interface CommunicationDocument {
+      id?: string | null;
+      url?: string | null;
+      extention?: string | null;
+      name?: string | null;
+      size?: string | null;
+    }
+    /**
+     * Save communication response
+     */
+    export interface CommunicationResponse {
+      /**
+       * The communication id
+       */
+      communicationId?: string | null;
+    }
+    /**
+     * Communication seen request
+     */
+    export interface CommunicationSeenRequest {
+      /**
+       * The communication ID
+       */
+      communicationId?: string | null;
+    }
+    export type CommunicationStatus =
+      | "Draft"
+      | "NotifiedRecipient"
+      | "Acknowledged"
+      | "Inactive";
+    export interface CommunicationsStatus {
+      count?: number; // int32
+      hasUnread?: boolean;
+    }
+    export interface CommunicationsStatusResults {
+      status?: CommunicationsStatus;
+    }
+    export interface Country {
+      countryId?: string | null;
+      countryName?: string | null;
+      countryCode?: string | null;
+      isICRA?: boolean;
+    }
+    export interface Course {
+      courseId: string;
+      courseNumber: string;
+      courseTitle: string;
+      newCourseNumber?: string | null;
+      newCourseTitle?: string | null;
+      courseAreaOfInstruction?: CourseAreaOfInstruction[] | null;
+      programType: string;
+    }
+    export interface CourseAreaOfInstruction {
+      courseAreaOfInstructionId?: string | null;
+      newHours?: string | null;
+      areaOfInstructionId?: string | null;
+    }
+    export interface DraftProgramResponse {
+      program?: Program;
+    }
+    export interface EducationInstitution {
+      id?: string | null;
+      name?: string | null;
+      auspice?: Auspice;
+      websiteUrl?: string | null;
+      street1?: string | null;
+      street2?: string | null;
+      street3?: string | null;
+      city?: string | null;
+      province?: string | null;
+      country?: string | null;
+      postalCode?: string | null;
+    }
+    /**
+     * file Response
+     */
+    export interface FileResponse {
+      /**
+       *
+       */
+      fileId?: string | null;
+      url?: string | null;
+    }
+    export type FunctionType = "ProgramProfile" | "ProgramApplication";
+    export interface GetMessagesResponse {
+      communications?: Communication[] | null;
+      totalMessagesCount?: number; // int32
+    }
+    export interface GetProgramsResponse {
+      programs?: Program[] | null;
+      totalProgramsCount?: number; // int32
+    }
+    export interface HttpValidationProblemDetails {
+      [name: string]: any;
+      type?: string | null;
+      title?: string | null;
+      status?: number | null; // int32
+      detail?: string | null;
+      instance?: string | null;
+      errors?: {
+        [name: string]: string[];
+      } | null;
+    }
+    export type InitiatedFrom =
+      | "Investigation"
+      | "PortalUser"
+      | "Registry"
+      | "ProgramRepresentative";
+    export type InviteType = "PSIProgramRepresentative";
+    export interface NewPspUserResponse {
+      id?: string | null;
+    }
+    export interface OidcAuthenticationSettings {
+      authority?: string | null;
+      clientId?: string | null;
+      scope?: string | null;
+      idp?: string | null;
+    }
+    export type PortalAccessStatus = "Invited" | "Active" | "Disabled";
+    export interface PortalInvitation {
+      id?: string | null;
+      pspProgramRepresentativeId?: string | null;
+      inviteType?: InviteType;
+      bceidBusinessName?: string | null;
+      isLinked?: boolean;
+    }
+    export interface PortalInvitationQueryResult {
+      portalInvitation?: PortalInvitation;
+    }
+    export interface ProblemDetails {
+      [name: string]: any;
+      type?: string | null;
+      title?: string | null;
+      status?: number | null; // int32
+      detail?: string | null;
+      instance?: string | null;
+    }
+    export interface Program {
+      id?: string | null;
+      portalStage?: string | null;
+      status?: ProgramStatus;
+      createdOn?: string | null; // date-time
+      name?: string | null;
+      programName?: string | null;
+      postSecondaryInstituteName?: string | null;
+      startDate?: string | null; // date-time
+      endDate?: string | null; // date-time
+      newBasicTotalHours?: string | null;
+      newSneTotalHours?: string | null;
+      newIteTotalHours?: string | null;
+      declarationDate?: string | null;
+      declarationUserName?: string | null;
+      programProfileType?: ProgramProfileType;
+      programTypes?: ProgramTypes[] | null;
+      offeredProgramTypes?: string[] | null;
+      courses?: Course[] | null;
+      changesMade?: boolean;
+      fromProgramProfileId?: string | null;
+      readyForReview?: boolean | null;
+    }
+    export type ProgramProfileType = "ChangeRequest" | "AnnualReview";
+    export type ProgramStatus =
+      | "Draft"
+      | "UnderReview"
+      | "Approved"
+      | "Denied"
+      | "Inactive"
+      | "ChangeRequestInProgress"
+      | "Withdrawn";
+    export type ProgramTypes = "Basic" | "SNE" | "ITE";
+    export interface Province {
+      provinceId?: string | null;
+      provinceName?: string | null;
+      provinceCode?: string | null;
+    }
+    /**
+     * Error codes for PSP user registration failures
+     */
+    export type PspRegistrationError =
+      | "PostSecondaryInstitutionNotFound"
+      | "PortalInvitationTokenInvalid"
+      | "PortalInvitationWrongStatus"
+      | "BceidBusinessIdDoesNotMatch"
+      | "GenericError";
+    /**
+     * Error response for PSP user registration failures. Returns only the error code for frontend handling.
+     */
+    export interface PspRegistrationErrorResponse {
+      errorCode?: /* Error codes for PSP user registration failures */ PspRegistrationError;
+    }
+    export interface PspUserListItem {
+      id?: string | null;
+      profile?: /* User profile information */ PspUserProfile;
+      accessToPortal?: PortalAccessStatus;
+      postSecondaryInstituteId?: string | null;
+    }
+    /**
+     * User profile information
+     */
+    export interface PspUserProfile {
+      id?: string | null;
+      firstName?: string | null;
+      lastName?: string | null;
+      preferredName?: string | null;
+      phone?: string | null;
+      phoneExtension?: string | null;
+      jobTitle?: string | null;
+      role?: /* Role of the PSP user */ PspUserRole;
+      unreadMessagesCount?: number; // int32
+      email?: string | null;
+      hasAcceptedTermsOfUse?: boolean | null;
+    }
+    /**
+     * Role of the PSP user
+     */
+    export type PspUserRole = "Primary" | "Secondary";
+    /**
+     * Request to register a new psp user
+     */
+    export interface RegisterPspUserRequest {
+      token?: string | null;
+      programRepresentativeId?: string | null;
+      bceidBusinessId?: string | null;
+      bceidBusinessName?: string | null;
+      profile: /* User profile information */ PspUserProfile;
+    }
+    export interface SaveDraftProgramRequest {
+      program?: Program;
+    }
+    /**
+     * Send Message Request
+     */
+    export interface SendMessageRequest {
+      communication?: Communication;
+    }
+    /**
+     * Send Message Response
+     */
+    export interface SendMessageResponse {
+      /**
+       *
+       */
+      communicationId?: string | null;
+    }
+    export interface SubmitProgramRequest {
+      programId?: string | null;
+    }
+    export interface UpdateCourseRequest {
+      courses?: Course[] | null;
+      type?: FunctionType;
+    }
+    export interface VersionMetadata {
+      version?: string | null;
+      timestamp?: string | null;
+      commit?: string | null;
+    }
+  }
 }
 declare namespace Paths {
-    namespace AreaOfInstructionGet {
-        namespace Responses {
-            export type $200 = Components.Schemas.AreaOfInstructionListResponse;
-        }
+  namespace AreaOfInstructionGet {
+    namespace Responses {
+      export type $200 = Components.Schemas.AreaOfInstructionListResponse;
     }
-    namespace ChangeprogramPut {
-        namespace Parameters {
-            export type Id = string;
-        }
-        export interface PathParameters {
-            id: Parameters.Id;
-        }
-        export type RequestBody = Components.Schemas.Program;
-        namespace Responses {
-            export type $200 = string;
-            export type $400 = Components.Schemas.HttpValidationProblemDetails;
-            export interface $404 {
-            }
-        }
+  }
+  namespace ChangeprogramPut {
+    namespace Parameters {
+      export type Id = string;
     }
-    namespace CommunicationPut {
-        namespace Parameters {
-            export type Id = string;
-        }
-        export interface PathParameters {
-            id?: Parameters.Id;
-        }
-        export type RequestBody = /* Communication seen request */ Components.Schemas.CommunicationSeenRequest;
-        namespace Responses {
-            export type $200 = /* Save communication response */ Components.Schemas.CommunicationResponse;
-            export type $400 = string;
-            export interface $404 {
-            }
-        }
+    export interface PathParameters {
+      id: Parameters.Id;
     }
-    namespace ConfigurationGet {
-        namespace Responses {
-            export type $200 = Components.Schemas.ApplicationConfiguration;
-        }
+    export type RequestBody = Components.Schemas.Program;
+    namespace Responses {
+      export type $200 = string;
+      export type $400 = Components.Schemas.HttpValidationProblemDetails;
+      export interface $404 {}
     }
-    namespace CountryGet {
-        namespace Responses {
-            export type $200 = Components.Schemas.Country[];
-        }
+  }
+  namespace CommunicationPut {
+    namespace Parameters {
+      export type Id = string;
     }
-    namespace CoursePut {
-        namespace Parameters {
-            export type Id = string;
-        }
-        export interface PathParameters {
-            id: Parameters.Id;
-        }
-        export type RequestBody = Components.Schemas.UpdateCourseRequest;
-        namespace Responses {
-            export type $200 = string;
-            export type $400 = Components.Schemas.HttpValidationProblemDetails;
-            export interface $404 {
-            }
-        }
+    export interface PathParameters {
+      id?: Parameters.Id;
     }
-    namespace DeleteFile {
-        namespace Parameters {
-            export type FileId = string;
-        }
-        export interface PathParameters {
-            fileId: Parameters.FileId;
-        }
-        namespace Responses {
-            export type $200 = /* file Response */ Components.Schemas.FileResponse;
-            export type $400 = Components.Schemas.HttpValidationProblemDetails;
-            export interface $404 {
-            }
-        }
+    export type RequestBody =
+      /* Communication seen request */ Components.Schemas.CommunicationSeenRequest;
+    namespace Responses {
+      export type $200 =
+        /* Save communication response */ Components.Schemas.CommunicationResponse;
+      export type $400 = string;
+      export interface $404 {}
     }
-    namespace DraftprogramPut {
-        namespace Parameters {
-            export type Id = string;
-        }
-        export interface PathParameters {
-            id?: Parameters.Id;
-        }
-        export type RequestBody = Components.Schemas.SaveDraftProgramRequest;
-        namespace Responses {
-            export type $200 = Components.Schemas.DraftProgramResponse;
-            export type $400 = Components.Schemas.HttpValidationProblemDetails;
-            export interface $404 {
-            }
-        }
+  }
+  namespace ConfigurationGet {
+    namespace Responses {
+      export type $200 = Components.Schemas.ApplicationConfiguration;
     }
-    namespace EducationInstitutionGet {
-        namespace Responses {
-            export type $200 = Components.Schemas.EducationInstitution;
-            export interface $404 {
-            }
-        }
+  }
+  namespace CountryGet {
+    namespace Responses {
+      export type $200 = Components.Schemas.Country[];
     }
-    namespace EducationInstitutionPut {
-        export type RequestBody = Components.Schemas.EducationInstitution;
-        namespace Responses {
-            export interface $200 {
-            }
-            export type $400 = Components.Schemas.ProblemDetails | Components.Schemas.HttpValidationProblemDetails;
-        }
+  }
+  namespace CoursePut {
+    namespace Parameters {
+      export type Id = string;
     }
-    namespace FilesCommunicationGet {
-        namespace Parameters {
-            export type CommunicationId = string;
-            export type FileId = string;
-        }
-        export interface PathParameters {
-            communicationId: Parameters.CommunicationId;
-            fileId: Parameters.FileId;
-        }
-        namespace Responses {
-            export type $400 = Components.Schemas.HttpValidationProblemDetails;
-            export interface $404 {
-            }
-        }
+    export interface PathParameters {
+      id: Parameters.Id;
     }
-    namespace MessageGet {
-        namespace Parameters {
-            export type ParentId = string;
-        }
-        export interface PathParameters {
-            parentId?: Parameters.ParentId;
-        }
-        namespace Responses {
-            export type $200 = Components.Schemas.GetMessagesResponse;
-            export type $400 = Components.Schemas.ProblemDetails | Components.Schemas.HttpValidationProblemDetails;
-            export interface $404 {
-            }
-        }
+    export type RequestBody = Components.Schemas.UpdateCourseRequest;
+    namespace Responses {
+      export type $200 = string;
+      export type $400 = Components.Schemas.HttpValidationProblemDetails;
+      export interface $404 {}
     }
-    namespace MessagePost {
-        export type RequestBody = /* Send Message Request */ Components.Schemas.SendMessageRequest;
-        namespace Responses {
-            export type $200 = /* Send Message Response */ Components.Schemas.SendMessageResponse;
-            export type $400 = Components.Schemas.ProblemDetails | Components.Schemas.HttpValidationProblemDetails;
-            export interface $404 {
-            }
-        }
+  }
+  namespace DeleteFile {
+    namespace Parameters {
+      export type FileId = string;
     }
-    namespace MessageStatusGet {
-        namespace Responses {
-            export type $200 = Components.Schemas.CommunicationsStatusResults;
-            export interface $404 {
-            }
-        }
+    export interface PathParameters {
+      fileId: Parameters.FileId;
     }
-    namespace PortalInvitationGet {
-        namespace Parameters {
-            export type Token = string;
-        }
-        export interface PathParameters {
-            token?: Parameters.Token;
-        }
-        namespace Responses {
-            export type $200 = Components.Schemas.PortalInvitationQueryResult;
-            export type $400 = Components.Schemas.HttpValidationProblemDetails;
-        }
+    namespace Responses {
+      export type $200 = /* file Response */ Components.Schemas.FileResponse;
+      export type $400 = Components.Schemas.HttpValidationProblemDetails;
+      export interface $404 {}
     }
-    namespace ProgramGet {
-        namespace Parameters {
-            export type ByStatus = Components.Schemas.ProgramStatus[];
-            export type Id = string;
-        }
-        export interface PathParameters {
-            id?: Parameters.Id;
-        }
-        export interface QueryParameters {
-            byStatus?: Parameters.ByStatus;
-        }
-        namespace Responses {
-            export type $200 = Components.Schemas.GetProgramsResponse;
-            export type $400 = Components.Schemas.HttpValidationProblemDetails;
-            export interface $404 {
-            }
-        }
+  }
+  namespace DraftprogramPut {
+    namespace Parameters {
+      export type Id = string;
     }
-    namespace ProgramPost {
-        export type RequestBody = Components.Schemas.SubmitProgramRequest;
-        namespace Responses {
-            export type $200 = string;
-            export type $400 = Components.Schemas.ProblemDetails | Components.Schemas.HttpValidationProblemDetails;
-            export interface $404 {
-            }
-        }
+    export interface PathParameters {
+      id?: Parameters.Id;
     }
-    namespace ProgramPut {
-        namespace Parameters {
-            export type Id = string;
-        }
-        export interface PathParameters {
-            id: Parameters.Id;
-        }
-        export type RequestBody = Components.Schemas.Program;
-        namespace Responses {
-            export type $200 = string;
-            export type $400 = Components.Schemas.HttpValidationProblemDetails;
-            export interface $404 {
-            }
-        }
+    export type RequestBody = Components.Schemas.SaveDraftProgramRequest;
+    namespace Responses {
+      export type $200 = Components.Schemas.DraftProgramResponse;
+      export type $400 = Components.Schemas.HttpValidationProblemDetails;
+      export interface $404 {}
     }
-    namespace ProvinceGet {
-        namespace Responses {
-            export type $200 = Components.Schemas.Province[];
-        }
+  }
+  namespace EducationInstitutionGet {
+    namespace Responses {
+      export type $200 = Components.Schemas.EducationInstitution;
+      export interface $404 {}
     }
-    namespace PspUserAdd {
-        export type RequestBody = /* User profile information */ Components.Schemas.PspUserProfile;
-        namespace Responses {
-            export type $200 = Components.Schemas.NewPspUserResponse;
-            export type $400 = string;
-            export interface $404 {
-            }
-        }
+  }
+  namespace EducationInstitutionPut {
+    export type RequestBody = Components.Schemas.EducationInstitution;
+    namespace Responses {
+      export interface $200 {}
+      export type $400 =
+        | Components.Schemas.ProblemDetails
+        | Components.Schemas.HttpValidationProblemDetails;
     }
-    namespace PspUserManageDeactivatePost {
-        namespace Parameters {
-            export type ProgramRepId = string;
-        }
-        export interface PathParameters {
-            programRepId: Parameters.ProgramRepId;
-        }
-        namespace Responses {
-            export interface $200 {
-            }
-            export type $400 = Components.Schemas.HttpValidationProblemDetails;
-            export interface $404 {
-            }
-        }
+  }
+  namespace FilesCommunicationGet {
+    namespace Parameters {
+      export type CommunicationId = string;
+      export type FileId = string;
     }
-    namespace PspUserManageGet {
-        namespace Responses {
-            export type $200 = Components.Schemas.PspUserListItem[];
-            export interface $404 {
-            }
-        }
+    export interface PathParameters {
+      communicationId: Parameters.CommunicationId;
+      fileId: Parameters.FileId;
     }
-    namespace PspUserManageReactivatePost {
-        namespace Parameters {
-            export type ProgramRepId = string;
-        }
-        export interface PathParameters {
-            programRepId: Parameters.ProgramRepId;
-        }
-        namespace Responses {
-            export interface $200 {
-            }
-            export type $400 = Components.Schemas.HttpValidationProblemDetails;
-            export interface $404 {
-            }
-        }
+    namespace Responses {
+      export type $400 = Components.Schemas.HttpValidationProblemDetails;
+      export interface $404 {}
     }
-    namespace PspUserManageSetPrimaryPost {
-        namespace Parameters {
-            export type ProgramRepId = string;
-        }
-        export interface PathParameters {
-            programRepId: Parameters.ProgramRepId;
-        }
-        namespace Responses {
-            export interface $200 {
-            }
-            export type $400 = Components.Schemas.HttpValidationProblemDetails;
-            export interface $404 {
-            }
-        }
+  }
+  namespace MessageGet {
+    namespace Parameters {
+      export type ParentId = string;
     }
-    namespace PspUserProfileGet {
-        namespace Responses {
-            export type $200 = /* User profile information */ Components.Schemas.PspUserProfile;
-            export interface $404 {
-            }
-        }
+    export interface PathParameters {
+      parentId?: Parameters.ParentId;
     }
-    namespace PspUserProfilePut {
-        export type RequestBody = /* User profile information */ Components.Schemas.PspUserProfile;
-        namespace Responses {
-            export interface $200 {
-            }
-        }
+    namespace Responses {
+      export type $200 = Components.Schemas.GetMessagesResponse;
+      export type $400 =
+        | Components.Schemas.ProblemDetails
+        | Components.Schemas.HttpValidationProblemDetails;
+      export interface $404 {}
     }
-    namespace PspUserRegisterPost {
-        export type RequestBody = /* Request to register a new psp user */ Components.Schemas.RegisterPspUserRequest;
-        namespace Responses {
-            export interface $200 {
-            }
-            export type $400 = /* Error response for PSP user registration failures. Returns only the error code for frontend handling. */ Components.Schemas.PspRegistrationErrorResponse;
-        }
+  }
+  namespace MessagePost {
+    export type RequestBody =
+      /* Send Message Request */ Components.Schemas.SendMessageRequest;
+    namespace Responses {
+      export type $200 =
+        /* Send Message Response */ Components.Schemas.SendMessageResponse;
+      export type $400 =
+        | Components.Schemas.ProblemDetails
+        | Components.Schemas.HttpValidationProblemDetails;
+      export interface $404 {}
     }
-    namespace UploadFile {
-        namespace Parameters {
-            export type FileId = string;
-        }
-        export interface PathParameters {
-            fileId: Parameters.FileId;
-        }
-        export interface RequestBody {
-            file: string; // binary
-        }
-        namespace Responses {
-            export type $200 = /* file Response */ Components.Schemas.FileResponse;
-            export type $400 = Components.Schemas.ProblemDetails | Components.Schemas.HttpValidationProblemDetails;
-            export interface $404 {
-            }
-        }
+  }
+  namespace MessageStatusGet {
+    namespace Responses {
+      export type $200 = Components.Schemas.CommunicationsStatusResults;
+      export interface $404 {}
     }
-    namespace VersionGet {
-        namespace Responses {
-            export type $200 = Components.Schemas.VersionMetadata;
-        }
+  }
+  namespace PortalInvitationGet {
+    namespace Parameters {
+      export type Token = string;
     }
+    export interface PathParameters {
+      token?: Parameters.Token;
+    }
+    namespace Responses {
+      export type $200 = Components.Schemas.PortalInvitationQueryResult;
+      export type $400 = Components.Schemas.HttpValidationProblemDetails;
+    }
+  }
+  namespace ProgramGet {
+    namespace Parameters {
+      export type ByStatus = Components.Schemas.ProgramStatus[];
+      export type Id = string;
+    }
+    export interface PathParameters {
+      id?: Parameters.Id;
+    }
+    export interface QueryParameters {
+      byStatus?: Parameters.ByStatus;
+    }
+    namespace Responses {
+      export type $200 = Components.Schemas.GetProgramsResponse;
+      export type $400 = Components.Schemas.HttpValidationProblemDetails;
+      export interface $404 {}
+    }
+  }
+  namespace ProgramPost {
+    export type RequestBody = Components.Schemas.SubmitProgramRequest;
+    namespace Responses {
+      export type $200 = string;
+      export type $400 =
+        | Components.Schemas.ProblemDetails
+        | Components.Schemas.HttpValidationProblemDetails;
+      export interface $404 {}
+    }
+  }
+  namespace ProgramPut {
+    namespace Parameters {
+      export type Id = string;
+    }
+    export interface PathParameters {
+      id: Parameters.Id;
+    }
+    export type RequestBody = Components.Schemas.Program;
+    namespace Responses {
+      export type $200 = string;
+      export type $400 = Components.Schemas.HttpValidationProblemDetails;
+      export interface $404 {}
+    }
+  }
+  namespace ProvinceGet {
+    namespace Responses {
+      export type $200 = Components.Schemas.Province[];
+    }
+  }
+  namespace PspUserAdd {
+    export type RequestBody =
+      /* User profile information */ Components.Schemas.PspUserProfile;
+    namespace Responses {
+      export type $200 = Components.Schemas.NewPspUserResponse;
+      export type $400 = string;
+      export interface $404 {}
+    }
+  }
+  namespace PspUserManageDeactivatePost {
+    namespace Parameters {
+      export type ProgramRepId = string;
+    }
+    export interface PathParameters {
+      programRepId: Parameters.ProgramRepId;
+    }
+    namespace Responses {
+      export interface $200 {}
+      export type $400 = Components.Schemas.HttpValidationProblemDetails;
+      export interface $404 {}
+    }
+  }
+  namespace PspUserManageGet {
+    namespace Responses {
+      export type $200 = Components.Schemas.PspUserListItem[];
+      export interface $404 {}
+    }
+  }
+  namespace PspUserManageReactivatePost {
+    namespace Parameters {
+      export type ProgramRepId = string;
+    }
+    export interface PathParameters {
+      programRepId: Parameters.ProgramRepId;
+    }
+    namespace Responses {
+      export interface $200 {}
+      export type $400 = Components.Schemas.HttpValidationProblemDetails;
+      export interface $404 {}
+    }
+  }
+  namespace PspUserManageSetPrimaryPost {
+    namespace Parameters {
+      export type ProgramRepId = string;
+    }
+    export interface PathParameters {
+      programRepId: Parameters.ProgramRepId;
+    }
+    namespace Responses {
+      export interface $200 {}
+      export type $400 = Components.Schemas.HttpValidationProblemDetails;
+      export interface $404 {}
+    }
+  }
+  namespace PspUserProfileGet {
+    namespace Responses {
+      export type $200 =
+        /* User profile information */ Components.Schemas.PspUserProfile;
+      export interface $404 {}
+    }
+  }
+  namespace PspUserProfilePut {
+    export type RequestBody =
+      /* User profile information */ Components.Schemas.PspUserProfile;
+    namespace Responses {
+      export interface $200 {}
+    }
+  }
+  namespace PspUserRegisterPost {
+    export type RequestBody =
+      /* Request to register a new psp user */ Components.Schemas.RegisterPspUserRequest;
+    namespace Responses {
+      export interface $200 {}
+      export type $400 =
+        /* Error response for PSP user registration failures. Returns only the error code for frontend handling. */ Components.Schemas.PspRegistrationErrorResponse;
+    }
+  }
+  namespace UploadFile {
+    namespace Parameters {
+      export type FileId = string;
+    }
+    export interface PathParameters {
+      fileId: Parameters.FileId;
+    }
+    export interface RequestBody {
+      file: string; // binary
+    }
+    namespace Responses {
+      export type $200 = /* file Response */ Components.Schemas.FileResponse;
+      export type $400 =
+        | Components.Schemas.ProblemDetails
+        | Components.Schemas.HttpValidationProblemDetails;
+      export interface $404 {}
+    }
+  }
+  namespace VersionGet {
+    namespace Responses {
+      export type $200 = Components.Schemas.VersionMetadata;
+    }
+  }
 }
-
 
 export interface OperationMethods {
   /**
    * configuration_get - Returns the UI initial configuration
    */
-  'configuration_get'(
+  "configuration_get"(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.ConfigurationGet.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.ConfigurationGet.Responses.$200>;
   /**
    * province_get - Handles province queries
    */
-  'province_get'(
+  "province_get"(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.ProvinceGet.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.ProvinceGet.Responses.$200>;
   /**
    * country_get - Handles country queries
    */
-  'country_get'(
+  "country_get"(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.CountryGet.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.CountryGet.Responses.$200>;
   /**
    * area_of_instruction_get - Handles area of instruction queries
    */
-  'area_of_instruction_get'(
+  "area_of_instruction_get"(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.AreaOfInstructionGet.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.AreaOfInstructionGet.Responses.$200>;
   /**
    * version_get - Returns the version information
    */
-  'version_get'(
+  "version_get"(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.VersionGet.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.VersionGet.Responses.$200>;
   /**
    * psp_user_manage_get - Gets PSP representatives for the current user's institution
    */
-  'psp_user_manage_get'(
+  "psp_user_manage_get"(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.PspUserManageGet.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.PspUserManageGet.Responses.$200>;
   /**
    * psp_user_manage_deactivate_post - Deactivates a PSP representative for the current user's institution
    */
-  'psp_user_manage_deactivate_post'(
+  "psp_user_manage_deactivate_post"(
     parameters?: Parameters<Paths.PspUserManageDeactivatePost.PathParameters> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.PspUserManageDeactivatePost.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.PspUserManageDeactivatePost.Responses.$200>;
   /**
    * psp_user_manage_reactivate_post - Reactivates a PSP representative for the current user's institution
    */
-  'psp_user_manage_reactivate_post'(
+  "psp_user_manage_reactivate_post"(
     parameters?: Parameters<Paths.PspUserManageReactivatePost.PathParameters> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.PspUserManageReactivatePost.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.PspUserManageReactivatePost.Responses.$200>;
   /**
    * psp_user_manage_set_primary_post - Sets the specified PSP representative as Primary for the current user's institution
    */
-  'psp_user_manage_set_primary_post'(
+  "psp_user_manage_set_primary_post"(
     parameters?: Parameters<Paths.PspUserManageSetPrimaryPost.PathParameters> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.PspUserManageSetPrimaryPost.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.PspUserManageSetPrimaryPost.Responses.$200>;
   /**
    * psp_user_add - Adds a new psp user to an institution
    */
-  'psp_user_add'(
+  "psp_user_add"(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: Paths.PspUserAdd.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.PspUserAdd.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.PspUserAdd.Responses.$200>;
   /**
    * psp_user_profile_get - Gets the currently logged in user profile or NotFound if no profile found
    */
-  'psp_user_profile_get'(
+  "psp_user_profile_get"(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.PspUserProfileGet.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.PspUserProfileGet.Responses.$200>;
   /**
    * psp_user_profile_put - Updates the currently logged in users profile
    */
-  'psp_user_profile_put'(
+  "psp_user_profile_put"(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: Paths.PspUserProfilePut.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.PspUserProfilePut.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.PspUserProfilePut.Responses.$200>;
   /**
    * psp_user_register_post - Update a psp user profile
    */
-  'psp_user_register_post'(
+  "psp_user_register_post"(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: Paths.PspUserRegisterPost.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.PspUserRegisterPost.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.PspUserRegisterPost.Responses.$200>;
   /**
    * draftprogram_put - Save a draft program for the current user
    */
-  'draftprogram_put'(
+  "draftprogram_put"(
     parameters?: Parameters<Paths.DraftprogramPut.PathParameters> | null,
     data?: Paths.DraftprogramPut.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.DraftprogramPut.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.DraftprogramPut.Responses.$200>;
   /**
    * program_get - Handles program queries
    */
-  'program_get'(
-    parameters?: Parameters<Paths.ProgramGet.QueryParameters & Paths.ProgramGet.PathParameters> | null,
+  "program_get"(
+    parameters?: Parameters<
+      Paths.ProgramGet.QueryParameters & Paths.ProgramGet.PathParameters
+    > | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.ProgramGet.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.ProgramGet.Responses.$200>;
   /**
    * program_put - Update program profile
    */
-  'program_put'(
+  "program_put"(
     parameters?: Parameters<Paths.ProgramPut.PathParameters> | null,
     data?: Paths.ProgramPut.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.ProgramPut.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.ProgramPut.Responses.$200>;
   /**
    * program_post - Submit a draft program profile
    */
-  'program_post'(
+  "program_post"(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: Paths.ProgramPost.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.ProgramPost.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.ProgramPost.Responses.$200>;
   /**
    * changeprogram_put - Initiate program profile change
    */
-  'changeprogram_put'(
+  "changeprogram_put"(
     parameters?: Parameters<Paths.ChangeprogramPut.PathParameters> | null,
     data?: Paths.ChangeprogramPut.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.ChangeprogramPut.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.ChangeprogramPut.Responses.$200>;
   /**
    * portal_invitation_get - Handles portal invitation queries
    */
-  'portal_invitation_get'(
+  "portal_invitation_get"(
     parameters?: Parameters<Paths.PortalInvitationGet.PathParameters> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.PortalInvitationGet.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.PortalInvitationGet.Responses.$200>;
   /**
    * files_communication_get - Handles fetching files
    */
-  'files_communication_get'(
+  "files_communication_get"(
     parameters?: Parameters<Paths.FilesCommunicationGet.PathParameters> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<any>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<any>;
   /**
    * upload_file - Handles upload file request
    */
-  'upload_file'(
+  "upload_file"(
     parameters?: Parameters<Paths.UploadFile.PathParameters> | null,
     data?: Paths.UploadFile.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.UploadFile.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.UploadFile.Responses.$200>;
   /**
    * delete_file - Handles delete uploaded file request
    */
-  'delete_file'(
+  "delete_file"(
     parameters?: Parameters<Paths.DeleteFile.PathParameters> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.DeleteFile.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.DeleteFile.Responses.$200>;
   /**
    * education_institution_get - Get users education institution
    */
-  'education_institution_get'(
+  "education_institution_get"(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.EducationInstitutionGet.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.EducationInstitutionGet.Responses.$200>;
   /**
    * education_institution_put - Updates the education institution
    */
-  'education_institution_put'(
+  "education_institution_put"(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: Paths.EducationInstitutionPut.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.EducationInstitutionPut.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.EducationInstitutionPut.Responses.$200>;
   /**
    * course_put - Update a course for a program profile
    */
-  'course_put'(
+  "course_put"(
     parameters?: Parameters<Paths.CoursePut.PathParameters> | null,
     data?: Paths.CoursePut.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.CoursePut.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.CoursePut.Responses.$200>;
   /**
    * message_get - Paginated endpoint to get all user messages
    */
-  'message_get'(
+  "message_get"(
     parameters?: Parameters<Paths.MessageGet.PathParameters> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.MessageGet.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.MessageGet.Responses.$200>;
   /**
    * message_post - Endpoint to reply to an existing message
    */
-  'message_post'(
+  "message_post"(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: Paths.MessagePost.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.MessagePost.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.MessagePost.Responses.$200>;
   /**
    * communication_put - Marks a communication as seen
    */
-  'communication_put'(
+  "communication_put"(
     parameters?: Parameters<Paths.CommunicationPut.PathParameters> | null,
     data?: Paths.CommunicationPut.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.CommunicationPut.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.CommunicationPut.Responses.$200>;
   /**
    * message_status_get - Handles messages status
    */
-  'message_status_get'(
+  "message_status_get"(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.MessageStatusGet.Responses.$200>
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.MessageStatusGet.Responses.$200>;
 }
 
 export interface PathsDictionary {
-  ['/api/configuration']: {
+  ["/api/configuration"]: {
     /**
      * configuration_get - Returns the UI initial configuration
      */
-    'get'(
+    "get"(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.ConfigurationGet.Responses.$200>
-  }
-  ['/api/provincelist']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.ConfigurationGet.Responses.$200>;
+  };
+  ["/api/provincelist"]: {
     /**
      * province_get - Handles province queries
      */
-    'get'(
+    "get"(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.ProvinceGet.Responses.$200>
-  }
-  ['/api/countrylist']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.ProvinceGet.Responses.$200>;
+  };
+  ["/api/countrylist"]: {
     /**
      * country_get - Handles country queries
      */
-    'get'(
+    "get"(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.CountryGet.Responses.$200>
-  }
-  ['/api/areaofinstructionlist']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.CountryGet.Responses.$200>;
+  };
+  ["/api/areaofinstructionlist"]: {
     /**
      * area_of_instruction_get - Handles area of instruction queries
      */
-    'get'(
+    "get"(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.AreaOfInstructionGet.Responses.$200>
-  }
-  ['/api/version']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.AreaOfInstructionGet.Responses.$200>;
+  };
+  ["/api/version"]: {
     /**
      * version_get - Returns the version information
      */
-    'get'(
+    "get"(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.VersionGet.Responses.$200>
-  }
-  ['/api/users/manage']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.VersionGet.Responses.$200>;
+  };
+  ["/api/users/manage"]: {
     /**
      * psp_user_manage_get - Gets PSP representatives for the current user's institution
      */
-    'get'(
+    "get"(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.PspUserManageGet.Responses.$200>
-  }
-  ['/api/users/manage/{programRepId}/deactivate']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.PspUserManageGet.Responses.$200>;
+  };
+  ["/api/users/manage/{programRepId}/deactivate"]: {
     /**
      * psp_user_manage_deactivate_post - Deactivates a PSP representative for the current user's institution
      */
-    'post'(
+    "post"(
       parameters?: Parameters<Paths.PspUserManageDeactivatePost.PathParameters> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.PspUserManageDeactivatePost.Responses.$200>
-  }
-  ['/api/users/manage/{programRepId}/reactivate']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.PspUserManageDeactivatePost.Responses.$200>;
+  };
+  ["/api/users/manage/{programRepId}/reactivate"]: {
     /**
      * psp_user_manage_reactivate_post - Reactivates a PSP representative for the current user's institution
      */
-    'post'(
+    "post"(
       parameters?: Parameters<Paths.PspUserManageReactivatePost.PathParameters> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.PspUserManageReactivatePost.Responses.$200>
-  }
-  ['/api/users/manage/{programRepId}/set-primary']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.PspUserManageReactivatePost.Responses.$200>;
+  };
+  ["/api/users/manage/{programRepId}/set-primary"]: {
     /**
      * psp_user_manage_set_primary_post - Sets the specified PSP representative as Primary for the current user's institution
      */
-    'post'(
+    "post"(
       parameters?: Parameters<Paths.PspUserManageSetPrimaryPost.PathParameters> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.PspUserManageSetPrimaryPost.Responses.$200>
-  }
-  ['/api/users/manage/add']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.PspUserManageSetPrimaryPost.Responses.$200>;
+  };
+  ["/api/users/manage/add"]: {
     /**
      * psp_user_add - Adds a new psp user to an institution
      */
-    'post'(
+    "post"(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: Paths.PspUserAdd.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.PspUserAdd.Responses.$200>
-  }
-  ['/api/users/profile']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.PspUserAdd.Responses.$200>;
+  };
+  ["/api/users/profile"]: {
     /**
      * psp_user_profile_get - Gets the currently logged in user profile or NotFound if no profile found
      */
-    'get'(
+    "get"(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.PspUserProfileGet.Responses.$200>
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.PspUserProfileGet.Responses.$200>;
     /**
      * psp_user_profile_put - Updates the currently logged in users profile
      */
-    'put'(
+    "put"(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: Paths.PspUserProfilePut.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.PspUserProfilePut.Responses.$200>
-  }
-  ['/api/users/register']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.PspUserProfilePut.Responses.$200>;
+  };
+  ["/api/users/register"]: {
     /**
      * psp_user_register_post - Update a psp user profile
      */
-    'post'(
+    "post"(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: Paths.PspUserRegisterPost.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.PspUserRegisterPost.Responses.$200>
-  }
-  ['/api/draftprograms/{id}']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.PspUserRegisterPost.Responses.$200>;
+  };
+  ["/api/draftprograms/{id}"]: {
     /**
      * draftprogram_put - Save a draft program for the current user
      */
-    'put'(
+    "put"(
       parameters?: Parameters<Paths.DraftprogramPut.PathParameters> | null,
       data?: Paths.DraftprogramPut.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.DraftprogramPut.Responses.$200>
-  }
-  ['/api/programs/{id}']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.DraftprogramPut.Responses.$200>;
+  };
+  ["/api/programs/{id}"]: {
     /**
      * program_get - Handles program queries
      */
-    'get'(
-      parameters?: Parameters<Paths.ProgramGet.QueryParameters & Paths.ProgramGet.PathParameters> | null,
+    "get"(
+      parameters?: Parameters<
+        Paths.ProgramGet.QueryParameters & Paths.ProgramGet.PathParameters
+      > | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.ProgramGet.Responses.$200>
-  }
-  ['/api/program/{id}']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.ProgramGet.Responses.$200>;
+  };
+  ["/api/program/{id}"]: {
     /**
      * program_put - Update program profile
      */
-    'put'(
+    "put"(
       parameters?: Parameters<Paths.ProgramPut.PathParameters> | null,
       data?: Paths.ProgramPut.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.ProgramPut.Responses.$200>
-  }
-  ['/api/programs']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.ProgramPut.Responses.$200>;
+  };
+  ["/api/programs"]: {
     /**
      * program_post - Submit a draft program profile
      */
-    'post'(
+    "post"(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: Paths.ProgramPost.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.ProgramPost.Responses.$200>
-  }
-  ['/api/changeprogram/{id}']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.ProgramPost.Responses.$200>;
+  };
+  ["/api/changeprogram/{id}"]: {
     /**
      * changeprogram_put - Initiate program profile change
      */
-    'put'(
+    "put"(
       parameters?: Parameters<Paths.ChangeprogramPut.PathParameters> | null,
       data?: Paths.ChangeprogramPut.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.ChangeprogramPut.Responses.$200>
-  }
-  ['/api/PortalInvitations/{token}']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.ChangeprogramPut.Responses.$200>;
+  };
+  ["/api/PortalInvitations/{token}"]: {
     /**
      * portal_invitation_get - Handles portal invitation queries
      */
-    'get'(
+    "get"(
       parameters?: Parameters<Paths.PortalInvitationGet.PathParameters> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.PortalInvitationGet.Responses.$200>
-  }
-  ['/api/files/communication/{communicationId}/file/{fileId}']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.PortalInvitationGet.Responses.$200>;
+  };
+  ["/api/files/communication/{communicationId}/file/{fileId}"]: {
     /**
      * files_communication_get - Handles fetching files
      */
-    'get'(
+    "get"(
       parameters?: Parameters<Paths.FilesCommunicationGet.PathParameters> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<any>
-  }
-  ['/api/files/{fileId}']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<any>;
+  };
+  ["/api/files/{fileId}"]: {
     /**
      * delete_file - Handles delete uploaded file request
      */
-    'delete'(
+    "delete"(
       parameters?: Parameters<Paths.DeleteFile.PathParameters> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.DeleteFile.Responses.$200>
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.DeleteFile.Responses.$200>;
     /**
      * upload_file - Handles upload file request
      */
-    'post'(
+    "post"(
       parameters?: Parameters<Paths.UploadFile.PathParameters> | null,
       data?: Paths.UploadFile.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.UploadFile.Responses.$200>
-  }
-  ['/api/education-institution']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.UploadFile.Responses.$200>;
+  };
+  ["/api/education-institution"]: {
     /**
      * education_institution_get - Get users education institution
      */
-    'get'(
+    "get"(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.EducationInstitutionGet.Responses.$200>
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.EducationInstitutionGet.Responses.$200>;
     /**
      * education_institution_put - Updates the education institution
      */
-    'put'(
+    "put"(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: Paths.EducationInstitutionPut.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.EducationInstitutionPut.Responses.$200>
-  }
-  ['/api/courses/{id}']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.EducationInstitutionPut.Responses.$200>;
+  };
+  ["/api/courses/{id}"]: {
     /**
      * course_put - Update a course for a program profile
      */
-    'put'(
+    "put"(
       parameters?: Parameters<Paths.CoursePut.PathParameters> | null,
       data?: Paths.CoursePut.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.CoursePut.Responses.$200>
-  }
-  ['/api/messages/{parentId}']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.CoursePut.Responses.$200>;
+  };
+  ["/api/messages/{parentId}"]: {
     /**
      * message_get - Paginated endpoint to get all user messages
      */
-    'get'(
+    "get"(
       parameters?: Parameters<Paths.MessageGet.PathParameters> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.MessageGet.Responses.$200>
-  }
-  ['/api/messages']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.MessageGet.Responses.$200>;
+  };
+  ["/api/messages"]: {
     /**
      * message_post - Endpoint to reply to an existing message
      */
-    'post'(
+    "post"(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: Paths.MessagePost.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.MessagePost.Responses.$200>
-  }
-  ['/api/messages/{id}/seen']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.MessagePost.Responses.$200>;
+  };
+  ["/api/messages/{id}/seen"]: {
     /**
      * communication_put - Marks a communication as seen
      */
-    'put'(
+    "put"(
       parameters?: Parameters<Paths.CommunicationPut.PathParameters> | null,
       data?: Paths.CommunicationPut.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.CommunicationPut.Responses.$200>
-  }
-  ['/api/messages/status']: {
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.CommunicationPut.Responses.$200>;
+  };
+  ["/api/messages/status"]: {
     /**
      * message_status_get - Handles messages status
      */
-    'get'(
+    "get"(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.MessageStatusGet.Responses.$200>
-  }
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.MessageStatusGet.Responses.$200>;
+  };
 }
 
-export type Client = OpenAPIClient<OperationMethods, PathsDictionary>
+export type Client = OpenAPIClient<OperationMethods, PathsDictionary>;
 
-
-export type ApplicationConfiguration = Components.Schemas.ApplicationConfiguration;
+export type ApplicationConfiguration =
+  Components.Schemas.ApplicationConfiguration;
 export type AreaOfInstruction = Components.Schemas.AreaOfInstruction;
-export type AreaOfInstructionListResponse = Components.Schemas.AreaOfInstructionListResponse;
+export type AreaOfInstructionListResponse =
+  Components.Schemas.AreaOfInstructionListResponse;
 export type Auspice = Components.Schemas.Auspice;
 export type Communication = Components.Schemas.Communication;
 export type CommunicationCategory = Components.Schemas.CommunicationCategory;
 export type CommunicationDocument = Components.Schemas.CommunicationDocument;
 export type CommunicationResponse = Components.Schemas.CommunicationResponse;
-export type CommunicationSeenRequest = Components.Schemas.CommunicationSeenRequest;
+export type CommunicationSeenRequest =
+  Components.Schemas.CommunicationSeenRequest;
 export type CommunicationStatus = Components.Schemas.CommunicationStatus;
 export type CommunicationsStatus = Components.Schemas.CommunicationsStatus;
-export type CommunicationsStatusResults = Components.Schemas.CommunicationsStatusResults;
+export type CommunicationsStatusResults =
+  Components.Schemas.CommunicationsStatusResults;
 export type Country = Components.Schemas.Country;
 export type Course = Components.Schemas.Course;
-export type CourseAreaOfInstruction = Components.Schemas.CourseAreaOfInstruction;
+export type CourseAreaOfInstruction =
+  Components.Schemas.CourseAreaOfInstruction;
 export type DraftProgramResponse = Components.Schemas.DraftProgramResponse;
 export type EducationInstitution = Components.Schemas.EducationInstitution;
 export type FileResponse = Components.Schemas.FileResponse;
 export type FunctionType = Components.Schemas.FunctionType;
 export type GetMessagesResponse = Components.Schemas.GetMessagesResponse;
 export type GetProgramsResponse = Components.Schemas.GetProgramsResponse;
-export type HttpValidationProblemDetails = Components.Schemas.HttpValidationProblemDetails;
+export type HttpValidationProblemDetails =
+  Components.Schemas.HttpValidationProblemDetails;
 export type InitiatedFrom = Components.Schemas.InitiatedFrom;
 export type InviteType = Components.Schemas.InviteType;
 export type NewPspUserResponse = Components.Schemas.NewPspUserResponse;
-export type OidcAuthenticationSettings = Components.Schemas.OidcAuthenticationSettings;
+export type OidcAuthenticationSettings =
+  Components.Schemas.OidcAuthenticationSettings;
 export type PortalAccessStatus = Components.Schemas.PortalAccessStatus;
 export type PortalInvitation = Components.Schemas.PortalInvitation;
-export type PortalInvitationQueryResult = Components.Schemas.PortalInvitationQueryResult;
+export type PortalInvitationQueryResult =
+  Components.Schemas.PortalInvitationQueryResult;
 export type ProblemDetails = Components.Schemas.ProblemDetails;
 export type Program = Components.Schemas.Program;
 export type ProgramProfileType = Components.Schemas.ProgramProfileType;
@@ -1159,12 +1195,14 @@ export type ProgramStatus = Components.Schemas.ProgramStatus;
 export type ProgramTypes = Components.Schemas.ProgramTypes;
 export type Province = Components.Schemas.Province;
 export type PspRegistrationError = Components.Schemas.PspRegistrationError;
-export type PspRegistrationErrorResponse = Components.Schemas.PspRegistrationErrorResponse;
+export type PspRegistrationErrorResponse =
+  Components.Schemas.PspRegistrationErrorResponse;
 export type PspUserListItem = Components.Schemas.PspUserListItem;
 export type PspUserProfile = Components.Schemas.PspUserProfile;
 export type PspUserRole = Components.Schemas.PspUserRole;
 export type RegisterPspUserRequest = Components.Schemas.RegisterPspUserRequest;
-export type SaveDraftProgramRequest = Components.Schemas.SaveDraftProgramRequest;
+export type SaveDraftProgramRequest =
+  Components.Schemas.SaveDraftProgramRequest;
 export type SendMessageRequest = Components.Schemas.SendMessageRequest;
 export type SendMessageResponse = Components.Schemas.SendMessageResponse;
 export type SubmitProgramRequest = Components.Schemas.SubmitProgramRequest;

--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/utils/constant.ts
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/utils/constant.ts
@@ -1,10 +1,3 @@
-import type {
-  CheckBoxWrapper,
-  DropdownWrapper,
-  RadioButtonWrapper,
-} from "@/types/form";
-import type { Components } from "@/types/openapi";
-
 export enum ApplicationState {
   IN_PROGRESS = 0,
   COMPLETED = 1,
@@ -59,3 +52,6 @@ export enum ProgramType {
 export enum IntervalTime {
   INTERVAL_10_SECONDS = 10000,
 }
+
+// Earliest year for program profiles to be displayed
+export const EARLIEST_PROFILE_YEAR = 2023;

--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/utils/functions.ts
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/utils/functions.ts
@@ -1,4 +1,20 @@
 import type { Components } from "@/types/openapi";
+import { DateTime } from "luxon";
+import { EARLIEST_PROFILE_YEAR } from "@/utils/constant";
+
+/**
+ * Checks if a program's start date is on or after the earliest profile year
+ * @param program - The program to check
+ * @returns true if the program's start date year is >= EARLIEST_PROFILE_YEAR
+ */
+export function shouldDisplayProfile(
+  program: Components.Schemas.Program,
+): boolean {
+  if (!program.startDate) {
+    return false;
+  }
+  return DateTime.fromISO(program.startDate).year >= EARLIEST_PROFILE_YEAR;
+}
 
 export function cleanPreferredName(
   firstName: string | null | undefined,


### PR DESCRIPTION
## Description

- Implemented AllProgramProfiles.vue to display a list of program profiles.
- Created ProgramProfilesList.vue for rendering individual program profile cards.
- Updated Breadcrumb.vue to include navigation for the new All Program Profiles page.
- Added routing for the All Program Profiles page in router.ts.
- Introduced filtering logic in shouldDisplayProfile function to only show profiles from 2023 onwards.
- Updated constants to define the earliest profile year.

## Related Jira Issue(s)

- [ECER-5597](https://eccbc.atlassian.net/browse/ECER-5597)
- [ECER-5733](https://eccbc.atlassian.net/browse/ECER-5733)
- [ECER-5722](https://eccbc.atlassian.net/browse/ECER-5722)

## Checklist
- [X] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.