### PR TITLE
ECER-6192 - go directly to profile page when creating a change request

### DIFF
--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/pages/InitiateProgramUpdate.vue
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/pages/InitiateProgramUpdate.vue
@@ -136,20 +136,6 @@
             Continue to program profile
           </v-btn>
         </div>
-        <div>
-          <div v-if="updateInProgress" class="mt-8">
-            <v-progress-circular
-              class="mb-2"
-              color="primary"
-              indeterminate
-            ></v-progress-circular>
-            <h4>
-              Your request has been initiated. Please wait a few minutes while
-              we prepare it for review. When ready, it will appear here and will
-              also be available in your dashboard.
-            </h4>
-          </div>
-        </div>
       </div>
     </div>
   </PageContainer>
@@ -167,6 +153,7 @@ import ECEHeader from "@/components/ECEHeader.vue";
 import Callout from "@/components/common/Callout.vue";
 import { getPrograms, initiateProgramChange } from "@/api/program";
 import { IntervalTime } from "@/utils/constant";
+import router from "@/router.ts";
 
 export default defineComponent({
   name: "ProgramProfiles",
@@ -283,14 +270,12 @@ export default defineComponent({
       this.updateInProgress = true;
       const response = await initiateProgramChange(this.program);
 
-      if (response.error) {
+      if (response.error || !response.data) {
         console.error("Failed to initiate program change:", response.error);
         this.updateInProgress = false;
         return;
       }
-
-      await this.fetchNewProgram();
-      this.startPolling();
+      router.push(`/program/${response.data}`);
     },
     stopPolling() {
       if (this.pollInterval) {

--- a/src/ECER.Resources.Documents/Programs/ProgramRepository.cs
+++ b/src/ECER.Resources.Documents/Programs/ProgramRepository.cs
@@ -215,7 +215,7 @@ internal sealed class ProgramRepository : IProgramRepository
     context.UpdateObject(existingProgram);
     context.SaveChanges();
 
-    var newProgram = context.ecer_ProgramSet.SingleOrDefault(p => p.ecer_FromProgramProfileIdName == program.Name);
+    var newProgram = context.ecer_ProgramSet.SingleOrDefault(p => p.ecer_FromProgramProfileId.Id == Guid.Parse(program.Id!));
     if (newProgram == null) throw new InvalidOperationException($"New program for ecer_Program '{program.Id}' not found");
 
     var newProgramId = newProgram.ecer_ProgramId != null ? newProgram.ecer_ProgramId.ToString() : string.Empty;


### PR DESCRIPTION

## Title
ECER-6192: go directly to profile page when creating a change request

## Description

- go directly to profile page when creating a change request

## Related Jira Issue(s)

- ECER-{###}
- etc.

## Checklist
- [ ] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.