### PR TITLE
ecer-6184 deactivate invitations in portal

### DIFF
--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/UserCard.vue
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/UserCard.vue
@@ -60,7 +60,7 @@
 
     <!-- Pending invitations: Resend invitation button -->
     <v-row v-if="user.accessToPortal === 'Invited'">
-      <v-col cols="12" class="align-self-end">
+      <v-col cols="auto" class="align-self-end">
         <v-btn
           color="primary"
           size="small"
@@ -71,6 +71,15 @@
           <v-icon class="mr-2">mdi-email-arrow-right-outline</v-icon>
           Resend invitation
         </v-btn>
+      </v-col>
+      <v-col cols="auto" class="align-self-end">
+        <a
+          v-if="!isLoading"
+          href="#"
+          @click.prevent="showDeactivateConfirmation = true"
+        >
+          cancel invitation
+        </a>
       </v-col>
     </v-row>
 
@@ -117,6 +126,32 @@
       <p><strong>Do you wish to continue?</strong></p>
     </template>
   </ConfirmationDialog>
+  <ConfirmationDialog
+    :show="showCancelInvitationConfirmation"
+    :loading="isLoading"
+    title="Cancel invitation"
+    accept-button-text="Cancel invitation"
+    cancel-button-text="Keep invitation"
+    @accept="
+      $emit('remove-access', user.id);
+      showCancelInvitationConfirmation = false;
+    "
+    @cancel="showCancelInvitationConfirmation = false"
+  >
+    <template #confirmation-text>
+      <p>
+        You are about to cancel the invitation to this portal for:
+        <strong>{{ displayName }}</strong>
+      </p>
+      <br />
+      <p>
+        This user will no longer be able to accept this invitation. You can
+        invite them to the portal again at a later time.
+      </p>
+      <br />
+      <p><strong>Do you wish to continue?</strong></p>
+    </template>
+  </ConfirmationDialog>
 </template>
 
 <script lang="ts">
@@ -148,6 +183,7 @@ export default defineComponent({
   data() {
     return {
       showDeactivateConfirmation: false,
+      showCancelInvitationConfirmation: false,
     };
   },
   emits: {

--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/pages/ManageUsers.vue
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/pages/ManageUsers.vue
@@ -126,6 +126,7 @@
             <UserCard
               :user="user"
               @resend-invitation="handleResendInvitation"
+              @remove-access="handleRemoveAccess"
               :currentUserId="userStore.pspUserProfile?.id || ''"
             />
           </v-col>

--- a/src/ECER.Resources.Accounts/PspReps/PspRepRepository.cs
+++ b/src/ECER.Resources.Accounts/PspReps/PspRepRepository.cs
@@ -115,6 +115,17 @@ internal sealed class PspRepRepository(EcerContext context, IMapper mapper) : IP
     var pspRep = context.ecer_ECEProgramRepresentativeSet.SingleOrDefault(r => r.Id == Guid.Parse(pspRepId));
     if (pspRep == null) throw new InvalidOperationException($"psp representative with id {pspRepId} not found");
 
+    //disable any active portal invitations
+    var invitations = context.ecer_PortalInvitationSet.Where(invitation =>
+      invitation.ecer_psiprogramrepresentativeid.Id == userId && invitation.StateCode == ecer_portalinvitation_statecode.Active).ToList();
+
+    foreach (var invitation in invitations)
+    {
+      invitation.StatusCode = ecer_PortalInvitation_StatusCode.Cancelled;
+      invitation.StateCode = ecer_portalinvitation_statecode.Inactive;
+      context.UpdateObject(invitation);
+    }
+
     pspUser.ecer_AccessToPortal = ecer_AccessToPortal.Disabled;
     pspUser.ecer_HasAcceptedTermsofUse = false;
     setModifiedByPspRepFields(pspRep, pspUser);


### PR DESCRIPTION
---
name: Pull Request Template
about: Template for creating pull requests
---

## Title
https://eccbc.atlassian.net/browse/ECER-6184 

## Description

- ended up reusing the deactivation endpoint and also removing any active portal invitations. 

## Related Jira Issue(s)

- ECER-{###}
- etc.

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.
invitations pending we can see cancel invitation "link"
<img width="1724" height="358" alt="image" src="https://github.com/user-attachments/assets/1bea3bcb-d225-4618-8111-20fc2c281d64" />

Confirmation dialog will pop up to confirm
<img width="644" height="298" alt="image" src="https://github.com/user-attachments/assets/1fa99ae4-aab2-44f3-bb2f-721e3effa67c" />

user will be put into deactivated users section
<img width="570" height="403" alt="image" src="https://github.com/user-attachments/assets/871117db-e843-47d0-8490-d4d9832ccb72" />

active portal invitations are cancelled
<img width="1659" height="209" alt="image" src="https://github.com/user-attachments/assets/5fc6e192-9af2-42fa-b6ad-d1c0215ba567" />


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.