### PR TITLE
ecer-6384-6408 display order for areasOfInstruction on review page an…

### DIFF
--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/store/config.ts
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/store/config.ts
@@ -112,7 +112,14 @@ export const useConfigStore = defineStore("config", {
         areaOfInstructionList !== null &&
         areaOfInstructionList !== undefined
       ) {
-        this.areaOfInstructionList = areaOfInstructionList;
+        this.areaOfInstructionList = areaOfInstructionList.sort((a, b) => {
+          if (a.displayOrder === null || a.displayOrder === undefined) return 1;
+          if (b.displayOrder === null || b.displayOrder === undefined)
+            return -1;
+          return a.displayOrder.localeCompare(b.displayOrder, undefined, {
+            numeric: true,
+          });
+        });
       }
       if (systemMessages !== null && systemMessages !== undefined) {
         this.systemMessages = systemMessages;

--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/utils/functions.ts
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/utils/functions.ts
@@ -372,7 +372,8 @@ export function getCoursesForProgramApplicationReview(
 
         if (
           area.areaOfInstructionId !== null &&
-          area.areaOfInstructionId !== undefined
+          area.areaOfInstructionId !== undefined &&
+          area.newHours !== "0"
         ) {
           const existing = courseAreaOfInstructionMap.get(
             area.areaOfInstructionId,


### PR DESCRIPTION
…d showing courseAreaOfInstruction hours of zero on review page.

---
name: Pull Request Template
about: Template for creating pull requests
---

## Title
https://eccbc.atlassian.net/browse/ECER-6408 
https://eccbc.atlassian.net/browse/ECER-6384

## Description

- Change 1 detailed description
- Change 2 detailed description
- etc.

## Related Jira Issue(s)

- ECER-{###}
- etc.

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

this is a course with areaOfInstructionHour of zero
<img width="909" height="514" alt="image" src="https://github.com/user-attachments/assets/4acad904-d9a8-4a48-9a74-505880375f17" />

Display order fixed 

<img width="3732" height="4468" alt="localhost_5130_program-application_a2fe60f9-f383-458d-903c-dc302fe75115_component_program-profile_review-courses" src="https://github.com/user-attachments/assets/d728a8c9-3664-4d25-a446-3b4e31ad38ed" />

## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.