### PR TITLE
bugfix for programprofiles section showing up in the incorrect catego…

### DIFF
--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/common/ComponentGroupNavigation.vue
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/common/ComponentGroupNavigation.vue
@@ -33,12 +33,7 @@
             Institution and program info
           </v-list-item-title>
         </v-list-item>
-        <v-list-group
-          v-else-if="
-            category === 'Program Profile' &&
-            applicationType === 'NewBasicECEPostBasicProgram'
-          "
-        >
+        <v-list-group v-else-if="category === 'Program Profile'">
           <template #activator="{ props }">
             <v-list-item v-bind="props">
               <v-list-item-title
@@ -248,7 +243,16 @@ export default defineComponent({
   },
   computed: {
     groupByCategoryName(): ComponentGroupNavigationMap | undefined {
-      return groupByCategoryName(this.componentGroups);
+      return groupByCategoryName(this.filteredComponentGroups);
+    },
+    filteredComponentGroups(): Components.Schemas.NavigationMetadata[] {
+      // The "Program Profile" category is only shown for NewBasicECEPostBasicProgram
+      if (this.applicationType === "NewBasicECEPostBasicProgram") {
+        return this.componentGroups;
+      }
+      return this.componentGroups.filter(
+        (group) => group.categoryName !== "Program Profile",
+      );
     },
   },
   data() {


### PR DESCRIPTION
…ry type

---
name: Pull Request Template
about: Template for creating pull requests
---

## Title
https://eccbc.atlassian.net/browse/ECER-6422

## Description

- bug fix with the logic with showing program profiles
- we always defaulted to an else to show the components in the componentMetadata navigation. 
- which meant when programProfiles was only supposed to show for PostBasic applications, we would still show it in the else block. 
- fix was to filter out the componentMetadata depending on applicationType. 

## Related Jira Issue(s)

- ECER-{###}
- etc.

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.
shown on basic applicaitons
<img width="1319" height="718" alt="image" src="https://github.com/user-attachments/assets/d0cd7caa-db4d-42df-a145-4a04a238d0c7" />

hidden on non basic applications
<img width="1244" height="602" alt="image" src="https://github.com/user-attachments/assets/2b058c67-1987-40cb-b625-7738625e6327" />


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.