### PR TITLE
ecer-6421 and 6420. added promise based confirmationDialog. changed a…

### DIFF
--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/ConfirmationDialog.vue
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/ConfirmationDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <v-dialog
-    :model-value="show"
+    :model-value="visible"
     width="650"
     :disabled="disabled"
     @click:outside="cancel"
@@ -104,17 +104,46 @@ export default defineComponent({
       default: false,
     },
   },
+  data() {
+    return {
+      internalShow: false,
+      resolvePromise: null as ((value: boolean) => void) | null,
+    };
+  },
   emits: {
     accept: () => true,
     cancel: () => true,
   },
-
   methods: {
     cancel() {
       this.$emit("cancel");
+      if (this.resolvePromise) {
+        this.resolvePromise(false);
+      }
     },
     accept() {
       this.$emit("accept");
+      if (this.resolvePromise) {
+        this.resolvePromise(true);
+      }
+    },
+    open() {
+      this.internalShow = true;
+      return new Promise<boolean>((resolve) => {
+        this.resolvePromise = resolve;
+      });
+    },
+    close() {
+      this.internalShow = false;
+      if (this.resolvePromise) {
+        this.resolvePromise(false);
+        this.resolvePromise = null;
+      }
+    },
+  },
+  computed: {
+    visible() {
+      return this.show || this.internalShow;
     },
   },
 });

--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/program-application/ProgramApplication.vue
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/program-application/ProgramApplication.vue
@@ -12,7 +12,7 @@
             'text-grey-very-dark': item.disabled,
           }"
           :disabled="false"
-          :href="item.disabled ? undefined : item.href"
+          :to="item.disabled ? undefined : item.to"
         >
           {{ item.title }}
         </v-breadcrumbs-item>
@@ -191,11 +191,11 @@ export default defineComponent({
             this.programApplication.programApplicationType;
       }
       return [
-        { title: "Home", disabled: false, href: "/" },
+        { title: "Home", disabled: false, to: { name: "dashboard" } },
         {
           title: "All applications",
           disabled: false,
-          href: "/program-applications",
+          to: { name: "program-applications" },
         },
         { title: `${programApplicationTypeDisplay}`, disabled: true },
       ];

--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/program-application/ProgramApplicationHeader.vue
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/program-application/ProgramApplicationHeader.vue
@@ -13,8 +13,13 @@
             Application: {{ programApplicationName }}
           </span>
           <div :class="[{ ['text-right mb-2']: mobile }]">
-            <v-btn id="btnSaveAndExit" variant="outlined" @click="exit">
-              Save and exit
+            <v-btn
+              id="btnSaveAndExit"
+              variant="outlined"
+              prepend-icon="mdi-door-open"
+              @click="exit"
+            >
+              Exit application
             </v-btn>
           </div>
         </v-col>

--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/program-application/components/ProgramApplicationComponent.vue
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/program-application/components/ProgramApplicationComponent.vue
@@ -44,11 +44,26 @@
       </v-col>
     </v-row>
   </template>
+  <ConfirmationDialog
+    ref="confirmationDialogRef"
+    title="Unsaved changes"
+    accept-button-text="Save changes"
+    cancel-button-text="Continue without saving"
+    :loading="saving"
+    persistent
+  >
+    <template #confirmation-text>
+      <p>You have made changes to this page that have not been saved.</p>
+      <br />
+      <p>Are you sure you want to leave this page without saving changes?</p>
+    </template>
+  </ConfirmationDialog>
 </template>
 
 <script lang="ts">
 import { defineComponent } from "vue";
 import Loading from "@/components/Loading.vue";
+import ConfirmationDialog from "@/components/ConfirmationDialog.vue";
 import {
   getComponentGroupComponents,
   updateComponentGroup,
@@ -58,6 +73,7 @@ import type { Components, ComponentGroupWithComponents } from "@/types/openapi";
 import Question from "@/components/program-application/Question.vue";
 import type { QuestionModelValue } from "@/components/program-application/Question.vue";
 import type { NextStepPayload } from "@/components/program-application/ProgramApplication.vue";
+import { cloneDeep, isEqual, mapValues, omit } from "lodash";
 
 interface ComponentGroupWithComponentsFlat {
   id?: string | null;
@@ -71,7 +87,7 @@ interface ComponentGroupWithComponentsFlat {
 
 export default defineComponent({
   name: "ProgramApplicationComponent",
-  components: { Question, Loading },
+  components: { Question, Loading, ConfirmationDialog },
   props: {
     applicationType: { type: String, required: false },
     programApplicationId: {
@@ -84,6 +100,14 @@ export default defineComponent({
     },
   },
   emits: { next: (_payload: NextStepPayload) => true, refreshNav: () => true },
+  async beforeRouteLeave(_to, _from, next) {
+    const leave = await this.waitForConfirmation();
+    next(leave);
+  },
+  async beforeRouteUpdate(_to, _from, next) {
+    const leave = await this.waitForConfirmation();
+    next(leave);
+  },
   computed: {
     isRFAI(): boolean {
       return (
@@ -91,6 +115,21 @@ export default defineComponent({
         (this.programApplicationObject?.status === "InterimRecognition" ||
           this.programApplicationObject?.status === "ReviewAnalysis") &&
         this.programApplicationObject?.statusReasonDetail === "RFAIrequested"
+      );
+    },
+    hasChanges(): boolean {
+      //we do not need to compare files for changes since those are automatically saved when uploaded
+      const componentsWithFormWithoutFiles = mapValues(
+        this.formByComponentId,
+        (value) => omit(value, ["files"]),
+      );
+      const originalComponentsWithFormWithoutFiles = mapValues(
+        this.originalFormByComponentId,
+        (value) => omit(value, ["files"]),
+      );
+      return !isEqual(
+        componentsWithFormWithoutFiles,
+        originalComponentsWithFormWithoutFiles,
       );
     },
   },
@@ -101,6 +140,7 @@ export default defineComponent({
       loading: true,
       saving: false,
       formByComponentId: {} as Record<string, QuestionModelValue>,
+      originalFormByComponentId: {} as Record<string, QuestionModelValue>,
       programApplicationObject:
         null as Components.Schemas.ProgramApplication | null,
     };
@@ -149,6 +189,7 @@ export default defineComponent({
           },
         ]),
       );
+      this.originalFormByComponentId = cloneDeep(this.formByComponentId);
     },
     async handleSave() {
       if (!this.componentGroup) return;
@@ -172,6 +213,23 @@ export default defineComponent({
     async saveAndContinue() {
       await this.handleSave();
       this.$emit("next", { currentComponentGroupId: this.componentGroupId });
+    },
+    async waitForConfirmation(): Promise<boolean> {
+      if (this.hasChanges) {
+        let dialogRef = this.$refs.confirmationDialogRef as InstanceType<
+          typeof ConfirmationDialog
+        >;
+        const saveBeforeLeaving = await dialogRef.open();
+        if (saveBeforeLeaving) {
+          await this.handleSave();
+          dialogRef.close();
+          return true;
+        } else if (!saveBeforeLeaving) {
+          dialogRef.close();
+          return true;
+        }
+      }
+      return true;
     },
   },
 });

--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/program-application/components/ProgramApplicationInstituteInfo.vue
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/program-application/components/ProgramApplicationInstituteInfo.vue
@@ -1,7 +1,11 @@
 <template>
   <!-- Online/Hybrid: campus changed to location input conditional input for hybrid deliveryType -->
   <ProgramApplicationInstituteInfoLayout
-    v-if="applicationType === 'AddOnlineorHybridDeliveryMethod'"
+    ref="instituteInfoLayoutRef"
+    v-if="
+      applicationType === 'AddOnlineorHybridDeliveryMethod' &&
+      programApplicationObject !== null
+    "
     :programApplicationObject="programApplicationObject"
     :is-rfai="isRFAI"
     @next="$emit('next', $event)"
@@ -23,7 +27,12 @@
         onUpdateOnlineDeliveryHoursPercentage,
       }"
     >
-      <template v-if="programApplicationObject.deliveryType === 'Hybrid'">
+      <template
+        v-if="
+          programApplicationObject.deliveryType === 'Hybrid' &&
+          programApplicationObject !== null
+        "
+      >
         <v-row>
           <v-col cols="12">
             <p>Approximate percentage of instructional hours (hybrid only)</p>
@@ -67,7 +76,11 @@
 
   <!-- New Campus: hide campus section -->
   <ProgramApplicationInstituteInfoLayout
-    v-else-if="applicationType === 'NewCampusatRecognizedPrivateInstitution'"
+    ref="instituteInfoLayoutRef"
+    v-else-if="
+      applicationType === 'NewCampusatRecognizedPrivateInstitution' &&
+      programApplicationObject !== null
+    "
     :programApplicationObject="programApplicationObject"
     :is-rfai="isRFAI"
     @next="$emit('next', $event)"
@@ -77,7 +90,11 @@
 
   <!-- Basic/Post-Basic: condensed summary, add post-basic disclaimer -->
   <ProgramApplicationInstituteInfoLayout
-    v-else-if="applicationType === 'NewBasicECEPostBasicProgram'"
+    ref="instituteInfoLayoutRef"
+    v-else-if="
+      applicationType === 'NewBasicECEPostBasicProgram' &&
+      programApplicationObject !== null
+    "
     :programApplicationObject="programApplicationObject"
     :is-rfai="isRFAI"
     @next="$emit('next', $event)"
@@ -127,7 +144,11 @@
 
   <!-- Satellite: hide campus, program length, delivery, enrollment; add date fields -->
   <ProgramApplicationInstituteInfoLayout
-    v-else-if="applicationType === 'SatelliteProgram'"
+    ref="instituteInfoLayoutRef"
+    v-else-if="
+      applicationType === 'SatelliteProgram' &&
+      programApplicationObject !== null
+    "
     :programApplicationObject="programApplicationObject"
     :is-rfai="isRFAI"
     @next="$emit('next', $event)"
@@ -182,6 +203,7 @@ import ProgramApplicationInstituteInfoLayout from "./ProgramApplicationInstitute
 import type { NextStepPayload } from "@/components/program-application/ProgramApplication.vue";
 import EceDateInput from "@/components/inputs/EceDateInput.vue";
 import EceTextField from "@/components/inputs/EceTextField.vue";
+import ConfirmationDialog from "@/components/ConfirmationDialog.vue";
 import * as Rules from "@/utils/formRules";
 import { getProgramApplicationById } from "@/api/program-application";
 import type { Components } from "@/types/openapi";
@@ -193,6 +215,7 @@ export default defineComponent({
     ProgramApplicationInstituteInfoLayout,
     EceDateInput,
     EceTextField,
+    ConfirmationDialog,
   },
   props: {
     programApplicationId: {
@@ -203,6 +226,22 @@ export default defineComponent({
       type: String,
       required: true,
     },
+  },
+  async beforeRouteLeave(_to, _from, next) {
+    const instituteInfoLayout = this.$refs
+      .instituteInfoLayoutRef as InstanceType<
+      typeof ProgramApplicationInstituteInfoLayout
+    >;
+    const leave = await instituteInfoLayout.waitForConfirmation();
+    next(leave);
+  },
+  async beforeRouteUpdate(_to, _from, next) {
+    const instituteInfoLayout = this.$refs
+      .instituteInfoLayoutRef as InstanceType<
+      typeof ProgramApplicationInstituteInfoLayout
+    >;
+    const leave = await instituteInfoLayout.waitForConfirmation();
+    next(leave);
   },
   async mounted() {
     await this.fetchApplication();

--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/program-application/components/ProgramApplicationInstituteInfoLayout.vue
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/program-application/components/ProgramApplicationInstituteInfoLayout.vue
@@ -488,6 +488,37 @@
         </v-col>
       </v-row>
     </v-form>
+    <ConfirmationDialog
+      ref="confirmationDialogRef"
+      title="Unsaved changes"
+      accept-button-text="Save changes"
+      cancel-button-text="Continue without saving"
+      :loading="isSaving"
+      persistent
+    >
+      <template #confirmation-text>
+        <p>You have made changes to this page that have not been saved.</p>
+        <br />
+        <p>Are you sure you want to leave this page without saving changes?</p>
+      </template>
+    </ConfirmationDialog>
+    <ConfirmationDialog
+      ref="confirmationDialogInvalidFormRef"
+      title="Unsaved changes"
+      accept-button-text="Leave page"
+      cancel-button-text="Stay and fix errors"
+      :loading="isSaving"
+      persistent
+    >
+      <template #confirmation-text>
+        <p>
+          You have made changes on this page that cannot be saved until the
+          errors are corrected.
+        </p>
+        <br />
+        <p>Are you sure you want to leave this page and abandon changes?</p>
+      </template>
+    </ConfirmationDialog>
   </template>
 </template>
 
@@ -497,8 +528,10 @@ import { useUserStore } from "@/store/user";
 import { getUsers } from "@/api/manage-users";
 import type { PspUserListItem, Components } from "@/types/openapi";
 import type { VForm } from "vuetify/components";
+import type { ProgramApplicationContact } from "@/types/helperFunctions";
 import * as Rules from "@/utils/formRules";
 import EceTextField from "@/components/inputs/EceTextField.vue";
+import ConfirmationDialog from "@/components/ConfirmationDialog.vue";
 import {
   mapProgramType,
   updateProgramApplication,
@@ -506,13 +539,13 @@ import {
 } from "@/api/program-application";
 import type { NextStepPayload } from "@/components/program-application/ProgramApplication.vue";
 import Loading from "@/components/Loading.vue";
-import type { ProgramApplicationContact } from "@/types/helperFunctions";
 import EceDateInput from "@/components/inputs/EceDateInput.vue";
 import { dateBeforeRule } from "@/utils/formRules";
+import { cloneDeep, isEqual } from "lodash";
 
 export default defineComponent({
   name: "ProgramApplicationInstituteInfoLayout",
-  components: { EceDateInput, EceTextField, Loading },
+  components: { EceDateInput, EceTextField, Loading, ConfirmationDialog },
   props: {
     programApplicationObject: {
       type: Object as PropType<Components.Schemas.ProgramApplication | null>,
@@ -532,6 +565,12 @@ export default defineComponent({
   },
   emits: { next: (_payload: NextStepPayload) => true, refreshNav: () => true },
   computed: {
+    hasChanges(): boolean {
+      return !isEqual(
+        this.programApplicationObject,
+        this.originalProgramApplicationObject,
+      );
+    },
     validateHours() {
       return (v: string) => {
         if (!v) return true;
@@ -716,9 +755,14 @@ export default defineComponent({
       programCampus: [] as (string | null | undefined)[],
       isLoading: true,
       isSaving: false,
+      originalProgramApplicationObject:
+        null as Components.Schemas.ProgramApplication | null,
     };
   },
   async mounted() {
+    this.originalProgramApplicationObject = cloneDeep(
+      this.programApplicationObject,
+    );
     await this.loadUsers();
 
     this.programCampus =
@@ -764,12 +808,13 @@ export default defineComponent({
       });
       this.programRepresentativeId = currentUser?.id || null;
     },
-    async saveAndContinue() {
+    async handleSave() {
       const { valid } = await (
         this.$refs.instituteInfoForm as VForm
       ).validate();
 
-      if (!valid) return;
+      if (!valid) return false;
+
       this.isSaving = true;
       try {
         if (this.programApplicationObject !== null) {
@@ -783,11 +828,17 @@ export default defineComponent({
             );
           } else {
             this.isSaving = false;
-            this.$emit("next", {});
+            return true;
           }
         }
       } finally {
         this.isSaving = false;
+      }
+    },
+    async saveAndContinue() {
+      const success = await this.handleSave();
+      if (success) {
+        this.$emit("next", {});
       }
     },
     //This is so we can pass an empty slot to override default slot
@@ -830,6 +881,45 @@ export default defineComponent({
             });
           }
         }
+      }
+    },
+    async waitForConfirmation() {
+      const { valid } = await (
+        this.$refs.instituteInfoForm as VForm
+      ).validate();
+
+      //if form is invalid and user wants to leave we need to see if they want to try to fix their changes
+      if (!valid) {
+        let dialogInvalidFormRef = this.$refs
+          .confirmationDialogInvalidFormRef as InstanceType<
+          typeof ConfirmationDialog
+        >;
+        const confirmedLeaveWithoutSave = await dialogInvalidFormRef.open();
+        if (confirmedLeaveWithoutSave) {
+          dialogInvalidFormRef.close();
+          return true;
+        } else if (!confirmedLeaveWithoutSave) {
+          dialogInvalidFormRef.close();
+          return false;
+        }
+      }
+
+      //form is valid proceed with checking for changes to save
+      if (this.hasChanges) {
+        let dialogRef = this.$refs.confirmationDialogRef as InstanceType<
+          typeof ConfirmationDialog
+        >;
+        const confirmed = await dialogRef.open();
+        if (confirmed) {
+          await this.handleSave();
+          dialogRef.close();
+          return true;
+        } else if (!confirmed) {
+          dialogRef.close();
+          return true;
+        }
+      } else {
+        return true;
       }
     },
   },


### PR DESCRIPTION
…pplication breadcrumb to use to instead of href to trigger router guard. program application flow will detect for changes if user tries to leave page

---
name: Pull Request Template
about: Template for creating pull requests
---

## Title
https://eccbc.atlassian.net/browse/ECER-6420
https://eccbc.atlassian.net/browse/ECER-6421

## Description

- confirmationDialog can be used as promise to wait for user interaction. 
- routerGuards added when user tries to leave programApplication process with unsaved changes. 
- changed breadcrumb (only for programapplication) to use to property to trigger routerGuard. 
- flow for instituteInfo is different because only the parent component has access to the router guard. So we needed to hook into the child to trigger the changesCheck and save functionality. 

## Related Jira Issue(s)

- ECER-{###}
- etc.

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.
scenario 1 user has changes and tries to leave 
<img width="1101" height="662" alt="image" src="https://github.com/user-attachments/assets/5adb2124-d9dd-4c7c-ba23-80d889e6c0b4" />

no matter what the user chooses, they will leave the page. It's weather they want to save. 

scenario 2 user has errors on the page and we cannot allow them to save. (only applicable to institute info page)
They can choose to stay on the page or leave. 
<img width="1110" height="526" alt="image" src="https://github.com/user-attachments/assets/b881224c-1036-48f6-a333-bb0ee0a274b3" />

header icon updated 
<img width="1315" height="269" alt="image" src="https://github.com/user-attachments/assets/75b2a955-ef89-45e3-a6e6-970a1ec9523c" />


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.