### PR TITLE
rework ecer-6466 needed to adjust filesize limit to 50mb for total fi…

### DIFF
--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/program-application/ProgramApplicationFileUploader.vue
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/components/program-application/ProgramApplicationFileUploader.vue
@@ -200,7 +200,7 @@ export default defineComponent({
   async setup() {
     const alertStore = useAlertStore();
     const applicationFilesStore = useApplicationFilesStore();
-    const maxFileSizeInMB = 10;
+    const maxFileSizeInMB = 50;
     const maxFileSizeInBytes = maxFileSizeInMB * 1024 * 1024;
     return {
       alertStore,
@@ -295,10 +295,25 @@ export default defineComponent({
       if (this.selectedFiles.length + files.length > this.maxNumberOfFiles) {
         this.showErrorBanner = true;
         this.errorBannerMessage = `You can only upload ${this.maxNumberOfFiles} files. You need to remove files before you can continue.`;
-      } else {
-        for (const file of Array.from(files)) {
-          this.addFileToQueue(file);
-        }
+        return;
+      }
+      const filesUploadedSize = [...files].reduce(
+        (acc, file) => acc + file.size,
+        0,
+      );
+      const existingFilesSize = this.selectedFiles.reduce(
+        (acc, sf) =>
+          acc + (sf.file.size || Functions.parseHumanFileSize(sf.fileSize)),
+        0,
+      );
+      if (existingFilesSize + filesUploadedSize > this.maxFileSizeInBytes) {
+        this.showErrorBanner = true;
+        this.errorBannerMessage = `The total file size exceeds the maximum allowed. You have ${Functions.humanFileSize(Math.max(this.maxFileSizeInBytes - existingFilesSize, 0))} remaining.`;
+        return;
+      }
+
+      for (const file of Array.from(files)) {
+        this.addFileToQueue(file);
       }
     },
     addFileToQueue(file: File) {
@@ -314,18 +329,6 @@ export default defineComponent({
         storageFolder: "permanent",
       };
       this.selectedFiles.push(selectedFile);
-
-      if (this.selectedFiles.length > 1) {
-        const totalSize = this.selectedFiles.reduce(
-          (acc, sf) => acc + sf.file.size,
-          0,
-        );
-        if (totalSize > this.maxFileSizeInBytes) {
-          fileErrors.push(
-            `The total file size exceeds the maximum allowed. Upload a file that is ${Functions.humanFileSize(selectedFile.file.size - (totalSize - this.maxFileSizeInBytes))} or smaller.`,
-          );
-        }
-      }
 
       if (fileErrors.length === 0) {
         this.uploadFileWithProgress(selectedFile);
@@ -485,7 +488,8 @@ export default defineComponent({
     },
     triggerFileInput() {
       const totalSize = this.selectedFiles.reduce(
-        (acc, f) => acc + f.file.size,
+        (acc, f) =>
+          acc + (f.file.size || Functions.parseHumanFileSize(f.fileSize)),
         0,
       );
       if (totalSize > this.maxFileSizeInBytes) {

--- a/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/utils/functions.ts
+++ b/src/ECER.Clients.PSPPortal/ecer.clients.pspportal.client/src/utils/functions.ts
@@ -75,7 +75,7 @@ export function areObjectsEqual(obj1: any, obj2: any): boolean {
  */
 
 export function humanFileSize(bytes: number, decimals = 2) {
-  if (bytes === 0) return "0 Bytes";
+  if (bytes === 0) return "0 B";
   const k = 1024;
   const dm = decimals < 0 ? 0 : decimals;
   const sizes = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];


### PR DESCRIPTION
…les. Also needed to adjust issues when uploading multiple files that exceeded the file size limit

---
name: Pull Request Template
about: Template for creating pull requests
---

## Title
https://eccbc.atlassian.net/browse/ECER-6466 

## Description

- Issue raised when user uploaded multiple file items that exceeded the file size limit. 
- moved check to prior to file upload so that it would block if the total number of files selected exceeds the maximum file size limit 
- increased filesize limit to 50mb
- changed function to return 0 B when a file size is 0 to prevent issues converting between humanFileSize to bytes. 
- fixed file size calculator to take into account files that were previously uploaded. 

## Related Jira Issue(s)

- ECER-{###}
- etc.

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.
New behaviour
<img width="907" height="277" alt="image" src="https://github.com/user-attachments/assets/8575a988-5fc3-4647-81fc-4b14b05e861d" />

Old behaviour we would upload files to the point we exceed the maximum file size limit. Led to odd behavior. 

<img width="850" height="278" alt="image" src="https://github.com/user-attachments/assets/f8e690e4-93e9-44d4-8d94-a4ca886e0521" />



## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.