### PR TITLE
ecer-5704 set comprehensive report as received when user selects the …

### DIFF
--- a/src/ECER.Resources.Documents/Applications/ApplicationChildren/Transcripts.cs
+++ b/src/ECER.Resources.Documents/Applications/ApplicationChildren/Transcripts.cs
@@ -106,6 +106,8 @@ internal sealed partial class ApplicationRepository
         transcript.ecer_iwishtoapplyforafeewaiver = false;
         transcript.ecer_ihavesubmittedanapplicationtobcits = false;
         transcript.ecer_ECERegistryalreadyhasmyComprehensiveReport = true;
+
+        transcript.ecer_ComprehensiveEvaluationReportReceived = true;
       }
     }
 


### PR DESCRIPTION
…registry already has it

---
name: Pull Request Template
about: Template for creating pull requests
---

## Title
https://eccbc.atlassian.net/browse/ECER-5704

## Description

- One liner change, sets dynamics variable and that sets off the flow to set the received date and flag. Only if user selects that registryAlready has my application. 

## Related Jira Issue(s)

- ECER-{###}
- etc.

## Checklist
- [ ] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.
<img width="1340" height="91" alt="image" src="https://github.com/user-attachments/assets/01de3b96-7310-4550-91e4-a061fbb7bbec" />

<img width="1697" height="118" alt="image" src="https://github.com/user-attachments/assets/b3c85b85-29e7-49ae-bee0-4c56a9e809d0" />


## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.