### PR TITLE
fixing guid validation so application does not throw validation error…

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/ConfigurationEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/ConfigurationEndpoints.cs
@@ -1,4 +1,5 @@
 using ECER.Clients.RegistryPortal.Server.Shared;
+using ECER.Infrastructure.Common.Validators;
 using ECER.Managers.Admin.Contract.Metadatas;
 using ECER.Utilities.Hosting;
 using Mediator;
@@ -50,18 +51,20 @@ public class ConfigurationEndpoints : IRegisterEndpoints
 
     endpointRouteBuilder.MapGet("/api/certificationComparison/{id?}", async (string? id, string? provinceId, HttpContext ctx, IMediator messageBus, IConfigurationMapper configurationMapper, CancellationToken ct) =>
     {
-      bool IdIsNotGuid = !Guid.TryParse(id, out _); if (IdIsNotGuid && id != null) { id = null; }
       var results = await messageBus.Send(new CertificationComparisonQuery() { ById = id, ByProvinceId = provinceId }, ct);
       return TypedResults.Ok(configurationMapper.MapComparisonRecords(results.Items));
     })
+    .AddGuidValidationQueryParams(["provinceId"], false)
+    .AddGuidValidation("id", false)
     .WithOpenApi("Handles certification comparison queries", string.Empty, "certificationComparison_get");
 
     endpointRouteBuilder.MapGet("/api/postSecondaryInstitutionList/{id?}", async (string? id, string? name, string? provinceId, PostSecondaryInstitutionStatus? status, IMediator messageBus, IConfigurationMapper configurationMapper, CancellationToken ct) =>
     {
-      bool IdIsNotGuid = !Guid.TryParse(id, out _); if (IdIsNotGuid && id != null) { id = null; }
       var results = await messageBus.Send(new PostSecondaryInstitutionsQuery() { ById = id, ByName = name, ByProvinceId = provinceId, ByStatus = status }, ct);
       return TypedResults.Ok(configurationMapper.MapPostSecondaryInstitutions(results.Items));
     })
+    .AddGuidValidationQueryParams(["provinceId"], false)
+    .AddGuidValidation("id", false)
     .WithOpenApi("Handles psi queries", string.Empty, "psi_get");
 
     endpointRouteBuilder.MapGet("/api/systemMessages", async (HttpContext ctx, IMediator messageBus, IConfigurationMapper configurationMapper, CancellationToken ct) =>
@@ -74,11 +77,12 @@ public class ConfigurationEndpoints : IRegisterEndpoints
 
     endpointRouteBuilder.MapGet("/api/identificationTypes", async ([AsParameters] IdentificationTypesQuery request, HttpContext ctx, IMediator messageBus, IConfigurationMapper configurationMapper, CancellationToken ct) =>
     {
-      var query = new Managers.Admin.Contract.Metadatas.IdentificationTypesQuery() { ById = request.ById, ForPrimary = request.ForPrimary, ForSecondary = request.ForSecondary };
+      var query = new Managers.Admin.Contract.Metadatas.IdentificationTypesQuery() { ById = string.IsNullOrWhiteSpace(request.ById) ? null : request.ById, ForPrimary = request.ForPrimary, ForSecondary = request.ForSecondary };
       var results = await messageBus.Send(query, ct);
       return TypedResults.Ok(configurationMapper.MapIdentificationTypes(results.Items));
     })
      .WithOpenApi("Handles identification types queries", string.Empty, "identificationTypes_get")
+     .AddGuidValidationQueryParams(["ById"], false)
      .CacheOutput(p => p.Expire(TimeSpan.FromMinutes(5)));
 
     endpointRouteBuilder.MapGet("/api/captchaSiteKey", async (IOptions<CaptchaSettings> captchaSettings, CancellationToken ct) =>

--- a/src/ECER.Infrastructure.Common/Validators/RouterValidationExtensions.cs
+++ b/src/ECER.Infrastructure.Common/Validators/RouterValidationExtensions.cs
@@ -34,13 +34,14 @@ public static class RouterValidationExtensions
       foreach (var queryParameter in parameterNames)
       {
         var value = context.HttpContext.Request.Query[queryParameter].ToString();
+        bool valueProvided = context.HttpContext.Request.Query.TryGetValue(queryParameter, out var _);
 
-        if (string.IsNullOrWhiteSpace(value) && isRequired)
+        if (!valueProvided && isRequired)
         {
-          errors.Add($"{queryParameter} is required cannot be null or whitespace");
+          errors.Add($"{queryParameter} is required");
         }
 
-        if (!string.IsNullOrEmpty(value) && !Guid.TryParse(value, out _))
+        if (valueProvided && !Guid.TryParse(value, out _))
         {
           errors.Add($"{queryParameter} must be a valid GUID");
         }


### PR DESCRIPTION
---
name: Pull Request Template
about: Template for creating pull requests
---

## Title
confirmed unit tests still pass 
testing with bruno passing in non-guid attributes 

this came about when I noticed zap scans were triggering 500 errors in our application instead of a bad request

--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddlewareImpl.<Invoke>g__Awaited|10_0(ExceptionHandlerMiddlewareImpl middleware, HttpContext context, Task task)
[01:07:05 ERR Serilog.AspNetCore.RequestLoggingMiddleware] HTTP GET /api/postSecondaryInstitutionList/id?name=ZAP&provinceId=%22%2F%3E%3Cxsl%3Avalue-of+select%3D%22system-property%28%27xsl%3Avendor%27%29%22%2F%3E%3C%21--&status=Active responded 500 in 3.3930 ms

## Description

- Change 1 detailed description
- Change 2 detailed description
- etc.

## Related Jira Issue(s)

- ECER-{###}
- etc.

## Checklist
- [x] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.