### PR TITLE
fixing validation, there was an edge case where frontend sends back u…

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/ConfigurationEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/ConfigurationEndpoints.cs
@@ -51,20 +51,20 @@ public class ConfigurationEndpoints : IRegisterEndpoints
 
     endpointRouteBuilder.MapGet("/api/certificationComparison/{id?}", async (string? id, string? provinceId, HttpContext ctx, IMediator messageBus, IConfigurationMapper configurationMapper, CancellationToken ct) =>
     {
+      bool IdIsNotGuid = !Guid.TryParse(id, out _); if (IdIsNotGuid && id != null) { id = null; }
       var results = await messageBus.Send(new CertificationComparisonQuery() { ById = id, ByProvinceId = provinceId }, ct);
       return TypedResults.Ok(configurationMapper.MapComparisonRecords(results.Items));
     })
     .AddGuidValidationQueryParams(["provinceId"], false)
-    .AddGuidValidation("id", false)
     .WithOpenApi("Handles certification comparison queries", string.Empty, "certificationComparison_get");
 
     endpointRouteBuilder.MapGet("/api/postSecondaryInstitutionList/{id?}", async (string? id, string? name, string? provinceId, PostSecondaryInstitutionStatus? status, IMediator messageBus, IConfigurationMapper configurationMapper, CancellationToken ct) =>
     {
+      bool IdIsNotGuid = !Guid.TryParse(id, out _); if (IdIsNotGuid && id != null) { id = null; }
       var results = await messageBus.Send(new PostSecondaryInstitutionsQuery() { ById = id, ByName = name, ByProvinceId = provinceId, ByStatus = status }, ct);
       return TypedResults.Ok(configurationMapper.MapPostSecondaryInstitutions(results.Items));
     })
     .AddGuidValidationQueryParams(["provinceId"], false)
-    .AddGuidValidation("id", false)
     .WithOpenApi("Handles psi queries", string.Empty, "psi_get");
 
     endpointRouteBuilder.MapGet("/api/systemMessages", async (HttpContext ctx, IMediator messageBus, IConfigurationMapper configurationMapper, CancellationToken ct) =>


### PR DESCRIPTION
…ndefined for query param /undefined which is flagged as a non-guid string. Before we would catch this and default it to null. Need to revert to previous behaviour to allow that

---
name: Pull Request Template
about: Template for creating pull requests
---

## Title
ECER-{###}: Brief description of the changes

## Description

- Change 1 detailed description
- Change 2 detailed description
- etc.

## Related Jira Issue(s)

- ECER-{###}
- etc.

## Checklist
- [ ] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.