### PR TITLE
updating openapi and fixing type issues. optional path parameters no …

### DIFF
--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/ConfigurationEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/ConfigurationEndpoints.cs
@@ -3,6 +3,7 @@ using ECER.Infrastructure.Common.Validators;
 using ECER.Managers.Admin.Contract.Metadatas;
 using ECER.Utilities.Hosting;
 using Mediator;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
 namespace ECER.Clients.RegistryPortal.Server;
@@ -49,7 +50,7 @@ public class ConfigurationEndpoints : IRegisterEndpoints
     .WithOpenApi("Handles country queries", string.Empty, "country_get")
     .CacheOutput(p => p.Expire(TimeSpan.FromMinutes(5)));
 
-    endpointRouteBuilder.MapGet("/api/certificationComparison/{id?}", async (string? id, string? provinceId, HttpContext ctx, IMediator messageBus, IConfigurationMapper configurationMapper, CancellationToken ct) =>
+    endpointRouteBuilder.MapGet("/api/certificationComparison/{id?}", async ([FromRoute]string? id, string? provinceId, HttpContext ctx, IMediator messageBus, IConfigurationMapper configurationMapper, CancellationToken ct) =>
     {
       bool IdIsNotGuid = !Guid.TryParse(id, out _); if (IdIsNotGuid && id != null) { id = null; }
       var results = await messageBus.Send(new CertificationComparisonQuery() { ById = id, ByProvinceId = provinceId }, ct);
@@ -58,7 +59,7 @@ public class ConfigurationEndpoints : IRegisterEndpoints
     .AddGuidValidationQueryParams(["provinceId"], false)
     .WithOpenApi("Handles certification comparison queries", string.Empty, "certificationComparison_get");
 
-    endpointRouteBuilder.MapGet("/api/postSecondaryInstitutionList/{id?}", async (string? id, string? name, string? provinceId, PostSecondaryInstitutionStatus? status, IMediator messageBus, IConfigurationMapper configurationMapper, CancellationToken ct) =>
+    endpointRouteBuilder.MapGet("/api/postSecondaryInstitutionList/{id?}", async ([FromRoute]string? id, string? name, string? provinceId, PostSecondaryInstitutionStatus? status, IMediator messageBus, IConfigurationMapper configurationMapper, CancellationToken ct) =>
     {
       bool IdIsNotGuid = !Guid.TryParse(id, out _); if (IdIsNotGuid && id != null) { id = null; }
       var results = await messageBus.Send(new PostSecondaryInstitutionsQuery() { ById = id, ByName = name, ByProvinceId = provinceId, ByStatus = status }, ct);

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Reconsiderations/ReconsiderationsEndpoints.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Reconsiderations/ReconsiderationsEndpoints.cs
@@ -82,19 +82,10 @@ public record Reconsideration()
   public string? ReconsiderationDetails { get; set; }
   public string? ExplanationAndEvidence { get; set; }
   public ReconsiderationStatusCode Status { get; set; }
-  public IEnumerable<FileInfo> Files { get; set; } = Array.Empty<FileInfo>();
+  public IEnumerable<Applications.FileInfo> Files { get; set; } = Array.Empty<Applications.FileInfo>();
   public DateTime? ReconsiderationEndDate { get; set; }
   [ValidGuid]
   public string? ApplicationId { get; set; }
-}
-
-public record FileInfo(string Id)
-{
-  public string? Url { get; set; } = string.Empty;
-  public string? Extention { get; set; } = string.Empty;
-  public string? Name { get; set; } = string.Empty;
-  public string? Size { get; set; } = string.Empty;
-  public EcerWebApplicationType EcerWebApplicationType { get; set; }
 }
 
 public enum ReconsiderationStatusCode

--- a/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Reconsiderations/ReconsiderationsMapper.cs
+++ b/src/ECER.Clients.RegistryPortal/ECER.Clients.RegistryPortal.Server/Reconsiderations/ReconsiderationsMapper.cs
@@ -51,16 +51,15 @@ internal partial class ReconsiderationsMapper : IReconsiderationsMapper
 
   public IEnumerable<ReconsiderationStatusCode> MapReconsiderationStatusCodes(IEnumerable<ContractReconsiderations.ReconsiderationStatusCode> source) => source.Select(MapReconsiderationStatus).ToList();
 
-  private static FileInfo MapFileInfo(ContractReconsiderations.FileInfo source) => new(source.Id)
+  private static Applications.FileInfo MapFileInfo(ContractReconsiderations.FileInfo source) => new(source.Id)
   {
     Url = source.Url,
     Extention = source.Extention,
     Name = source.Name,
     Size = source.Size,
-    EcerWebApplicationType = EcerWebApplicationType.Registry
   };
 
-  private static ContractReconsiderations.FileInfo MapFileInfo(FileInfo source) => new(source.Id)
+  private static ContractReconsiderations.FileInfo MapFileInfo(Applications.FileInfo source) => new(source.Id)
   {
     Url = source.Url,
     Extention = source.Extention,

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/api/configuration.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/api/configuration.ts
@@ -36,7 +36,8 @@ const getPostSecondaryInstitutionList = async (
   Components.Schemas.PostSecondaryInstitution[] | null | undefined
 > => {
   const client = await getClient(false);
-  const parameters: Paths.PsiGet.QueryParameters = { status };
+  const parameters: Paths.PsiGet.QueryParameters & Paths.PsiGet.PathParameters =
+    { status, id: "" };
   return (await client.psi_get(parameters)).data;
 };
 
@@ -44,8 +45,10 @@ const getCertificationComparisonList = async (
   provinceId?: string,
 ): Promise<Components.Schemas.ComparisonRecord[] | null | undefined> => {
   const client = await getClient(false);
-  const parameters: Paths.CertificationComparisonGet.QueryParameters = {
+  const parameters: Paths.CertificationComparisonGet.QueryParameters &
+    Paths.CertificationComparisonGet.PathParameters = {
     provinceId: provinceId || "",
+    id: "",
   };
   return (await client.certificationComparison_get(parameters)).data;
 };

--- a/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
+++ b/src/ECER.Clients.RegistryPortal/ecer.clients.registryportal.client/src/types/openapi.d.ts
@@ -630,6 +630,19 @@ declare namespace Components {
       provinceName?: string | null;
       provinceCode?: string | null;
     }
+    /**
+     * Represents a reconsideration request submitted by an applicant.
+     */
+    export interface Reconsideration {
+      id?: string | null;
+      reconsiderationDetails?: string | null;
+      explanationAndEvidence?: string | null;
+      status?: ReconsiderationStatusCode;
+      files?: FileInfo[] | null;
+      reconsiderationEndDate?: string | null; // date-time
+      applicationId?: string | null;
+    }
+    export type ReconsiderationStatusCode = "Complete" | "InReview" | "New";
     export interface ReferenceContactInformation {
       lastName?: string | null;
       email?: string | null;
@@ -936,7 +949,7 @@ declare namespace Paths {
     }
     export interface PathParameters {
       application_id: Parameters.ApplicationId;
-      reference_id?: Parameters.ReferenceId;
+      reference_id: Parameters.ReferenceId;
     }
     export type RequestBody = Components.Schemas.CharacterReference;
     namespace Responses {
@@ -951,7 +964,7 @@ declare namespace Paths {
       export type Id = string;
     }
     export interface PathParameters {
-      id?: Parameters.Id;
+      id: Parameters.Id;
     }
     export interface QueryParameters {
       byStatus?: Parameters.ByStatus;
@@ -1031,7 +1044,7 @@ declare namespace Paths {
     }
     export interface PathParameters {
       application_id: Parameters.ApplicationId;
-      reference_id?: Parameters.ReferenceId;
+      reference_id: Parameters.ReferenceId;
     }
     export type RequestBody = Components.Schemas.WorkExperienceReference;
     namespace Responses {
@@ -1063,7 +1076,7 @@ declare namespace Paths {
       export type ProvinceId = string;
     }
     export interface PathParameters {
-      id?: Parameters.Id;
+      id: Parameters.Id;
     }
     export interface QueryParameters {
       provinceId?: Parameters.ProvinceId;
@@ -1077,7 +1090,7 @@ declare namespace Paths {
       export type Id = string;
     }
     export interface PathParameters {
-      id?: Parameters.Id;
+      id: Parameters.Id;
     }
     namespace Responses {
       export type $200 = Components.Schemas.Certification[];
@@ -1089,7 +1102,7 @@ declare namespace Paths {
       export type Id = string;
     }
     export interface PathParameters {
-      id?: Parameters.Id;
+      id: Parameters.Id;
     }
     namespace Responses {
       export type $200 = string;
@@ -1119,7 +1132,7 @@ declare namespace Paths {
       export type Id = string;
     }
     export interface PathParameters {
-      id?: Parameters.Id;
+      id: Parameters.Id;
     }
     export type RequestBody =
       /* Communication seen request */ Components.Schemas.CommunicationSeenRequest;
@@ -1175,7 +1188,7 @@ declare namespace Paths {
       export type Id = string;
     }
     export interface PathParameters {
-      id?: Parameters.Id;
+      id: Parameters.Id;
     }
     export type RequestBody =
       /* Save draft application request */ Components.Schemas.SaveDraftApplicationRequest;
@@ -1218,7 +1231,7 @@ declare namespace Paths {
       export type Id = string;
     }
     export interface PathParameters {
-      id?: Parameters.Id;
+      id: Parameters.Id;
     }
     export interface QueryParameters {
       byStatus?: Parameters.ByStatus;
@@ -1244,7 +1257,7 @@ declare namespace Paths {
       export type Id = string;
     }
     export interface PathParameters {
-      id?: Parameters.Id;
+      id: Parameters.Id;
     }
     export type RequestBody =
       Components.Schemas.SaveDraftICRAEligibilityRequest;
@@ -1354,7 +1367,7 @@ declare namespace Paths {
       export type ParentId = string;
     }
     export interface PathParameters {
-      parentId?: Parameters.ParentId;
+      parentId: Parameters.ParentId;
     }
     namespace Responses {
       export type $200 = Components.Schemas.GetMessagesResponse;
@@ -1417,7 +1430,7 @@ declare namespace Paths {
       export type Status = Components.Schemas.PostSecondaryInstitutionStatus;
     }
     export interface PathParameters {
-      id?: Parameters.Id;
+      id: Parameters.Id;
     }
     export interface QueryParameters {
       name?: Parameters.Name;
@@ -1426,6 +1439,39 @@ declare namespace Paths {
     }
     namespace Responses {
       export type $200 = Components.Schemas.PostSecondaryInstitution[];
+    }
+  }
+  namespace ReconsiderationsGet {
+    namespace Parameters {
+      export type ByApplicationId = string;
+      export type ById = string;
+      export type ByStatusCodes =
+        Components.Schemas.ReconsiderationStatusCode[];
+    }
+    export interface QueryParameters {
+      ByStatusCodes?: Parameters.ByStatusCodes;
+      ById?: Parameters.ById;
+      ByApplicationId?: Parameters.ByApplicationId;
+    }
+    namespace Responses {
+      export type $200 =
+        /* Represents a reconsideration request submitted by an applicant. */ Components.Schemas.Reconsideration[];
+      export type $400 = Components.Schemas.HttpValidationProblemDetails;
+      export interface $404 {}
+    }
+  }
+  namespace ReconsiderationsSubmitPut {
+    namespace Parameters {
+      export type Id = string;
+    }
+    export interface PathParameters {
+      id: Parameters.Id;
+    }
+    export type RequestBody =
+      /* Represents a reconsideration request submitted by an applicant. */ Components.Schemas.Reconsideration;
+    namespace Responses {
+      export type $200 = string;
+      export type $400 = Components.Schemas.HttpValidationProblemDetails;
     }
   }
   namespace ReferenceOptout {
@@ -1440,7 +1486,7 @@ declare namespace Paths {
       export type Token = string;
     }
     export interface PathParameters {
-      token?: Parameters.Token;
+      token: Parameters.Token;
     }
     namespace Responses {
       export type $200 = Components.Schemas.PortalInvitationQueryResult;
@@ -1624,6 +1670,22 @@ export interface OperationMethods {
     data?: Paths.UserinfoPost.RequestBody,
     config?: AxiosRequestConfig,
   ): OperationResponse<Paths.UserinfoPost.Responses.$200>;
+  /**
+   * reconsiderations_get - Handles reconsiderations queries
+   */
+  reconsiderations_get(
+    parameters?: Parameters<Paths.ReconsiderationsGet.QueryParameters> | null,
+    data?: any,
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.ReconsiderationsGet.Responses.$200>;
+  /**
+   * reconsiderations_submit_put - Handles reconsiderations queries
+   */
+  reconsiderations_submit_put(
+    parameters?: Parameters<Paths.ReconsiderationsSubmitPut.PathParameters> | null,
+    data?: Paths.ReconsiderationsSubmitPut.RequestBody,
+    config?: AxiosRequestConfig,
+  ): OperationResponse<Paths.ReconsiderationsSubmitPut.Responses.$200>;
   /**
    * references_get - Handles references queries
    */
@@ -2079,6 +2141,26 @@ export interface PathsDictionary {
       data?: Paths.UserinfoPost.RequestBody,
       config?: AxiosRequestConfig,
     ): OperationResponse<Paths.UserinfoPost.Responses.$200>;
+  };
+  ["/api/reconsiderations"]: {
+    /**
+     * reconsiderations_get - Handles reconsiderations queries
+     */
+    get(
+      parameters?: Parameters<Paths.ReconsiderationsGet.QueryParameters> | null,
+      data?: any,
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.ReconsiderationsGet.Responses.$200>;
+  };
+  ["/api/reconsiderations/submit/{id}"]: {
+    /**
+     * reconsiderations_submit_put - Handles reconsiderations queries
+     */
+    put(
+      parameters?: Parameters<Paths.ReconsiderationsSubmitPut.PathParameters> | null,
+      data?: Paths.ReconsiderationsSubmitPut.RequestBody,
+      config?: AxiosRequestConfig,
+    ): OperationResponse<Paths.ReconsiderationsSubmitPut.Responses.$200>;
   };
   ["/api/PortalInvitations/{token}"]: {
     /**
@@ -2578,6 +2660,9 @@ export type ProfileIdentification = Components.Schemas.ProfileIdentification;
 export type ProgramConfirmationOptions =
   Components.Schemas.ProgramConfirmationOptions;
 export type Province = Components.Schemas.Province;
+export type Reconsideration = Components.Schemas.Reconsideration;
+export type ReconsiderationStatusCode =
+  Components.Schemas.ReconsiderationStatusCode;
 export type ReferenceContactInformation =
   Components.Schemas.ReferenceContactInformation;
 export type ReferenceKnownTime = Components.Schemas.ReferenceKnownTime;

--- a/src/ECER.Tests/Integration/RegistryApi/ReconsiderationTests.cs
+++ b/src/ECER.Tests/Integration/RegistryApi/ReconsiderationTests.cs
@@ -58,7 +58,7 @@ public class ReconsiderationTests : RegistryPortalWebAppScenarioBase
     var existingReconsideration = (await queryResponse.ReadAsJsonAsync<IEnumerable<Reconsideration>>()).FirstOrDefault().ShouldNotBeNull();
 
     existingReconsideration.ExplanationAndEvidence = "updated explanation and evidence for reconsideration submission";
-    existingReconsideration.Files = [new Clients.RegistryPortal.Server.Reconsiderations.FileInfo(uploadedFileResponse.fileId) { }];
+    existingReconsideration.Files = [new Clients.RegistryPortal.Server.Applications.FileInfo(uploadedFileResponse.fileId) { }];
 
     await Host.Scenario(_ =>
     {


### PR DESCRIPTION
…longer parsed as optional in openapi spec

---
name: Pull Request Template
about: Template for creating pull requests
---

## Title
Quick fix to correct openapi generation failure on the frontend. 

Cause was that we had a duplicate entity that swagger generation does not like. So I ended up reusing duplicated FileInfo entity. 

OpenApi file is auto generated. 

There was also a typescript error that was popping up where a required ID param was not being passed. This used to be allowed in older version, but since updating the openapi spec marks it as required. 

## Description

- Change 1 detailed description
- Change 2 detailed description
- etc.

## Related Jira Issue(s)

- ECER-{###}
- etc.

## Checklist
- [ ] I have tested these changes locally.
- [ ] Changes to backend endpoints are covered by passing integration tests.
- [ ] I have added or updated the necessary documentation.

## Screenshots (if applicable)
Include screenshots to demonstrate the changes visually.

## Additional Comments (optional)
Any additional context or information that might be helpful for the reviewer.